### PR TITLE
Add "auto" vertical-split

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -12,6 +12,8 @@ Note to packagers:
 
 Improvements:
 
+ - Add a new "auto" value for the 'vertical-split' option to let Tig choose the
+   split orientation (this is the new default behavior).
  - Add 'stage-split-chunk' action for splitting chunks in the stage view.
    Bound to '\' by default. (GH #107)
  - Add 'back' action bound to '<' by default, which will return the blame view

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -239,9 +239,11 @@ The following variables can be set:
 
 	Whether to show line numbers. Can be toggled.
 
-'vertical-split' (bool)::
+'vertical-split' (mixed) ["auto" | bool]::
 
 	Whether to split the view horizontally or vertically.
+	"auto" (which is the default) means that it will depend on the window
+	dimensions. A boolean value forces the split orientation.
 
 'split-view-height' (mixed)::
 

--- a/tig.c
+++ b/tig.c
@@ -476,6 +476,7 @@ static int opt_num_interval		= 5;
 static double opt_hscroll		= 0.50;
 static double opt_scale_split_view	= 2.0 / 3.0;
 static double opt_scale_vsplit_view	= 0.5;
+static bool opt_auto_vsplit		= TRUE;
 static bool opt_vsplit			= FALSE;
 static int opt_tab_size			= 8;
 static int opt_author_width		= AUTHOR_WIDTH;
@@ -1552,8 +1553,10 @@ option_set_command(int argc, const char *argv[])
 	if (!strcmp(argv[0], "split-view-height"))
 		return parse_step(&opt_scale_split_view, argv[2]);
 
-	if (!strcmp(argv[0], "vertical-split"))
-		return parse_bool(&opt_vsplit, argv[2]);
+	if (!strcmp(argv[0], "vertical-split")) {
+		opt_auto_vsplit = strcmp(argv[2], "auto") == 0;
+		return opt_auto_vsplit ? SUCCESS : parse_bool(&opt_vsplit, argv[2]);
+	}
 
 	if (!strcmp(argv[0], "tab-size"))
 		return parse_int(&opt_tab_size, argv[2], 1, 1024);
@@ -2530,6 +2533,9 @@ resize_display(void)
 
 	/* Make room for the status window. */
 	base->height -= 1;
+
+	if (opt_auto_vsplit)
+		opt_vsplit = base->width * opt_scale_vsplit_view > base->height * 2;
 
 	if (view != base) {
 		if (opt_vsplit) {


### PR DESCRIPTION
This patch adds a new option to control the vertical split.
If the value of the "vertical-split" option is set to "auto" (which is
the default behavior as of this commit), Tig will choose either vertical
or horizontal split depending on the window size.

Forcing the "vertical-split" option to "yes" or "no" naturally disables
the auto feature.
