### PR TITLE
fix wrong way grep_text finding whether match or not

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -7425,7 +7425,7 @@ grep_refs(struct ref_list *list, regex_t *regex)
 		return FALSE;
 
 	for (i = 0; i < list->size; i++) {
-		if (regexec(regex, list->refs[i]->name, 1, &pmatch, 0) != REG_NOMATCH)
+		if (!regexec(regex, list->refs[i]->name, 1, &pmatch, 0))
 			return TRUE;
 	}
 


### PR DESCRIPTION
Normally, regexec() returns 0 for success and the non-zero code REG_NOMATCH for failure.
so it should be '!result' instead of 'result != REG_NOMATCH'
