### PR TITLE
Cancel quitting after answering No to a prompt

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -3521,6 +3521,8 @@ open_run_request(struct view *view, enum request request)
 		return request;
 	}
 
+	bool confirmed = !req->confirm;
+
 	if (format_argv(&argv, req->argv, FALSE)) {
 		if (req->internal) {
 			char cmd[SIZEOF_STR];
@@ -3530,7 +3532,6 @@ open_run_request(struct view *view, enum request request)
 			}
 		}
 		else {
-			bool confirmed = !req->confirm;
 
 			if (req->confirm) {
 				char cmd[SIZEOF_STR], prompt[SIZEOF_STR];
@@ -3556,7 +3557,10 @@ open_run_request(struct view *view, enum request request)
 	free(argv);
 
 	if (request == REQ_NONE) {
-		if (req->exit)
+		if (req->confirm && !confirmed)
+			request = REQ_NONE;
+
+		else if (req->exit)
 			request = REQ_QUIT;
 
 		else if (!view->unrefreshable)


### PR DESCRIPTION
Currently tig quits even when we put "n" a prompt. However, this behaviour is not useful because, when a user cancels a command because of miss choosing, he may immediately want to retry the command with other (correct) commit/branch. The current behaviour forces users to relaunch tig and search the correct commit/branch from the top of history again.

This commit fixes the behaviour to do nothing when users choose "n" to a prompt.
