### PR TITLE
Pass arguments in filter_options()

### DIFF
--- a/tig.c
+++ b/tig.c
@@ -9145,6 +9145,8 @@ filter_options(const char *argv[], bool blame)
 			update_diff_context_arg(opt_diff_context);
 			continue;
 		}
+
+		argv[flags_pos++] = flag;
 	}
 
 	argv[flags_pos] = NULL;


### PR DESCRIPTION
Commit 80f9dff ("Parse -U argument and update internal diff context
state") accidently dropped the passing of arguments, breaking for
example calling tig with branch name as argument.

Signed-off-by: Sven Wegener sven.wegener@stealer.net
