### PR TITLE
fix: reading git colors in rang 0 255

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -1288,7 +1288,8 @@ set_color(int *color, const char *name)
 		return TRUE;
 	if (!prefixcmp(name, "color"))
 		return parse_int(color, name + 5, 0, 255) == OPT_OK;
-	return FALSE;
+	/* Used when reading git colors. Git expects a plain int w/o prefix.  */
+	return parse_int(color, name, 0, 255) == OPT_OK;
 }
 
 /* Wants: object fgcolor bgcolor [attribute] */


### PR DESCRIPTION
In 'tig' a color from the 256 colors range is specified using the string
'colorN' where N is the integer. In 'git' you can used 256 colors too. However
instead of 'colorN' they are specified using just N. This needs to be taken
into account for using the option 'use-git-colors' which reads options from the
git config for use in tig.
