### PR TITLE
Doc update

### DIFF
--- a/tigrc.5.txt
+++ b/tigrc.5.txt
@@ -444,13 +444,8 @@ setting the *default* color option.
 [frame="none",grid="none",cols="25<m,75<"]
 |=============================================================================
 |graph-commit		|The commit dot in the revisino graph.
-|graph-line-0		|First graph line color.
-|graph-line-1		|2nd graph line color.
-|graph-line-2		|3rd graph line color.
-|graph-line-3		|4th graph line color.
-|graph-line-4		|5th graph line color.
-|graph-line-5		|6th graph line color.
-|graph-line-6		|7th graph line color.
+|graph-line-[0-6]	|7 different branching colors, for example,
+graph-line-0 = red
 |main-commit		|The commit comment.
 |main-head		|Label of the current branch.
 |main-remote		|Label of a remote.


### PR DESCRIPTION
Noticed that going to 0.17 I couldn't change the color on the revgraph anymore. I found out why and updated tigrc.5

Don't mind which version you pick or if you change it.
