### PR TITLE
Fix staged view when file called "HEAD" exists

### DIFF
--- a/git.h
+++ b/git.h
@@ -35,7 +35,7 @@
 
 /* Don't show staged unmerged entries. */
 #define GIT_DIFF_STAGED_FILES(output_arg) \
-	"git", "diff-index", (output_arg), "--diff-filter=ACDMRTXB", "-M", "--cached", "HEAD", NULL
+	"git", "diff-index", (output_arg), "--diff-filter=ACDMRTXB", "-M", "--cached", "HEAD", "--", NULL
 
 #define GIT_DIFF_UNSTAGED_FILES(output_arg) \
 	"git", "diff-files", (output_arg), NULL


### PR DESCRIPTION
Staged view could not show staged files correctly when a file called "HEAD" exists in git root directory.

Issue fixed by adding "--" to the parameter list.
