### PR TITLE
blame: treat HEAD as the parent of not-committed-yet

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -433,7 +433,7 @@ blame_request(struct view *view, enum request request, struct line *line)
 	switch (request) {
 	case REQ_VIEW_BLAME:
 	case REQ_PARENT:
-		if (!check_blame_commit(blame, TRUE))
+		if (!check_blame_commit(blame, request == REQ_VIEW_BLAME))
 			break;
 		blame_go_forward(view, blame, request == REQ_PARENT);
 		break;


### PR DESCRIPTION
When blaming a file with uncommitted changes, it is annoying that it is
not possible to jump to the HEAD version from an uncommitted line.  It
turns out that the commit already has HEAD as its parent, so we simply
need to relax the check in check_blame_commit() to allow the parent
request to make it to blame_go_forward().

Signed-off-by: John Keeping john@keeping.me.uk
