### PR TITLE
Edit in diff

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -4363,6 +4363,8 @@ diff_get_pathname(struct view *view, struct line *line)
 static enum request
 diff_request(struct view *view, enum request request, struct line *line)
 {
+	const char *file;
+
 	switch (request) {
 	case REQ_VIEW_BLAME:
 		return diff_trace_origin(view, line);
@@ -4374,6 +4376,12 @@ diff_request(struct view *view, enum request request, struct line *line)
 		reload_view(view);
 		return REQ_NONE;
 
+	case REQ_EDIT:
+		file = diff_get_pathname(view, line);
+		if (access(file, R_OK))
+			return pager_request(view, request, line);
+		open_editor(file);
+		return REQ_NONE;
 
 	case REQ_ENTER:
 		return diff_common_enter(view, request, line);


### PR DESCRIPTION
Hi Jonas,

I've written a patchset initially to add the support to open the editor from within the diff view. This is really helpful in a large repository, where I use the log to recall and re-edit a pathname. I figured out that some cases (e.g. copy, delete) didn't handle very well the changed file, resulting in this text in the status line:

```
Diff of '(null)'
```

I've fixed that and added the editor support for the diff view. It adds a diff_get_pathname() function and simplify diff_select(), which also avoids return statements.

Cheers,
Vivien.
