### PR TITLE
Remove enforced git-{diff,show} move/copy detection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@ Release notes
 master
 ------
 
+Incompatibilities:
+
+ - Disable git-diff / git-show move/copy detection by default, boosting diff
+   performance on larger projects. Use git config diff.renames option
+   (git-wide) to set your preferred behavior.
+   Environment variable TIG_DIFF_OPTS can be used to restore the old behavior.
+
 Improvements:
 
  - Typing a text in the prompt will be interpreted as a tig command. Prefixing

--- a/git.h
+++ b/git.h
@@ -26,16 +26,16 @@
 	GIT_DIFF_INITIAL("--cached", context_arg, space_arg, "", new_name)
 
 #define GIT_DIFF_STAGED(context_arg, space_arg, old_name, new_name) \
-	"git", "diff-index", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M", \
+	"git", "diff-index", ENCODING_ARG, "--root", "--patch-with-stat", \
 		"--cached", (context_arg), (space_arg), "HEAD", "--", (old_name), (new_name), NULL
 
 #define GIT_DIFF_UNSTAGED(context_arg, space_arg, old_name, new_name) \
-	"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M", \
+	"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", \
 		(context_arg), (space_arg), "--", (old_name), (new_name), NULL
 
 /* Don't show staged unmerged entries. */
 #define GIT_DIFF_STAGED_FILES(output_arg) \
-	"git", "diff-index", (output_arg), "--diff-filter=ACDMRTXB", "--cached", "-M", "HEAD", NULL
+	"git", "diff-index", (output_arg), "--diff-filter=ACDMRTXB", "--cached", "HEAD", NULL
 
 #define GIT_DIFF_UNSTAGED_FILES(output_arg) \
 	"git", "diff-files", (output_arg), NULL

--- a/tig.1.txt
+++ b/tig.1.txt
@@ -120,8 +120,7 @@ TIG_LS_REMOTE::
 
 TIG_DIFF_OPTS::
 	The diff options to use in the diff view. The diff view uses
-	git-show(1) for formatting and always passes --patch-with-stat,
-	--find-copies-harder, and -C.
+	git-show(1) for formatting and always passes --patch-with-stat.
 
 TIG_TRACE::
 	Path for trace file where information about git commands are logged.

--- a/tig.c
+++ b/tig.c
@@ -4057,7 +4057,7 @@ diff_open(struct view *view, enum open_flags flags)
 {
 	static const char *diff_argv[] = {
 		"git", "show", ENCODING_ARG, "--pretty=fuller", "--no-color", "--root",
-			"--patch-with-stat", "--find-copies-harder", "-C",
+			"--patch-with-stat",
 			opt_notes_arg, opt_diff_context_arg, opt_ignore_space_arg,
 			"%(diffargs)", "%(commit)", "--", "%(fileargs)", NULL
 	};
@@ -6744,7 +6744,7 @@ stage_open(struct view *view, enum open_flags flags)
 	/* Diffs for unmerged entries are empty when passing the new
 	 * path, so leave out the new path. */
 	static const char *files_unmerged_argv[] = {
-		"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M",
+		"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat",
 			opt_diff_context_arg, opt_ignore_space_arg, "--",
 			stage_status.old.name, NULL
 	};


### PR DESCRIPTION
Second revision of pull request #63 ("disable git-diff copy similarity detection").

I've removed "-M" as well, since it's configurable in the same fashion. I've tested this patch with several repositories and with TIG_DIFF_OPTS and everything works more or less as expected.

The problem is that diff.renames=copy enables only basic copy detection, ie. copy is detected only when the source file is changed in the same commit, which is fine with me, but the old behavior (find-copies-harder) is harder to trigger, one needs to use either TIG_DIFF_OPTS or set shell alias for git-diff (+ variants) and git-show.

What surprised me is that not even the basic rename detection is enabled on my git v1.7.10, so the user needs to have diff.renames in the config.

Still, I believe in using configuration options provided by the git suite rather than using hardcoded command line options.

Feel free to amend any minor changes.

Thanks.
