### PR TITLE
Enable tilde expansion in .tigrc "source" commands

### DIFF
--- a/tig.h
+++ b/tig.h
@@ -49,6 +49,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <fcntl.h>
+#include <wordexp.h>
 
 #include <regex.h>
 


### PR DESCRIPTION
The examples listed in the SOURCE COMMAND section of tigrc(5) seem to indicate that one can rely on tilde expansion to be applied to the paths of configuration files includes via the "source" command.  However, it doesn't seem as if this had ever been implemented.

I've tried to add this functionality here, and it seems to work fine in my tests.

(Thanks to @antoinevg for pointing me in the right direction.)
