### PR TITLE
Add ZSH autocomplete compatibility.

### DIFF
--- a/contrib/tig-completion.bash
+++ b/contrib/tig-completion.bash
@@ -256,6 +256,13 @@ _tig ()
 	esac
 }
 
+# Detect if current shell is ZSH, and if so, load this file in bash
+# compatibility mode.
+if [ -n "$ZSH_VERSION" ]; then
+	autoload bashcompinit
+	bashcompinit
+fi
+
 complete -o default -o nospace -F _tig tig
 
 # The following are necessary only for Cygwin, and only are needed


### PR DESCRIPTION
Add a couple of lines that ensure that tab completions are run properly in zsh. Otherwise, pressing tab will cause a mess of newlines, error messages, and missing prompts.

Below is an example of bad autocomplete behavior. `tig <TAB>` was typed, and while the desired result is there (the file listing), the additional error messages make it very hard to work with tig, especially on larger projects and longer commands.

![Image of bad tab completion](https://f.cloud.github.com/assets/550023/2058828/c05875d4-8b86-11e3-817b-3f188b9f873e.png)
