### PR TITLE
Add a log view default mode with `log` option

### DIFF
--- a/tig.1.txt
+++ b/tig.1.txt
@@ -12,6 +12,7 @@ tig        [options] [revisions] [--] [paths]
 tig show   [options] [revisions] [--] [paths]
 tig blame  [options] [rev] [--] path
 tig status
+tig log
 tig <      [git command output]
 
 DESCRIPTION
@@ -46,6 +47,9 @@ blame::
 
 status::
 	Start up in status view.
+
+log::
+	Start up in log view.
 
 +<number>::
     Show the first view with line <number> visible and selected.

--- a/tig.c
+++ b/tig.c
@@ -8383,6 +8383,7 @@ static const char usage[] =
 "   or: tig show   [options] [revs] [--] [paths]\n"
 "   or: tig blame  [options] [rev] [--] path\n"
 "   or: tig status\n"
+"   or: tig log\n"
 "   or: tig <      [git command output]\n"
 "\n"
 "Options:\n"
@@ -8520,6 +8521,9 @@ parse_options(int argc, const char *argv[])
 
 	} else if (!strcmp(subcommand, "show")) {
 		request = REQ_VIEW_DIFF;
+
+	} else if (!strcmp(subcommand, "log")) {
+		request = REQ_VIEW_LOG;
 
 	} else {
 		subcommand = NULL;


### PR DESCRIPTION
I added a new command line option `log` that shows the log view by default.
Users can replace the `git log` command with this new `tig log` command.
