### PR TITLE
draw_text_overflow: fix wrong offsets for multibyte text.

### DIFF
--- a/include/tig/string.h
+++ b/include/tig/string.h
@@ -105,6 +105,11 @@ int unicode_width(unsigned long c, int tab_size);
 
 unsigned char utf8_char_length(const char *string);
 
+size_t utf8_char_count(const char *string);
+
+/* Advance string by `skip' UTF-8 characters. */
+const char* utf8_skip(const char *string, size_t skip);
+
 /* Decode UTF-8 multi-byte representation into a Unicode character. */
 unsigned long utf8_to_unicode(const char *string, size_t length);
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -133,12 +133,12 @@ draw_text_overflow(struct view *view, const char *text, enum line_type type,
 	if (on) {
 		int overflow = overflow_length + offset;
 		int max = MIN(VIEW_MAX_LEN(view), overflow);
-		int len = strlen(text);
+		int len = utf8_char_count(text);
 
 		if (draw_text_expanded(view, type, text, max, max < overflow))
 			return TRUE;
 
-		text = len > overflow ? text + overflow : "";
+		text = len > overflow ? utf8_skip(text, overflow) : "";
 		type = LINE_OVERFLOW;
 	}
 

--- a/src/string.c
+++ b/src/string.c
@@ -297,6 +297,37 @@ utf8_to_unicode(const char *string, size_t length)
 	return unicode > 0xffff ? 0 : unicode;
 }
 
+size_t
+utf8_char_count(const char *string)
+{
+	size_t count = 0;
+	while (1) {
+		unsigned char len = utf8_char_length(string);
+		while (len-- > 0) {
+			if (!*string)
+				return count;
+			string++;
+		}
+		count += 1;
+	}
+}
+
+
+const char*
+utf8_skip(const char *string, size_t skip)
+{
+	while (skip-- > 0) {
+		unsigned char len = utf8_char_length(string);
+		assert(len > 0);
+		while (len-- > 0) {
+			if (!*string)
+				return string;
+			string++;
+		}
+	}
+	return string;
+}
+
 /* Calculates how much of string can be shown within the given maximum width
  * and sets trimmed parameter to non-zero value if all of string could not be
  * shown. If the reserve flag is TRUE, it will reserve at least one


### PR DESCRIPTION
Won't work for surrogate pairs or probably even combining characters, but it's better than strlen() and 'text + offset'.
