### PR TITLE
Fix press 'd' (REQ_VIEW_DIFF) on LINE_STAT_UNSTAGED and LINE_STAT_STAGED

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -7360,6 +7360,7 @@ main_request(struct view *view, enum request request, struct line *line)
 		move_view(view, request);
 		break;
 
+	case REQ_VIEW_DIFF:
 	case REQ_ENTER:
 		if (view_is_displayed(view) && display[0] != view)
 			maximize_view(view, TRUE);
@@ -7380,12 +7381,21 @@ main_request(struct view *view, enum request request, struct line *line)
 			const char **diff_argv = line->type == LINE_STAT_STAGED
 				? diff_staged_argv : diff_unstaged_argv;
 
-			open_argv(view, diff, diff_argv, NULL, flags);
+			if (request == REQ_VIEW_DIFF){
+				open_argv(view, diff, diff_argv, NULL, OPEN_DEFAULT);
+			} else {
+				open_argv(view, diff, diff_argv, NULL, flags);
+			}
 			break;
 		}
 
-		open_view(view, REQ_VIEW_DIFF, flags);
+		if (request == REQ_VIEW_DIFF){
+			open_view(view, REQ_VIEW_DIFF, OPEN_DEFAULT);
+		} else {
+			open_view(view, REQ_VIEW_DIFF, flags);
+		}
 		break;
+
 	case REQ_REFRESH:
 		load_refs();
 		refresh_view(view);


### PR DESCRIPTION
pressing 'd' shows actual diff of stage/unstaged line instead of just a blank diff with "[diff] 0000000000000000000000000000000000000000" in the status bar.

i just looked at the code for some minutes and found this code path to work. if there is a better on, which i'm sure, please re-implement it there. :)
