### PR TITLE
Avoid initializing ncurses before parsing options

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -634,8 +634,6 @@ main(int argc, const char *argv[])
 	if (load_refs(FALSE) == ERR)
 		die("Failed to load refs.");
 
-	init_display();
-
 	if (pager_mode)
 		request = open_pager_mode(request);
 

--- a/src/view.c
+++ b/src/view.c
@@ -755,9 +755,15 @@ split_view(struct view *prev, struct view *view)
 void
 maximize_view(struct view *view, bool redraw)
 {
+	static bool display_initialized;
+
 	memset(display, 0, sizeof(display));
 	current_view = 0;
 	display[current_view] = view;
+	if (!display_initialized) {
+		init_display();
+		display_initialized = true;
+	}
 	resize_display();
 	if (redraw) {
 		redraw_display(FALSE);


### PR DESCRIPTION
If called before a view has been set up, report() will call die() which
prints to stderr and exits.  However, because init_display() is called
well before the first view is set, this is likely to result in endwin()
being called which will clear the user's terminal meaning that they do
not see the message.

For example, running "tig blame master" results in:

	user@host ~/src/tig $ tig blame master
	user@host ~/src/tig $d options to blame

	tig 2.0.3 (Dec 20 2014)

	Usage: tig        [options] [revs] [--] [paths]
	   or: tig log    [options] [revs] [--] [paths]
	   or: tig show   [options] [revs] [--] [paths]
	   or: tig blame  [options] [rev] [--] path
	   or: tig grep   [options] [pattern]
	   or: tig refs
	   or: tig stash
	   or: tig status
	   or: tig <      [git command output]

	Options:
	  +<number>       Select line <number> in the first view
	  -v, --version   Show version and exit
	  -h, --help      Show help message and exit

with the cursor positioned on the second prompt above most of the error
output.