### PR TITLE
Fix parsing of repo info, for case when current dir starting from dot

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -8353,7 +8353,7 @@ read_repo_info(char *name, size_t namelen, char *value, size_t valuelen, void *d
 		 * Default to true for the unknown case. */
 		opt_is_inside_work_tree = strcmp(name, "false") ? TRUE : FALSE;
 
-	} else if (*name == '.') {
+	} else if (*name == '.' && !strlen(opt_cdup)) {
 		string_ncopy(opt_cdup, name, namelen);
 
 	} else {


### PR DESCRIPTION
In this case command
$(git rev-parse --git-dir --is-inside-work-tree --show-cdup --show-prefix)
will print some thing like this:
{code}
/tig/.git
true
../
.started-from-dot/
{/code}

And after this in read_repo_info() it will overwrite "opt_cdup", by
"--show-prefix" value, and for example $(tig blame ../io.h) from
".started-from-dot" directory will fail, because of wrong opt_cdup.
