### PR TITLE
Add +ESC key binding

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -1047,6 +1047,8 @@ get_key_value(const char *name)
 		if (!strcasecmp(key_table[i].name, name))
 			return key_table[i].value;
 
+	if (strlen(name) == 3 && name[0] == '^' && name[1] == '[' && isprint(*name))
+		return (int)name[2] + 0x80;
 	if (strlen(name) == 2 && name[0] == '^' && isprint(*name))
 		return (int)name[1] & 0x1f;
 	if (strlen(name) == 1 && isprint(*name))
@@ -8516,6 +8518,9 @@ main(int argc, const char *argv[])
 
 	while (view_driver(display[current_view], request)) {
 		int key = get_input(0);
+
+		if (key == KEY_ESC)
+			key  = get_input(0) + 0x80;
 
 		view = display[current_view];
 		request = get_keybinding(&view->ops->keymap, key);


### PR DESCRIPTION
Mainly for emacs users, I'd like to introduce a new form to define key bindings with a Meta key with "^[".

Exapmle:

```
bind generic ^[v move-page-up
```

In actuality, when press a key with a Meta(or Option key on Mac) key, terminal apps send a key sequence whose first key code is KEY_ESC. This commit add a trap to receive KEY_ESC and then get the main key code again.
