### PR TITLE
Recalculate commit in log on line number change

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -8723,6 +8723,11 @@ run_prompt_command(struct view *view, char *cmd) {
 		int lineno = view->pos.lineno + 1;
 
 		if (parse_int(&lineno, cmd, 1, view->lines + 1) == OPT_OK) {
+			if (!strcmp(view->name, "log") && displayed_views() == 1) {
+				struct log_state *state = view->private;
+
+				state->recalculate_commit_context = TRUE;
+			}
 			select_view_line(view, lineno - 1);
 			report_clear();
 		} else {


### PR DESCRIPTION
In the unsplit log view, if the line number is altered using the
:<number> approach in the command prompt, the current status line
number doesn't get updated. This commit handles the specific case of
commit recalculation for the log view when the command prompt is used.

Signed-Off-By: Kumar Appaiah a.kumar@alumni.iitm.ac.in

GH: #183
