### PR TITLE
Fix %(commit) assignment in the diff view

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -4498,7 +4498,7 @@ diff_common_read(struct view *view, const char *data, struct diff_state *state)
 	}
 
 	if (!state->after_commit_title && !prefixcmp(data, "    ")) {
-		struct line *line = add_line_text(view, data, LINE_COMMIT);
+		struct line *line = add_line_text(view, data, LINE_DIFF_STAT);
 
 		if (line)
 			line->user_flags |= DIFF_LINE_COMMIT_TITLE;


### PR DESCRIPTION
I run into an issue, view-blob (`f` binding) wasn't working, sometimes. I noticed that the %(commit) variable was wrong. After bisecting, I found that the commit title "Fix regression causing incorect coloring of the commit title" introduced this. Reverting it fixes the issue and the commit title seems to be still correctly colored. Below is the commit message.

---

Since commit 0c278556e52b9b78fde9f089cab755a6366d9ce6, the %(commit)
variable is badly overwritten with part of the commit title when we
highlight this line. For instance, browsing a commit message like this:

```
linux: add support for [...]

This text explains the patch
[...]
```

will result in the %(commit) variable to be "ux:".
(the offset corresponds to strlen("commit ") which is LINE_COMMIT).

This patch reverts commit 0c278556e52b9b78fde9f089cab755a6366d9ce6:
"Fix regression causing incorect coloring of the commit title"
