### PR TITLE
Eliminate a constant expression

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -89,7 +89,6 @@ graph_needs_expansion(struct graph *graph)
 	if (graph->position + graph->parents.size > graph->row.size)
 		return TRUE;
 	return graph->parents.size > 1
-	    && graph->position < 0
 	    && graph->expanded < graph->parents.size;
 }
 


### PR DESCRIPTION
Clang warns that the expression `graph->position < 0` is always false
because `->position` is unsigned. The whole function collapses quite
a bit as a consequence.
