### PR TITLE
graph: don't call string_copy_rev() on empty string

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -71,7 +71,8 @@ graph_insert_column(struct graph *graph, struct graph_row *row, size_t pos, cons
 
 	row->size++;
 	memset(column, 0, sizeof(*column));
-	string_copy_rev(column->id, id);
+	if (*id != '\0')
+		string_copy_rev(column->id, id);
 	column->symbol.boundary = !!graph->is_boundary;
 
 	return column;


### PR DESCRIPTION
graph_expand() calls graph_insert_column() with the empty string as id,
which in turns leads to string_copy_rev() reading outside the allowed
memory area looking for whitespace.

To avoid this, don't call string_copy_rev() if we know the string is
empty anyway.

Signed-off-by: Romain Francoise romain@orebokech.com
