### PR TITLE
Add chocolate theme

### DIFF
--- a/contrib/chocolate.theme.tigrc
+++ b/contrib/chocolate.theme.tigrc
@@ -1,0 +1,16 @@
+color diff-stat			95	default
+color date			172	default
+color "Merge: "			cyan	default
+color graph-commit		red	default
+color id			167	default
+color "author "			95	default
+color "Commit: "		90	default
+color cursor			white	101	bold
+
+color palette-0			93	default
+color palette-1			95	default
+color palette-2			124	default
+color palette-7			90	default bold
+
+color delimiter			90	default
+color main-tracked		99	default	bold


### PR DESCRIPTION
I haven't seen any other themes in the repository, here is how it looks like : 

![selection_017](https://cloud.githubusercontent.com/assets/2071336/9425003/19cd0c72-4901-11e5-8629-bb024a5d4cbe.png)

I'm not sure if it is possible to colorize the commit messages, but if it is I'd like to colorize them a little bit.

Hope you enjoy it