### PR TITLE
Update AX_WITH_CURSES to build under Cygwin

### DIFF
--- a/contrib/ax_with_curses.m4
+++ b/contrib/ax_with_curses.m4
@@ -8,29 +8,153 @@
 #
 # DESCRIPTION
 #
-#   Detect SysV compatible curses, such as ncurses.
+#   This macro checks whether a SysV or X/Open-compatible Curses library is
+#   present, along with the associated header file.  The NcursesW
+#   (wide-character) library is searched for first, followed by Ncurses,
+#   then the system-default plain Curses.  The first library found is the
+#   one returned.
 #
-#   Defines HAVE_CURSES_H or HAVE_NCURSES_H if curses is found. CURSES_LIB
-#   is also set with the required library, but is not appended to LIBS
-#   automatically. If no working curses library is found CURSES_LIB will be
-#   left blank. If CURSES_LIB is set in the environment, the supplied value
-#   will be used.
+#   The following options are understood: --with-ncursesw, --with-ncurses,
+#   --without-ncursesw, --without-ncurses.  The "--with" options force the
+#   macro to use that particular library, terminating with an error if not
+#   found.  The "--without" options simply skip the check for that library.
+#   The effect on the search pattern is:
 #
-#   There are two options: --with-ncurses forces the use of ncurses, and
-#   --with-ncursesw forces the use of ncursesw (wide character ncurses). The
-#   corresponding options --without-ncurses and --without-ncursesw force
-#   those libraries not to be used. By default, ncursesw is preferred to
-#   ncurses, which is preferred to plain curses.
+#     (no options)                           - NcursesW, Ncurses, Curses
+#     --with-ncurses     --with-ncursesw     - NcursesW only [*]
+#     --without-ncurses  --with-ncursesw     - NcursesW only [*]
+#                        --with-ncursesw     - NcursesW only [*]
+#     --with-ncurses     --without-ncursesw  - Ncurses only [*]
+#     --with-ncurses                         - NcursesW, Ncurses [**]
+#     --without-ncurses  --without-ncursesw  - Curses only
+#                        --without-ncursesw  - Ncurses, Curses
+#     --without-ncurses                      - NcursesW, Curses
 #
