### PR TITLE
remove useless call to strdup() in get_temp_dir()

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -237,10 +237,10 @@ mkmode(mode_t mode)
 		return "----------";
 }
 
-static char *
+static const char *
 get_temp_dir(void)
 {
-	static char *tmp;
+	static const char *tmp;
 
 	if (tmp)
 		return tmp;
@@ -251,9 +251,6 @@ get_temp_dir(void)
 		tmp = getenv("TEMP");
 	if (!tmp)
 		tmp = getenv("TMP");
-
-	if (tmp)
-		tmp = strdup(tmp);
 	if (!tmp)
 		tmp = "/tmp";
 


### PR DESCRIPTION
Since env variables and "/tmp" (literal string) are present for the
execution of the program, there's no need to call strdup().

Also constify the tmp variable.

Ref: GH#148
