### PR TITLE
blame: fix invocation of diff for line tracking

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -339,7 +339,7 @@ setup_blame_parent_line(struct view *view, struct blame *blame)
 	char from[SIZEOF_REF + SIZEOF_STR];
 	char to[SIZEOF_REF + SIZEOF_STR];
 	const char *diff_tree_argv[] = {
-		"git", "diff", encoding_arg, "--no-textconv", "--no-extdiff",
+		"git", "diff", encoding_arg, "--no-textconv", "--no-ext-diff",
 			"--no-color", "-U0", from, to, "--", NULL
 	};
 	struct io io;


### PR DESCRIPTION
The argument to `git diff` is spelled "--no-ext-diff" not
"--no-extdiff".  This allows line tracking to work instead of causing
`git diff` to spit out its usage on stderr.