-#   ax_cv_curses is set to "yes" if any curses is found (including
-#   ncurses!); ax_cv_ncurses is set to "yes" if any ncurses is found, and
-#   ax_cv_ncursesw is set to "yes" if ncursesw is found.
+#   [*]  If the library is not found, abort the configure script.
+#
+#   [**] If the second library (Ncurses) is not found, abort configure.
+#
+#   The following preprocessor symbols may be defined by this macro if the
+#   appropriate conditions are met:
+#
+#     HAVE_CURSES             - if any SysV or X/Open Curses library found
+#     HAVE_CURSES_ENHANCED    - if library supports X/Open Enhanced functions
+#     HAVE_CURSES_COLOR       - if library supports color (enhanced functions)
+#     HAVE_CURSES_OBSOLETE    - if library supports certain obsolete features
+#     HAVE_NCURSESW           - if NcursesW (wide char) library is to be used
+#     HAVE_NCURSES            - if the Ncurses library is to be used
+#
+#     HAVE_CURSES_H           - if <curses.h> is present and should be used
+#     HAVE_NCURSESW_H         - if <ncursesw.h> should be used
+#     HAVE_NCURSES_H          - if <ncurses.h> should be used
+#     HAVE_NCURSESW_CURSES_H  - if <ncursesw/curses.h> should be used
+#     HAVE_NCURSES_CURSES_H   - if <ncurses/curses.h> should be used
+#
+#   (These preprocessor symbols are discussed later in this document.)
+#
+#   The following output variable is defined by this macro; it is precious
+#   and may be overridden on the ./configure command line:
+#
+#     CURSES_LIB  - library to add to xxx_LDADD
+#
+#   The library listed in CURSES_LIB is NOT added to LIBS by default. You
+#   need to add CURSES_LIB to the appropriate xxx_LDADD line in your
+#   Makefile.am.  For example:
+#
+#     prog_LDADD = @CURSES_LIB@
+#
+#   If CURSES_LIB is set on the configure command line (such as by running
+#   "./configure CURSES_LIB=-lmycurses"), then the only header searched for
+#   is <curses.h>.  The user may use the CPPFLAGS precious variable to
+#   override the standard #include search path.  If the user needs to
+#   specify an alternative path for a library (such as for a non-standard
+#   NcurseW), the user should use the LDFLAGS variable.
+#
+#   The following shell variables may be defined by this macro:
+#
+#     ax_cv_curses           - set to "yes" if any Curses library found
+#     ax_cv_curses_enhanced  - set to "yes" if Enhanced functions present
+#     ax_cv_curses_color     - set to "yes" if color functions present
+#     ax_cv_curses_obsolete  - set to "yes" if obsolete features present
+#
+#     ax_cv_ncursesw      - set to "yes" if NcursesW library found
+#     ax_cv_ncurses       - set to "yes" if Ncurses library found
+#     ax_cv_plaincurses   - set to "yes" if plain Curses library found
+#     ax_cv_curses_which  - set to "ncursesw", "ncurses", "plaincurses" or "no"
+#
+#   These variables can be used in your configure.ac to determine the level
+#   of support you need from the Curses library.  For example, if you must
+#   have either Ncurses or NcursesW, you could include:
+#
+#     AX_WITH_CURSES
+#     if test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes; then
+#         AX_MSG_ERROR([requires either NcursesW or Ncurses library])
+#     fi
+#
+#   If any Curses library will do (but one must be present and must support
+#   color), you could use:
+#
+#     AX_WITH_CURSES
+#     if test "x$ax_cv_curses" != xyes || test "x$ax_cv_curses_color" != xyes; then
+#         AC_MSG_ERROR([requires an X/Open-compatible Curses library with color])
+#     fi
+#
+#   Certain preprocessor symbols and shell variables defined by this macro
+#   can be used to determine various features of the Curses library.  In
+#   particular, HAVE_CURSES and ax_cv_curses are defined if the Curses
+#   library found conforms to the traditional SysV and/or X/Open Base Curses
+#   definition.  Any working Curses library conforms to this level.
+#
+#   HAVE_CURSES_ENHANCED and ax_cv_curses_enhanced are defined if the
+#   library supports the X/Open Enhanced Curses definition.  In particular,
+#   the wide-character types attr_t, cchar_t and wint_t, the functions
+#   wattr_set() and wget_wch() and the macros WA_NORMAL and _XOPEN_CURSES
+#   are checked.  The Ncurses library does NOT conform to this definition,
+#   although NcursesW does.
+#
+#   HAVE_CURSES_COLOR and ax_cv_curses_color are defined if the library
+#   supports color functions and macros such as COLOR_PAIR, A_COLOR,
+#   COLOR_WHITE, COLOR_RED and init_pair().  These are NOT part of the
+#   X/Open Base Curses definition, but are part of the Enhanced set of
+#   functions.  The Ncurses library DOES support these functions, as does
+#   NcursesW.
+#
+#   HAVE_CURSES_OBSOLETE and ax_cv_curses_obsolete are defined if the
+#   library supports certain features present in SysV and BSD Curses but not
+#   defined in the X/Open definition.  In particular, the functions
+#   getattrs(), getcurx() and getmaxx() are checked.
+#
+#   To use the HAVE_xxx_H preprocessor symbols, insert the following into
+#   your system.h (or equivalent) header file:
+#
+#     #if defined HAVE_NCURSESW_CURSES_H
+#     #  include <ncursesw/curses.h>
+#     #elif defined HAVE_NCURSESW_H
+#     #  include <ncursesw.h>
+#     #elif defined HAVE_NCURSES_CURSES_H
+#     #  include <ncurses/curses.h>
+#     #elif defined HAVE_NCURSES_H
+#     #  include <ncurses.h>
+#     #elif defined HAVE_CURSES_H
+#     #  include <curses.h>
+#     #else
+#     #  error "SysV or X/Open-compatible Curses header file required"
+#     #endif
+#
+#   For previous users of this macro: you should not need to change anything
+#   in your configure.ac or Makefile.am, as the previous (serial 10)
+#   semantics are still valid.  However, you should update your system.h (or
+#   equivalent) header file to the fragment shown above. You are encouraged
+#   also to make use of the extended functionality provided by this version
+#   of AX_WITH_CURSES, as well as in the additional macros
+#   AX_WITH_CURSES_PANEL, AX_WITH_CURSES_MENU and AX_WITH_CURSES_FORM.
 #
 # LICENSE
 #
 #   Copyright (c) 2009 Mark Pulford <mark@kyne.com.au>
 #   Copyright (c) 2009 Damian Pietras <daper@daper.net>
