### PR TITLE
Add move-half-page-up and move-half-page-down actions

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -719,8 +719,10 @@ Cursor navigation
 |=============================================================================
 |move-up                 |Move cursor one line up
 |move-down               |Move cursor one line down
-|move-page-down          |Move cursor one page down
 |move-page-up            |Move cursor one page up
+|move-page-down          |Move cursor one page down
+|move-half-page-up       |Move cursor half a page up
+|move-half-page-down     |Move cursor half a page down
 |move-first-line         |Move cursor to first line
 |move-last-line          |Move cursor to last line
 |=============================================================================

--- a/include/tig/request.h
+++ b/include/tig/request.h
@@ -49,7 +49,9 @@
 	REQ_(MOVE_UP,		"Move cursor one line up"), \
 	REQ_(MOVE_DOWN,		"Move cursor one line down"), \
 	REQ_(MOVE_PAGE_DOWN,	"Move cursor one page down"), \
-	REQ_(MOVE_PAGE_UP,	"Move cursor one page up"), \
+	REQ_(MOVE_PAGE_UP,	"Move cursor half a page up"), \
+	REQ_(MOVE_HALF_PAGE_DOWN,	"Move cursor half a page down"), \
+	REQ_(MOVE_HALF_PAGE_UP,	"Move cursor one page up"), \
 	REQ_(MOVE_FIRST_LINE,	"Move cursor to first line"), \
 	REQ_(MOVE_LAST_LINE,	"Move cursor to last line"), \
 	\

--- a/src/tig.c
+++ b/src/tig.c
@@ -212,6 +212,8 @@ view_driver(struct view *view, enum request request)
 	case REQ_MOVE_DOWN:
 	case REQ_MOVE_PAGE_UP:
 	case REQ_MOVE_PAGE_DOWN:
+	case REQ_MOVE_HALF_PAGE_UP:
+	case REQ_MOVE_HALF_PAGE_DOWN:
 	case REQ_MOVE_FIRST_LINE:
 	case REQ_MOVE_LAST_LINE:
 		move_view(view, request);

--- a/src/view.c
+++ b/src/view.c
@@ -190,6 +190,16 @@ move_view(struct view *view, enum request request)
 		      ? view->lines - view->pos.lineno - 1 : view->height;
 		break;
 
+	case REQ_MOVE_HALF_PAGE_UP:
+		steps = view->height/2 > view->pos.lineno
+		      ? -view->pos.lineno : -(view->height/2);
+		break;
+
+	case REQ_MOVE_HALF_PAGE_DOWN:
+		steps = view->pos.lineno + view->height/2 >= view->lines
+		      ? view->lines - view->pos.lineno - 1 : view->height/2;
+		break;
+
 	case REQ_MOVE_UP:
 	case REQ_PREVIOUS:
 		steps = -1;


### PR DESCRIPTION
This allows a user to maintain half a window of context when paging
through content (and allows for <Ctrl-u> and <Ctrl-d> behavior to match
Vim's), but does not bind any keys to them by default.
