### PR TITLE
Fix diff-options to be considerated only in view-diff

### DIFF
--- a/git.h
+++ b/git.h
@@ -48,7 +48,7 @@
 
 #define GIT_MAIN_LOG(encoding_arg, diffargs, revargs, fileargs) \
 	"git", "log", (encoding_arg), \
-		opt_commit_order_arg, (diffargs), (revargs), \
+		opt_commit_order_arg, (revargs), \
 		"--no-color", "--pretty=raw", "--parents", \
 		"--", (fileargs), NULL
 


### PR DESCRIPTION
diff-options was considerated not only in view-diff but also view-main. So, it
is impossible to set `git show` option. But tigrc.5.html says

```
diff-options(string)
    A space separate string of diff options to use in the diff view.
```

So, diff-options should be considerated only in view-diff. This commit fixes
the issue.

---

Base idea is that I wanted to see merge diff in tig's view-diff.
It is enabled by passing `-m --first-parent` to git show options.
But tig's diff-options was passed to view-diff and view-main.
So, passing show options only into view-diff is impossible.
