### PR TITLE
compact prefix -/+ instead of verbose ago/ahead sulfix.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -135,10 +135,10 @@ mkdate(const struct time *time, enum date date)
 				continue;
 
 			seconds /= reldate[i].namelen;
-			if (!string_format(buf, "%ld %s%s %s",
+			if (!string_format(buf, "%s%ld %s%s",
+					   now.tv_sec >= date ? "-" : "+",
 					   seconds, reldate[i].name,
-					   seconds > 1 ? "s" : "",
-					   now.tv_sec >= date ? "ago" : "ahead"))
+					   seconds > 1 ? "s" : ""))
 				break;
 			return buf;
 		}


### PR DESCRIPTION
so i can have a few more chars for the log message on a small screen. ...i think i can probably work this out as an option if nobody likes this way (i.e. everyone works on 42" monitors :)