-#   Copyright (c) 2009 Reuben Thomas <rrt@sc3d.org>
+#   Copyright (c) 2012 Reuben Thomas <rrt@sc3d.org>
+#   Copyright (c) 2011 John Zaitseff <J.Zaitseff@zap.org.au>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -58,65 +182,337 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 13
 
 AU_ALIAS([MP_WITH_CURSES], [AX_WITH_CURSES])
-AC_DEFUN([AX_WITH_CURSES],
-  [AC_ARG_WITH(ncurses, [AS_HELP_STRING([--with-ncurses],
-        [Force the use of ncurses over curses])],,)
-   ax_save_LIBS="$LIBS"
-   AC_ARG_WITH(ncursesw, [AS_HELP_STRING([--without-ncursesw],
-        [Don't use ncursesw (wide character support)])],,)
-   if test ! "$CURSES_LIB" -a "$with_ncurses" != no -a "$with_ncursesw" != "no"
-   then
-       AC_CACHE_CHECK([for working ncursesw], ax_cv_ncursesw,
-         [LIBS="$ax_save_LIBS -lncursesw"
-          AC_TRY_LINK(
-            [#include <ncurses.h>],
-            [chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr(); ],
-            ax_cv_ncursesw=yes, ax_cv_ncursesw=no)])
-       if test "$ax_cv_ncursesw" = yes
-       then
-         AC_CHECK_HEADER([ncursesw/curses.h], AC_DEFINE(HAVE_NCURSESW_H, 1,
-            [Define if you have ncursesw.h]))
-         AC_DEFINE(HAVE_NCURSES_H, 1, [Define if you have ncursesw/curses.h])
-         AC_DEFINE(HAVE_NCURSESW, 1, [Define if you have libncursesw])
-         CURSES_LIB="-lncursesw"
-         ax_cv_ncurses=yes
-         ax_cv_curses=yes
-       fi
-   fi
-   if test ! "$CURSES_LIB" -a "$with_ncurses" != no -a "$with_ncursesw" != yes
-   then
-     AC_CACHE_CHECK([for working ncurses], ax_cv_ncurses,
-       [LIBS="$ax_save_LIBS -lncurses"
-        AC_TRY_LINK(
-          [#include <ncurses.h>],
-          [chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr(); ],
-          ax_cv_ncurses=yes, ax_cv_ncurses=no)])
-     if test "$ax_cv_ncurses" = yes
-     then
-       AC_DEFINE([HAVE_NCURSES_H],[1],[Define if you have ncurses.h])
-       CURSES_LIB="-lncurses"
-       ax_cv_curses=yes
-     fi
-   fi
-   if test "$ax_cv_curses" != yes -a "$with_ncurses" != yes -a "$with_ncursesw" != yes
-   then
-     if test ! "$CURSES_LIB"
-     then
-       CURSES_LIB="-lcurses"
-     fi
-     AC_CACHE_CHECK([for working curses], ax_cv_curses,
-       [LIBS="$ax_save_LIBS $CURSES_LIB"
-        AC_TRY_LINK(
-          [#include <curses.h>],
-          [chtype a; int b=A_STANDOUT, c=KEY_LEFT; initscr(); ],
-          ax_cv_curses=yes, ax_cv_curses=no)])
-     if test "$ax_cv_curses" = yes
-     then
-       AC_DEFINE([HAVE_CURSES_H],[1],[Define if you have curses.h])
-     fi
-   fi
-   LIBS="$ax_save_LIBS"
+AC_DEFUN([AX_WITH_CURSES], [
+    AC_ARG_VAR([CURSES_LIB], [linker library for Curses, e.g. -lcurses])
+    AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],
+        [force the use of Ncurses or NcursesW])],
+        [], [with_ncurses=check])
+    AC_ARG_WITH([ncursesw], [AS_HELP_STRING([--without-ncursesw],
+        [do not use NcursesW (wide character support)])],
+        [], [with_ncursesw=check])
+
+    ax_saved_LIBS=$LIBS
+    AS_IF([test "x$with_ncurses" = xyes || test "x$with_ncursesw" = xyes],
+        [ax_with_plaincurses=no], [ax_with_plaincurses=check])
+
+    ax_cv_curses_which=no
+
+    # Test for NcursesW
+
+    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncursesw" != xno], [
+        LIBS="$ax_saved_LIBS -lncursesw"
+
+        AC_CACHE_CHECK([for NcursesW wide-character library], [ax_cv_ncursesw], [
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [ax_cv_ncursesw=yes], [ax_cv_ncursesw=no])
+        ])
+        AS_IF([test "x$ax_cv_ncursesw" = xno && test "x$with_ncursesw" = xyes], [
+            AC_MSG_ERROR([--with-ncursesw specified but could not find NcursesW library])
+        ])
+
+        AS_IF([test "x$ax_cv_ncursesw" = xyes], [
+            ax_cv_curses=yes
+            ax_cv_curses_which=ncursesw
+            CURSES_LIB="-lncursesw"
+            AC_DEFINE([HAVE_NCURSESW], [1], [Define to 1 if the NcursesW library is present])
+            AC_DEFINE([HAVE_CURSES],   [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
+
+            AC_CACHE_CHECK([for working ncursesw/curses.h], [ax_cv_header_ncursesw_curses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <ncursesw/curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        attr_t d = WA_NORMAL;
+                        cchar_t e;
+                        wint_t f;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                        wattr_set(stdscr, d, 0, NULL);
+                        wget_wch(stdscr, &f);
+                    ]])],
+                    [ax_cv_header_ncursesw_curses_h=yes],
+                    [ax_cv_header_ncursesw_curses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncursesw_curses_h" = xyes], [
+                ax_cv_curses_enhanced=yes
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_ENHANCED],   [1], [Define to 1 if library supports X/Open Enhanced functions])
+                AC_DEFINE([HAVE_CURSES_COLOR],      [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE],   [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSESW_CURSES_H], [1], [Define to 1 if <ncursesw/curses.h> is present])
+            ])
+
+            AC_CACHE_CHECK([for working ncursesw.h], [ax_cv_header_ncursesw_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <ncursesw.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        attr_t d = WA_NORMAL;
+                        cchar_t e;
+                        wint_t f;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                        wattr_set(stdscr, d, 0, NULL);
+                        wget_wch(stdscr, &f);
+                    ]])],
+                    [ax_cv_header_ncursesw_h=yes],
+                    [ax_cv_header_ncursesw_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncursesw_h" = xyes], [
+                ax_cv_curses_enhanced=yes
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_ENHANCED], [1], [Define to 1 if library supports X/Open Enhanced functions])
+                AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSESW_H],      [1], [Define to 1 if <ncursesw.h> is present])
+            ])
+
+            AC_CACHE_CHECK([for working ncurses.h], [ax_cv_header_ncurses_h_with_ncursesw], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <ncurses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        attr_t d = WA_NORMAL;
+                        cchar_t e;
+                        wint_t f;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                        wattr_set(stdscr, d, 0, NULL);
+                        wget_wch(stdscr, &f);
+                    ]])],
+                    [ax_cv_header_ncurses_h_with_ncursesw=yes],
+                    [ax_cv_header_ncurses_h_with_ncursesw=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncurses_h_with_ncursesw" = xyes], [
+                ax_cv_curses_enhanced=yes
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_ENHANCED], [1], [Define to 1 if library supports X/Open Enhanced functions])
+                AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSES_H],       [1], [Define to 1 if <ncurses.h> is present])
+            ])
+
+            AS_IF([test "x$ax_cv_header_ncursesw_curses_h" = xno && test "x$ax_cv_header_ncursesw_h" = xno && test "x$ax_cv_header_ncurses_h_with_ncursesw" = xno], [
+                AC_MSG_WARN([could not find a working ncursesw/curses.h, ncursesw.h or ncurses.h])
+            ])
+        ])
+    ])
+
+    # Test for Ncurses
+
+    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncurses" != xno && test "x$ax_cv_curses_which" = xno], [
+        LIBS="$ax_saved_LIBS -lncurses"
+
+        AC_CACHE_CHECK([for Ncurses library], [ax_cv_ncurses], [
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [ax_cv_ncurses=yes], [ax_cv_ncurses=no])
+        ])
+        AS_IF([test "x$ax_cv_ncurses" = xno && test "x$with_ncurses" = xyes], [
+            AC_MSG_ERROR([--with-ncurses specified but could not find Ncurses library])
+        ])
+
+        AS_IF([test "x$ax_cv_ncurses" = xyes], [
+            ax_cv_curses=yes
+            ax_cv_curses_which=ncurses
+            CURSES_LIB="-lncurses"
+            AC_DEFINE([HAVE_NCURSES], [1], [Define to 1 if the Ncurses library is present])
+            AC_DEFINE([HAVE_CURSES],  [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
+
+            AC_CACHE_CHECK([for working ncurses/curses.h], [ax_cv_header_ncurses_curses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <ncurses/curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                    ]])],
+                    [ax_cv_header_ncurses_curses_h=yes],
+                    [ax_cv_header_ncurses_curses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncurses_curses_h" = xyes], [
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_COLOR],     [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE],  [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSES_CURSES_H], [1], [Define to 1 if <ncurses/curses.h> is present])
+            ])
+
+            AC_CACHE_CHECK([for working ncurses.h], [ax_cv_header_ncurses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <ncurses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                    ]])],
+                    [ax_cv_header_ncurses_h=yes],
+                    [ax_cv_header_ncurses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncurses_h" = xyes], [
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSES_H],       [1], [Define to 1 if <ncurses.h> is present])
+            ])
+
+            AS_IF([test "x$ax_cv_header_ncurses_curses_h" = xno && test "x$ax_cv_header_ncurses_h" = xno], [
+                AC_MSG_WARN([could not find a working ncurses/curses.h or ncurses.h])
+            ])
+        ])
+    ])
+
+    # Test for plain Curses (or if CURSES_LIB was set by user)
+
+    AS_IF([test "x$with_plaincurses" != xno && test "x$ax_cv_curses_which" = xno], [
+        AS_IF([test "x$CURSES_LIB" != x], [
+            LIBS="$ax_saved_LIBS $CURSES_LIB"
+        ], [
+            LIBS="$ax_saved_LIBS -lcurses"
+        ])
+
+        AC_CACHE_CHECK([for Curses library], [ax_cv_plaincurses], [
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [ax_cv_plaincurses=yes], [ax_cv_plaincurses=no])
+        ])
+
+        AS_IF([test "x$ax_cv_plaincurses" = xyes], [
+            ax_cv_curses=yes
+            ax_cv_curses_which=plaincurses
+            AS_IF([test "x$CURSES_LIB" = x], [
+                CURSES_LIB="-lcurses"
+            ])
+            AC_DEFINE([HAVE_CURSES], [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
+
+            # Check for base conformance (and header file)
+
+            AC_CACHE_CHECK([for working curses.h], [ax_cv_header_curses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        initscr();
+                    ]])],
+                    [ax_cv_header_curses_h=yes],
+                    [ax_cv_header_curses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_curses_h" = xyes], [
+                AC_DEFINE([HAVE_CURSES_H], [1], [Define to 1 if <curses.h> is present])
+
+                # Check for X/Open Enhanced conformance
+
+                AC_CACHE_CHECK([for X/Open Enhanced Curses conformance], [ax_cv_plaincurses_enhanced], [
+                    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                            @%:@define _XOPEN_SOURCE_EXTENDED 1
+                            @%:@include <curses.h>
+                            @%:@ifndef _XOPEN_CURSES
+                            @%:@error "this Curses library is not enhanced"
+                            "this Curses library is not enhanced"
+                            @%:@endif
+                        ]], [[
+                            chtype a = A_BOLD;
+                            int b = KEY_LEFT;
+                            chtype c = COLOR_PAIR(1) & A_COLOR;
+                            attr_t d = WA_NORMAL;
+                            cchar_t e;
+                            wint_t f;
+                            initscr();
+                            init_pair(1, COLOR_WHITE, COLOR_RED);
+                            wattr_set(stdscr, d, 0, NULL);
+                            wget_wch(stdscr, &f);
+                        ]])],
+                        [ax_cv_plaincurses_enhanced=yes],
+                        [ax_cv_plaincurses_enhanced=no])
+                ])
+                AS_IF([test "x$ax_cv_plaincurses_enhanced" = xyes], [
+                    ax_cv_curses_enhanced=yes
+                    ax_cv_curses_color=yes
+                    AC_DEFINE([HAVE_CURSES_ENHANCED], [1], [Define to 1 if library supports X/Open Enhanced functions])
+                    AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                ])
+
+                # Check for color functions
+
+                AC_CACHE_CHECK([for Curses color functions], [ax_cv_plaincurses_color], [
+                    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <curses.h>
+                        ]], [[
+                            chtype a = A_BOLD;
+                            int b = KEY_LEFT;
+                            chtype c = COLOR_PAIR(1) & A_COLOR;
+                            initscr();
+                            init_pair(1, COLOR_WHITE, COLOR_RED);
+                        ]])],
+                        [ax_cv_plaincurses_color=yes],
+                        [ax_cv_plaincurses_color=no])
+                ])
+                AS_IF([test "x$ax_cv_plaincurses_color" = xyes], [
+                    ax_cv_curses_color=yes
+                    AC_DEFINE([HAVE_CURSES_COLOR], [1], [Define to 1 if library supports color (enhanced functions)])
+                ])
+
+                # Check for obsolete functions
+
+                AC_CACHE_CHECK([for obsolete Curses functions], [ax_cv_plaincurses_obsolete], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                    ]])],
+                    [ax_cv_plaincurses_obsolete=yes],
+                    [ax_cv_plaincurses_obsolete=no])
+                ])
+                AS_IF([test "x$ax_cv_plaincurses_obsolete" = xyes], [
+                    ax_cv_curses_obsolete=yes
+                    AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                ])
+            ])
+
+            AS_IF([test "x$ax_cv_header_curses_h" = xno], [
+                AC_MSG_WARN([could not find a working curses.h])
+            ])
+        ])
+    ])
+
+    AS_IF([test "x$ax_cv_curses"          != xyes], [ax_cv_curses=no])
+    AS_IF([test "x$ax_cv_curses_enhanced" != xyes], [ax_cv_curses_enhanced=no])
+    AS_IF([test "x$ax_cv_curses_color"    != xyes], [ax_cv_curses_color=no])
+    AS_IF([test "x$ax_cv_curses_obsolete" != xyes], [ax_cv_curses_obsolete=no])
+
+    LIBS=$ax_saved_LIBS
 ])dnl

--- a/tig.h
+++ b/tig.h
@@ -59,10 +59,18 @@
 /* ncurses(3): Must be defined to have extended wide-character functions. */
 #define _XOPEN_SOURCE_EXTENDED
 
-#ifdef HAVE_NCURSESW_H
-#include <ncursesw/ncurses.h>
+#if defined HAVE_NCURSESW_CURSES_H
+#  include <ncursesw/curses.h>
+#elif defined HAVE_NCURSESW_H
+#  include <ncursesw.h>
+#elif defined HAVE_NCURSES_CURSES_H
+#  include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+#  include <ncurses.h>
+#elif defined HAVE_CURSES_H
+#  include <curses.h>
 #else
-#include <ncurses.h>
+#  error "SysV or X/Open-compatible Curses header file required"
 #endif
 
 #if __GNUC__ >= 3


### PR DESCRIPTION
Hi Jonas,

After trying to get tig 1.0 to build under Cygwin, I found that AX_WITH_CURSES needed an update so that ./configure would find the Cygwin ncursesw header file.

With this patch, tig builds under Cygwin with make configure && ./configure && make. The tig Cygwin port is still on tig 0.15, I'd like to get that updated once I've worked out how to use the Cygwin packaging tools.

Douglas
