### PR TITLE
fix: the manpage says 'read-git-colors'

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -1516,7 +1516,7 @@ option_set_command(int argc, const char *argv[])
 	if (!strcmp(argv[0], "status-untracked-dirs"))
 		return parse_bool(&opt_untracked_dirs_content, argv[2]);
 
-	if (!strcmp(argv[0], "use-git-colors"))
+	if (!strcmp(argv[0], "read-git-colors"))
 		return parse_bool(&opt_read_git_colors, argv[2]);
 
 	if (!strcmp(argv[0], "ignore-case"))


### PR DESCRIPTION
The manpage says the option is called 'read-git-colors', but the code looks for
'use-git-colors'. Fix the code to look for what is described in the manpage.
