### PR TITLE
Add refs bind to delete branch.

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -71,6 +71,7 @@ Improvements:
  - Rename 'branch' view to 'refs' view and show tags. (GH #134)
  - More informative configuration error messages.
  - Add completion and history support to the prompt via readline. (GH #185)
+ - Add refs binding `!` to delete branch.
 
 Bug fixes:
 

--- a/tigrc
+++ b/tigrc
@@ -96,6 +96,7 @@ bind main	C	?git cherry-pick %(commit)
 bind status	C	!git commit
 bind stash	P	?git stash pop %(stash)
 bind branch	C	?git checkout %(branch)
+bind refs	!	!?git branch -d %(branch)
 
 # Normal commands
 # ---------------


### PR DESCRIPTION
Fixes #133.

Mnemonic: `deLete`, since the ideal `D` is already taken up, by... an option! If we implement #272, `D` would be free =)
