### PR TITLE
Fixing documentation for maximize keybinding

### DIFF
--- a/manual.txt
+++ b/manual.txt
@@ -293,7 +293,7 @@ View Manipulation
 	pressing Enter will simply scroll the view one line down.
 |Tab	|Switch to next view.
 |R	|Reload and refresh the current view.
-|M	|Maximize the current view to fill the whole display.
+|O	|Maximize the current view to fill the whole display.
 |Up	|This key is "context sensitive" and will move the cursor one
 	line up. However, if you opened a diff view from the main view
 	(split- or full-screen) it will change the cursor to point to


### PR DESCRIPTION
I noticed that the help output of tig and the tigmanual didn't agree
with each other.  I've updated the manual to reflect the actual
keybinding.
