### PR TITLE
disable git-diff copy similarity detection

### DIFF
--- a/git.h
+++ b/git.h
@@ -26,11 +26,11 @@
 	GIT_DIFF_INITIAL("--cached", context_arg, space_arg, "", new_name)
 
 #define GIT_DIFF_STAGED(context_arg, space_arg, old_name, new_name) \
-	"git", "diff-index", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M", \
+	"git", "diff-index", ENCODING_ARG, "--root", "--patch-with-stat", "-M", \
 		"--cached", (context_arg), (space_arg), "HEAD", "--", (old_name), (new_name), NULL
 
 #define GIT_DIFF_UNSTAGED(context_arg, space_arg, old_name, new_name) \
-	"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M", \
+	"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-M", \
 		(context_arg), (space_arg), "--", (old_name), (new_name), NULL
 
 /* Don't show staged unmerged entries. */

--- a/tig.1.txt
+++ b/tig.1.txt
@@ -120,8 +120,7 @@ TIG_LS_REMOTE::
 
 TIG_DIFF_OPTS::
 	The diff options to use in the diff view. The diff view uses
-	git-show(1) for formatting and always passes --patch-with-stat,
-	--find-copies-harder, and -C.
+	git-show(1) for formatting and always passes --patch-with-stat.
 
 TIG_TRACE::
 	Path for trace file where information about git commands are logged.

--- a/tig.c
+++ b/tig.c
@@ -4057,7 +4057,7 @@ diff_open(struct view *view, enum open_flags flags)
 {
 	static const char *diff_argv[] = {
 		"git", "show", ENCODING_ARG, "--pretty=fuller", "--no-color", "--root",
-			"--patch-with-stat", "--find-copies-harder", "-C",
+			"--patch-with-stat",
 			opt_notes_arg, opt_diff_context_arg, opt_ignore_space_arg,
 			"%(diffargs)", "%(commit)", "--", "%(fileargs)", NULL
 	};
@@ -6744,7 +6744,7 @@ stage_open(struct view *view, enum open_flags flags)
 	/* Diffs for unmerged entries are empty when passing the new
 	 * path, so leave out the new path. */
 	static const char *files_unmerged_argv[] = {
-		"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M",
+		"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-M",
 			opt_diff_context_arg, opt_ignore_space_arg, "--",
 			stage_status.old.name, NULL
 	};


### PR DESCRIPTION
Hello Jonas,
I'd like to propose this set of changes, which disables git-diff (and git-show) "copy detection" feature (which is AFAIK disabled by default in git).

The change has dramatic performance improvement impact on large projects - the current upstream Linux git repo for example. When I start tig on the v3.3.7 tag, tig itself takes ~10 seconds to start up and when I select one (any) of the commits, it takes about 8-10 seconds on a 3.5" 7200RPM drive to load a one-line change since git-diff (or git-show) has to walk the entire tree and look for possible copies.
With the patch applied, tig startup takes about ~10 seconds as well (unchanged), but a commit selection (commit msg + diff display) is instant.

However the main motivation for this patch wasn't performance improvement - I've been supporting various projects and helping them with git since 2007 and while move (rename) detection is a very useful feature and there are _very_ few cases where it's undesirable, the copy detection is as far as I remember always unwanted.
Some projects use templates for new files/trees and showing a diff against completely unrelated file/tree is undesirable, other projects simply copy a file made by someone else, make heavy modifications and want to see the entire file as added, not a 1200 line diff of another (unrelated) file. There are several other types of workload suffering from this feature, but I can't seem to recall them right now.

This behavior can't be turned off in any way I'm aware of (without recompiling tig), using `-C0%' or`-C0' in TIG_DIFF_OPTS is treated as adding another `-C', further increasing the aggressiveness of git-diff. Old behavior can easily be restored by setting TIG_DIFF_OPTS to the options removed from tig.c.

Please note that this is just a proposal, I'm not sure how to make this change available as a configuration option, but even if I knew, I'd still apply it by default.

The best solution could be to apply this set of changes (plus -M removal) and let the user (and git-config diff.renames option) decide what kind of diffs are wanted.

Thanks for comments and your work on tig.
