### PR TITLE
Add option to install Tig with Homebrew

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -48,6 +48,12 @@ and then run the following command:
 
 	$ make configure
 
+Installation using Homebrew
+---------------------------
+You can use link:http://brew.sh[Homebrew] to install Tig on OS X:
+
+        $ brew install git-tig
+
 Build configuration
 -------------------
 


### PR DESCRIPTION
I was pleased to find out I could install Tig with Homebrew, so I wanted to reflect this in the installation docs.
