### PR TITLE
increase title size for commits and branches

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -27,7 +27,7 @@
 struct reference {
 	const struct ident *author;	/* Author of the last commit. */
 	struct time time;		/* Date of the last activity. */
-	char title[128];		/* First line of the commit message. */
+	char title[256];		/* First line of the commit message. */
 	const struct ref *ref;		/* Name and commit ID information. */
 };
 


### PR DESCRIPTION
using char[128] causes problems when you try to checkout a branch with long name (ex.: branch created from jira with generated name)
