### PR TITLE
typo: fix in autogen.sh: Leapard -> Leopard

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,7 @@ set -e
 #${AUTORECONF:-autoreconf} -v -I tools
 #
 # Unfortunately, Autoconf 2.61's autoreconf(1) (found in Mac OS X 10.5
-# Leapard) neglects to pass the -I on to aclocal(1), which is
+# Leopard) neglects to pass the -I on to aclocal(1), which is
 # precisely where we need it!  So we do basically what it would have
 # done.
 


### PR DESCRIPTION
Heh, I managed to make a typo in branch name when doing initial pull request :)

Original PR: https://github.com/jonas/tig/pull/414
