### PR TITLE
Use i18n.commitEncoding instead of hardcoded UTF8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,8 +54,6 @@ Improvements:
    Bound to 'W' by default.
  - Use per-file encoding specified in gitattributes(5) for blobs and
    unstaged files.
- - Obsolete commit-encoding option and pass --encoding=UTF-8 to revision
-   commands.
  - Main view: show uncommitted changes as staged/unstaged commits.
    Can be disabled by putting `set show-changes = no` in ~/.tigrc.
  - Add %(prompt) external command variable, which will prompt for the

--- a/contrib/tigrc
+++ b/contrib/tigrc
@@ -6,6 +6,7 @@
 set show-rev-graph = yes	# Show revision graph?
 set line-number-interval = 5	# Interval between line numbers
 set tab-size = 8		# Number of spaces pr tab 
+set commit-encoding = UTF-8	# Commit encoding
 
 #
 # Key configuration

--- a/git.h
+++ b/git.h
@@ -19,18 +19,18 @@
  */
 
 #define GIT_DIFF_INITIAL(cached_arg, context_arg, space_arg, old_name, new_name) \
-	"git", "diff", ENCODING_ARG, "--no-color", "--patch-with-stat", \
+	"git", "diff", "--no-color", "--patch-with-stat", \
 		(cached_arg), (context_arg), (space_arg), "--", (old_name), (new_name), NULL
 
 #define GIT_DIFF_STAGED_INITIAL(context_arg, space_arg, new_name) \
 	GIT_DIFF_INITIAL("--cached", context_arg, space_arg, "", new_name)
 
 #define GIT_DIFF_STAGED(context_arg, space_arg, old_name, new_name) \
-	"git", "diff-index", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M", \
+	"git", "diff-index", "--root", "--patch-with-stat", "-C", "-M", \
 		"--cached", (context_arg), (space_arg), "HEAD", "--", (old_name), (new_name), NULL
 
 #define GIT_DIFF_UNSTAGED(context_arg, space_arg, old_name, new_name) \
-	"git", "diff-files", ENCODING_ARG, "--root", "--patch-with-stat", "-C", "-M", \
+	"git", "diff-files", "--root", "--patch-with-stat", "-C", "-M", \
 		(context_arg), (space_arg), "--", (old_name), (new_name), NULL
 
 /* Don't show staged unmerged entries. */
@@ -47,7 +47,7 @@
 	GIT_DIFF_INITIAL("", context_arg, space_arg, "/dev/null", new_name)
 
 #define GIT_MAIN_LOG(diffargs, revargs, fileargs) \
-	"git", "log", ENCODING_ARG, "--no-color", "--pretty=raw", "--parents", \
+	"git", "log", "--no-color", "--pretty=raw", "--parents", \
 		opt_commit_order_arg, (diffargs), (revargs), \
 		"--", (fileargs), NULL
 

--- a/tig.h
+++ b/tig.h
@@ -90,7 +90,6 @@
 
 #define ENCODING_UTF8	"UTF-8"
 #define ENCODING_SEP	": encoding: "
-#define ENCODING_ARG	"--encoding=" ENCODING_UTF8
 
 #define ICONV_NONE	((iconv_t) -1)
 #ifndef ICONV_CONST

--- a/tigrc.5.txt
+++ b/tigrc.5.txt
@@ -50,6 +50,7 @@ set commit-order = topo		# Order commits topologically
 set read-git-colors = no	# Do not read git's color settings.
 set show-line-numbers = no	# Show line numbers?
 set line-number-interval = 5	# Interval between line numbers
+set commit-encoding = "UTF-8"	# Commit encoding
 set horizontal-scroll = 33%	# Scroll 33% of the view width
 set blame-options = -C -C -C	# Blame lines from other files
 --------------------------------------------------------------------------
@@ -105,6 +106,11 @@ The following variables can be set:
 	telling git-blame(1) how to detect the origin of lines. The value
 	is ignored when tig is started in blame mode and given blame options
 	on the command line.
+
+'commit-encoding' (string)::
+
+	The encoding used for commits. The default is UTF-8. Note this option
+	is shadowed by the "i18n.commitencoding" option in `.git/config`.
 
 'line-graphics' (mixed) [ "ascii" | "default" | "utf8" | bool]::
 


### PR DESCRIPTION
This reverts commit 6b195c0fd1474961e6f252900e25748794b5c3cf.

It works perfect in here, whatever LC_CTYPE is set. My English is not good and this is my first pull request, just send your question and I'll try my best.
