### PR TITLE
Fix installation directory permissions.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -28,7 +28,7 @@ case "$data" in data)
 	mode=0644
 esac
 
-mkdir -p "$dest"
+install -d "$dest"
 
 if [ "$V" = "@" ]; then
 	echo "$src -> $dest"


### PR DESCRIPTION
I've installed tig as root with `make install` and had to fix the permissions of `/usr/local/etc` manually, therefore I believe `install` should be used there as well.
