### PR TITLE
Add setenv.c in compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,11 @@ COMPAT_CPPFLAGS += -DNO_MKSTEMPS
 COMPAT_OBJS += compat/mkstemps.o
 endif
 
+ifdef NO_SETENV
+COMPAT_CPPFLAGS += -DNO_SETENV
+COMPAT_OBJS += compat/setenv.o
+endif
+
 override CPPFLAGS += $(COMPAT_CPPFLAGS)
 
 graph.o: graph.c tig.h graph.h

--- a/compat.h
+++ b/compat.h
@@ -24,6 +24,11 @@
 int compat_mkstemps(char *pattern, int suffix_len);
 #endif
 
+#ifdef NO_SETENV
+#define setenv compat_setenv
+int compat_setenv(const char *name, const char *value, int replace);
+#endif
+
 #endif
 
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/compat/setenv.c
+++ b/compat/setenv.c
@@ -1,0 +1,184 @@
+/* Copyright (C) 1992, 1995, 1996, 1997, 2002, 2011 Free Software Foundation,
+   Inc.
+   This file based on setenv.c in the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the GNU C Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
+
+/*
+ * This file was borrowed on 2013-08-08 from:
+ * https://raw.github.com/mirrors/gcc/master/libiberty/setenv.c
+ */
+
+/*
+
+@deftypefn Supplemental int setenv (const char *@var{name}, @
+  const char *@var{value}, int @var{overwrite})
+@deftypefnx Supplemental void unsetenv (const char *@var{name})
+
+@code{setenv} adds @var{name} to the environment with value
+@var{value}.  If the name was already present in the environment,
+the new value will be stored only if @var{overwrite} is nonzero.
+The companion @code{unsetenv} function removes @var{name} from the
+environment.  This implementation is not safe for multithreaded code.
+
+@end deftypefn
+
+*/
+
+#if HAVE_CONFIG_H
+#include "../config.h"
+#endif
+
+#include <sys/types.h> /* For `size_t' */
+#include <stdio.h>     /* For `NULL' */
+
+#include <errno.h>
+#if !defined(errno) && !defined(HAVE_ERRNO_DECL)
+extern int errno;
+#endif
+#define __set_errno(ev) ((errno) = (ev))
+
+#if HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+#if HAVE_STRING_H
+# include <string.h>
+#endif
+#if HAVE_UNISTD_H
+# include <unistd.h>
+#endif
+
+#define __environ	environ
+#ifndef HAVE_ENVIRON_DECL
+extern char **environ;
+#endif
+
+/* LOCK and UNLOCK are defined as no-ops.  This makes the tig
+ * implementation MT-Unsafe. */
+#define LOCK
+#define UNLOCK
+
+/* Below this point, it's verbatim code from the glibc-2.0 implementation */
+
+/* If this variable is not a null pointer we allocated the current
+   environment.  */
+static char **last_environ;
+
+
+int
+compat_setenv (const char *name, const char *value, int replace)
+{
+  register char **ep = 0;
+  register size_t size;
+  const size_t namelen = strlen (name);
+  const size_t vallen = strlen (value) + 1;
+
+  LOCK;
+
+  size = 0;
+  if (__environ != NULL)
+    {
+      for (ep = __environ; *ep != NULL; ++ep)
+	if (!strncmp (*ep, name, namelen) && (*ep)[namelen] == '=')
+	  break;
+	else
+	  ++size;
+    }
+
+  if (__environ == NULL || *ep == NULL)
+    {
+      char **new_environ;
+      if (__environ == last_environ && __environ != NULL)
+	/* We allocated this space; we can extend it.  */
+	new_environ = (char **) realloc (last_environ,
+					 (size + 2) * sizeof (char *));
+      else
+	new_environ = (char **) malloc ((size + 2) * sizeof (char *));
+
+      if (new_environ == NULL)
+	{
+	  UNLOCK;
+	  return -1;
+	}
+
+      new_environ[size] = (char *) malloc (namelen + 1 + vallen);
+      if (new_environ[size] == NULL)
+	{
+	  free ((char *) new_environ);
+	  __set_errno (ENOMEM);
+	  UNLOCK;
+	  return -1;
+	}
+
+      if (__environ != last_environ)
+	memcpy ((char *) new_environ, (char *) __environ,
+		size * sizeof (char *));
+
+      memcpy (new_environ[size], name, namelen);
+      new_environ[size][namelen] = '=';
+      memcpy (&new_environ[size][namelen + 1], value, vallen);
+
+      new_environ[size + 1] = NULL;
+
+      last_environ = __environ = new_environ;
+    }
+  else if (replace)
+    {
+      size_t len = strlen (*ep);
+      if (len + 1 < namelen + 1 + vallen)
+	{
+	  /* The existing string is too short; malloc a new one.  */
+	  char *new_string = (char *) malloc (namelen + 1 + vallen);
+	  if (new_string == NULL)
+	    {
+	      UNLOCK;
+	      return -1;
+	    }
+	  *ep = new_string;
+	}
+      memcpy (*ep, name, namelen);
+      (*ep)[namelen] = '=';
+      memcpy (&(*ep)[namelen + 1], value, vallen);
+    }
+
+  UNLOCK;
+
+  return 0;
+}
+
+#if 0
+void
+compat_unsetenv (const char *name)
+{
+  const size_t len = strlen (name);
+  char **ep;
+
+  LOCK;
+
+  for (ep = __environ; *ep; ++ep)
+    if (!strncmp (*ep, name, len) && (*ep)[len] == '=')
+      {
+	/* Found it.  Remove this pointer by moving later ones back.  */
+	char **dp = ep;
+	do
+	  dp[0] = dp[1];
+	while (*dp++);
+	/* Continue the loop in case NAME appears again.  */
+      }
+
+  UNLOCK;
+}
+#endif

--- a/config.make.in
+++ b/config.make.in
@@ -20,6 +20,7 @@ DOCBOOK2PDF = @DOCBOOK2PDF@
 
 # Special compatibility features
 @NO_MKSTEMPS@ NO_MKSTEMPS = y
+@NO_SETENV@ NO_SETENV = y
 
 %.o: config.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ AC_CHECK_FUNCS([gettimeofday])
 dnl Checks for compatibility flags
 AC_CHECK_FUNCS([mkstemps], [AC_SUBST([NO_MKSTEMPS], ["#"])])
 
+AC_CHECK_FUNCS([setenv], [AC_SUBST([NO_SETENV], ["#"])])
+
 AX_WITH_CURSES
 case "$ax_cv_ncurses" in "no")
 	AC_MSG_ERROR([ncurses not found])


### PR DESCRIPTION
Based on the work from @n1xim, this patch removes the `set_environment_variable()` code and adds a `compat/setenv.c` file. This work is based on the `gh-152-missing-mkstemps` branch which implements Drew's work.
