### PR TITLE
Fix testframework

### DIFF
--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -21,7 +21,7 @@ if [ -n "${BASH_VERSION:-}" ]; then
 fi
 
 test="$(basename "$0")"
-source_dir="$(cd "$(dirname "$0")" && pwd)"
+source_dir="$(cd $(dirname "$0") >/dev/null && pwd)"
 base_dir="$(echo "$source_dir" | sed -n 's#\(.*/test\)\([/].*\)*#\1#p')"
 prefix_dir="$(echo "$source_dir" | sed -n 's#\(.*/test/\)\([/].*\)*#\2#p')"
 output_dir="$base_dir/tmp/$prefix_dir/$test"


### PR DESCRIPTION
At least in my shell(s), "cd foo" echoes the new cwd to stdout so that
"cd foo && pwd" echoes the new cwd twice, which lets the test framework
fail completely (due to the wrong $source_dir and everything that
depends on it).

Make that construct "cd foo >/dev/null && pwd" to be super safe, rather
than simplifying to "cd foo" and relying on the behaviour of "cd".

(I'm actually wondering how that ever worked ;)