### PR TITLE
remove --boundary from %(cmdlineargs)

### DIFF
--- a/include/git.h
+++ b/include/git.h
@@ -55,7 +55,7 @@
 /* FIXME(jfonseca): This is incomplete, but enough to support:
  * git rev-list --author=vivien HEAD | tig --stdin --no-walk */
 #define GIT_REV_FLAGS \
-	"--stdin", "--no-walk"
+	"--stdin", "--no-walk", "--boundary"
 
 #endif
 


### PR DESCRIPTION
If you ask tig to show boundary commits, like:

```
tig --boundary origin...master
```

we end up passing `--boundary` along to `git show` when we open the diff view for the commit. As a result, each diff contains not only the commit we cared about, but also the commit message and diff for its parent.

We can fix this by adding `--boundary` to the list of revision args to omit in `filter_options`.
