### PR TITLE
Fix Urls

### DIFF
--- a/README
+++ b/README
@@ -11,13 +11,13 @@ commands.
 Resources
 ---------
 
- - Homepage:	http://jonas.nitro.dk/tig/[]
- - Manual:	http://jonas.nitro.dk/tig/manual.html[]
- - Tarballs:	http://jonas.nitro.dk/tig/releases/[]
+ - Homepage:	http://jonas.nitro.dk/tig/
+ - Manual:	http://jonas.nitro.dk/tig/manual.html
+ - Tarballs:	http://jonas.nitro.dk/tig/releases/
  - Git URL:	git://github.com/jonas/tig.git (master) or
 		git://repo.or.cz/tig.git (mirror)
- - Gitweb:	http://repo.or.cz/w/tig.git[]
- - Q&A:		http://stackoverflow.com/questions/tagged/tig[]
+ - Gitweb:	http://repo.or.cz/w/tig.git
+ - Q&A:		http://stackoverflow.com/questions/tagged/tig
 
 Installation
 ------------


### PR DESCRIPTION
The urls for Homepage, Manual, Tarballs, Gitweb and Q&A hada, probably, mistaken '[]' on the end.
