### PR TITLE
Update documentation as regards color specification using bare numbers

### DIFF
--- a/tigrc.5.txt
+++ b/tigrc.5.txt
@@ -574,9 +574,11 @@ Color names::
 	you are using a terminal with a transparent background.
 +
 Colors can also be specified using the keywords color0, color1, ..., colorN-1
-(N being the number of colors supported by your terminal). This is useful when
-you remap the colors for your display or want to enable colors supported by
-256-color terminals.
+(N being the number of colors supported by your terminal). The prefix
+'color' is optional, such that specifying colors directly by their numbers
+0, 1, ..., N-1 is also possible, like in the initialization file of
+Git. This is useful when you remap the colors for your display or want to
+enable colors supported by 256-color terminals.
 
 Attribute names::
 


### PR DESCRIPTION
The change in the set_color function that allows colors to be specified by
numbers (like in Git) was done in commit 54e8c4d2, but the documentation
has not been updated accordingly.
