### PR TITLE
Add toggle for commit title overflow

### DIFF
--- a/manual.txt
+++ b/manual.txt
@@ -418,6 +418,7 @@ Misc
 |X	|Toggle commit ID display on/off
 |%	|Toggle file filtering in order to see the full diff instead of only
 	 the diff concerning the currently selected file.
+|$	|Toggle highlighting of commit title overflow.
 |:	|Open prompt. This allows you to specify what command to run.
 |e	|Open file in editor.
 |=============================================================================

--- a/tigrc.5.txt
+++ b/tigrc.5.txt
@@ -211,6 +211,13 @@ The following variables can be set:
 	Whether to show commit IDs in the main view. Disabled by default. Can
 	be toggled. See also 'id-width' option.
 
+'title-overflow' (bool/int)::
+
+	Whether to highlight text in commit titles exceeding a given width.
+	As a boolean, it enables/disables the highlighting, with a default value of
+	50 character. As a int, it enables and uses the value as the maximum width
+	for a title to be considered short.
+
 'show-rev-graph' (bool)::
 
 	Whether to show revision graph in the main view on start-up.


### PR DESCRIPTION
Hi Jonas,

This PR is the v3 of #122, which now implements the new **title-overflow** option as a boolint.
That means, we can set the title overflow highlighting like this:

```
set title-overflow = yes # defaults to 50 character
set title-overflow = false # disables highlighting
set title-overflow = 72 # enables and sets the limit to 72 character
```

Cheers,
Vivien
