### PR TITLE
main: highlight long commit titles

### DIFF
--- a/manual.txt
+++ b/manual.txt
@@ -416,6 +416,7 @@ Misc
 |F	|Toggle reference display on/off (tag and branch names).
 |W	|Toggle ignoring whitespace on/off for diffs
 |X	|Toggle commit ID display on/off
+|%	|Toggle highlighting of long commit titles (more than 50 chars).
 |:	|Open prompt. This allows you to specify what command to run.
 |e	|Open file in editor.
 |=============================================================================

--- a/tig.c
+++ b/tig.c
@@ -365,6 +365,7 @@ get_path_encoding(const char *path, struct encoding *default_encoding)
 	REQ_(TOGGLE_IGNORE_SPACE,	"Toggle ignoring whitespace in diffs"), \
 	REQ_(TOGGLE_COMMIT_ORDER,	"Toggle commit ordering"), \
 	REQ_(TOGGLE_ID,		"Toggle commit ID display"), \
+	REQ_(TOGGLE_LONG_TITLE,	"Toggle highlighting of long commit titles"), \
 	\
 	REQ_GROUP("Misc") \
 	REQ_(PROMPT,		"Bring up the prompt"), \
@@ -480,6 +481,7 @@ static const char **opt_blame_argv	= NULL;
 static int opt_lineno			= 0;
 static bool opt_show_id			= FALSE;
 static int opt_id_cols			= ID_WIDTH;
+static bool opt_show_long_title		= FALSE;
 
 #define is_initial_commit()	(!get_ref_head())
 #define is_head_commit(rev)	(!strcmp((rev), "HEAD") || (get_ref_head() && !strncmp(rev, get_ref_head()->id, SIZEOF_REV - 1)))
@@ -577,6 +579,7 @@ LINE(DELIMITER,	   "",			COLOR_MAGENTA,	COLOR_DEFAULT,	0), \
 LINE(DATE,         "",			COLOR_BLUE,	COLOR_DEFAULT,	0), \
 LINE(MODE,         "",			COLOR_CYAN,	COLOR_DEFAULT,	0), \
 LINE(ID,	   "",			COLOR_MAGENTA,	COLOR_DEFAULT,	0), \
+LINE(LONG_TITLE,   "",			COLOR_RED,	COLOR_DEFAULT,	0), \
 LINE(FILENAME,   "",			COLOR_DEFAULT,	COLOR_DEFAULT,	0), \
 LINE(LINE_NUMBER,  "",			COLOR_CYAN,	COLOR_DEFAULT,	0), \
 LINE(TITLE_BLUR,   "",			COLOR_WHITE,	COLOR_BLUE,	0), \
@@ -913,6 +916,7 @@ static struct keybinding default_keybindings[] = {
 	{ 'i',		REQ_TOGGLE_SORT_FIELD },
 	{ 'W',		REQ_TOGGLE_IGNORE_SPACE },
 	{ 'X',		REQ_TOGGLE_ID },
+	{ '%',		REQ_TOGGLE_LONG_TITLE },
 	{ ':',		REQ_PROMPT },
 	{ 'e',		REQ_EDIT },
 };
@@ -1578,6 +1582,9 @@ option_set_command(int argc, const char *argv[])
 	if (!strcmp(argv[0], "id-width"))
 		return parse_id(&opt_id_cols, argv[2]);
 
+	if (!strcmp(argv[0], "show-long-title"))
+		return parse_bool(&opt_show_long_title, argv[2]);
+
 	if (!strcmp(argv[0], "editor-line-number"))
 		return parse_bool(&opt_editor_lineno, argv[2]);
 
@@ -2078,6 +2085,25 @@ draw_text(struct view *view, enum line_type type, const char *string)
 	return VIEW_MAX_LEN(view) <= 0;
 }
 
+static bool
+draw_commit_title(struct view *view, const char *title)
+{
+	enum line_type type = LINE_DEFAULT;
+
+	if (opt_show_long_title) {
+		if (draw_chars(view, type, title, 50, FALSE))
+			return TRUE;
+
+		title += 50;
+		type = LINE_LONG_TITLE;
+	}
+
+	if (*title && draw_chars(view, type, title, VIEW_MAX_LEN(view), TRUE))
+		return TRUE;
+
+	return VIEW_MAX_LEN(view) <= 0;
+}
+
 static bool PRINTF_LIKE(3, 4)
 draw_formatted(struct view *view, enum line_type type, const char *format, ...)
 {
@@ -2507,7 +2533,8 @@ redraw_display(bool clear)
 	TOGGLE_(COMMIT_ORDER, 'l', "commit order",   &opt_commit_order, commit_order_map) \
 	TOGGLE_(REFS,      'F', "reference display", &opt_show_refs, NULL) \
 	TOGGLE_(CHANGES,   'C', "local change display", &opt_show_changes, NULL) \
-	TOGGLE_(ID,        'X', "commit ID display", &opt_show_id, NULL)
+	TOGGLE_(ID,        'X', "commit ID display", &opt_show_id, NULL) \
+	TOGGLE_(LONG_TITLE, '%', "long commit title display", &opt_show_long_title, NULL)
 
 static bool
 toggle_option(struct view *view, enum request request, char msg[SIZEOF_STR])
@@ -3676,6 +3703,7 @@ view_driver(struct view *view, enum request request)
 	case REQ_TOGGLE_CHANGES:
 	case REQ_TOGGLE_IGNORE_SPACE:
 	case REQ_TOGGLE_ID:
+	case REQ_TOGGLE_LONG_TITLE:
 		{
 			char action[SIZEOF_STR] = "";
 			bool reload = toggle_option(view, request, action);
@@ -7400,7 +7428,7 @@ main_draw(struct view *view, struct line *line, unsigned int lineno)
 	if (draw_refs(view, commit->refs))
 		return TRUE;
 
-	draw_text(view, LINE_DEFAULT, commit->title);
+	draw_commit_title(view, commit->title);
 	return TRUE;
 }
 

--- a/tigrc.5.txt
+++ b/tigrc.5.txt
@@ -211,6 +211,11 @@ The following variables can be set:
 	Whether to show commit IDs in the main view. Disabled by default. Can
 	be toggled. See also 'id-width' option.
 
+'show-long-title' (bool)::
+
+	Whether to highlight long commit titles (exceeding 50 characters) in the
+	main view on start-up. Can be toggled.
+
 'show-rev-graph' (bool)::
 
 	Whether to show revision graph in the main view on start-up.


### PR DESCRIPTION
Many developers and tools respect the Git convention for commit title,
as discussed in the git-commit(1) man page:

> Though not required, it's a good idea to begin the commit message with
> a single short (less than 50 character) line summarizing the change

This patch adds the ability to highlight text exceeding 50 characters in
commit titles, through a "show-long-title" toggle.

Here's what it looks like:
![Highlight long commit title in tig](http://i.imgur.com/dNRK5Fw.png)

Cheers,
Vivien
