### PR TITLE
[v2] Introduce the stash view

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,7 @@ Improvements:
  - Create temporary files in TMPDIR, TEMP, or TMP before defaulting to /tmp.
  - Reenable `tig log` as a subcommand. (GH #146)
  - Enable tilde expansion in ~/.tigrc "source" commands. (GH #168)
+ - Introduce the stash view, bound to the 'y' keybinding. (GH #169, #159)
 
 Bug fixes:
 

--- a/manual.txt
+++ b/manual.txt
@@ -124,6 +124,9 @@ The stage view::
 	Displays diff changes for staged or unstaged files being tracked or
 	file content of untracked files.
 
+The stash view::
+	Displays the list of stashes in the repository.
+
 The pager view::
 	Is used for displaying both input from stdin and output from git
 	commands entered in the internal prompt.
@@ -154,6 +157,7 @@ following variables.
 |%(commit)		|The currently selected commit ID.
 |%(blob)		|The currently selected blob ID.
 |%(branch)		|The currently selected branch name.
+|%(stash)		|The currently selected stash name.
 |%(directory)		|The current directory path in the tree view;
 			 empty for the root directory.
 |%(file)		|The currently selected file.
@@ -294,6 +298,7 @@ View Switching
 |f	|Switch to (file) blob view.
 |B	|Switch to blame view.
 |H	|Switch to branch view.
+|y	|Switch to stash view.
 |h	|Switch to help view
 |S	|Switch to status view
 |c	|Switch to stage view

--- a/tig.1.txt
+++ b/tig.1.txt
@@ -12,6 +12,7 @@ tig        [options] [revisions] [--] [paths]
 tig log    [options] [revisions] [--] [paths]
 tig show   [options] [revisions] [--] [paths]
 tig blame  [options] [rev] [--] path
+tig stash
 tig status
 tig <      [git command output]
 
@@ -101,6 +102,11 @@ $ tig --after="2004-01-01" --before="2006-05-16" -- README
 Blame file with copy detection enabled:
 -----------------------------------------------------------------------------
 $ tig blame -C README
+-----------------------------------------------------------------------------
+
+Display the list of stashes:
+-----------------------------------------------------------------------------
+$ tig stash
 -----------------------------------------------------------------------------
 
 ENVIRONMENT VARIABLES

--- a/tigrc.5.txt
+++ b/tigrc.5.txt
@@ -384,6 +384,7 @@ is run. Valid variable names are:
 |%(commit)		|The currently selected commit ID.
 |%(blob)		|The currently selected blob ID.
 |%(branch)		|The currently selected branch name.
+|%(stash)		|The currently selected stash name.
 |%(directory)		|The current directory path in the tree view;
 			 empty for the root directory.
 |%(file)		|The currently selected file.


### PR DESCRIPTION
This patch adds a new "stash" view, bound to the 'y' key.
This view displays the list of stashes. Pressing Enter on one of them
displays the corresponding change in a split view.

Running 'tig stash' opens directly the stash view.

A new %(stash) variable is added for bindings and commands.

A built-in command to pop the current stash is bound to 'P' in this
view. Other bindings may be added in the ~/.tigrc file, for instance:

```
bind stash D !?git stash drop %(stash)
bind stash A !?git stash apply %(stash)
bind status S !?git stash save --keep-index %(prompt)
```

References: #169, #159

[This is the v2 of PR #173.]
