### PR TITLE
blame: allow user to specify rev arguments to blame

### DIFF
--- a/test/blame/revargs-test
+++ b/test/blame/revargs-test
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+steps '
+	:save-display limit.screen
+
+	:8
+	:parent
+	:save-display parent-of-4779f9b.screen
+'
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+test_tig blame 74537d9..HEAD project/Build.scala
+
+# note that we show boundary commits, so the lower bound 74537d9 appears
+assert_equals 'limit.screen' <<EOF
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import sbt._                        
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import Keys._                       
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import scala.scalajs.sbtplugin._    
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import ScalaJSPlugin._              
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import ScalaJSKeys._                
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-11-26 20:13 Jonas Fonseca      4779f9b object ScalaJSBenchmarks extends Bui
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-11-26 20:13 Jonas Fonseca      4779f9b   val scalaJSScalaVersion = "2.10.2"
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   val projectSettings = Defaults.def
+2013-10-29 18:46 Sébastien Doeraene 74537d9       organization := "scalajs-bench
+2013-10-29 18:46 Sébastien Doeraene 74537d9       version := "0.1-SNAPSHOT"     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   )                                 
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   val defaultSettings = projectSetti
+2013-11-26 20:13 Jonas Fonseca      4779f9b       scalaVersion := scalaJSScalaVe
+2013-10-29 18:46 Sébastien Doeraene 74537d9       scalacOptions ++= Seq(        
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-deprecation",           
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-unchecked",             
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-feature",               
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-encoding", "utf8"       
+2013-10-29 18:46 Sébastien Doeraene 74537d9       )                             
+2013-10-29 18:46 Sébastien Doeraene 74537d9   )                                 
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   lazy val parent: Project = Project
+2013-10-29 18:46 Sébastien Doeraene 74537d9       id = "parent",                
+[blame] project/Build.scala - line 1 of 64                                   43%
+EOF
+
+# confirm that we kept our lower bound
+assert_equals 'parent-of-4779f9b.screen' <<EOF
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import sbt._                        
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import Keys._                       
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import scala.scalajs.sbtplugin._    
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import ScalaJSPlugin._              
+2013-10-29 18:46 Sébastien Doeraene 74537d9 import ScalaJSKeys._                
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9 object ScalaJSBuild extends Build { 
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   val scalajsScalaVersion = "2.10.2"
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   val projectSettings = Defaults.def
+2013-10-29 18:46 Sébastien Doeraene 74537d9       organization := "scalajs-bench
+2013-10-29 18:46 Sébastien Doeraene 74537d9       version := "0.1-SNAPSHOT"     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   )                                 
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   val defaultSettings = projectSetti
+2013-10-29 18:46 Sébastien Doeraene 74537d9       scalaVersion := scalajsScalaVe
+2013-10-29 18:46 Sébastien Doeraene 74537d9       scalacOptions ++= Seq(        
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-deprecation",           
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-unchecked",             
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-feature",               
+2013-10-29 18:46 Sébastien Doeraene 74537d9           "-encoding", "utf8"       
+2013-10-29 18:46 Sébastien Doeraene 74537d9       )                             
+2013-10-29 18:46 Sébastien Doeraene 74537d9   )                                 
+2013-10-29 18:46 Sébastien Doeraene 74537d9                                     
+2013-10-29 18:46 Sébastien Doeraene 74537d9   lazy val benchmarkSettings = defau
+2013-10-29 18:46 Sébastien Doeraene 74537d9       unmanagedSources in (Compile, 
+[blame] project/Build.scala - line 8 of 69                                   40%
+EOF


### PR DESCRIPTION
The options parser for blame is currently quite strict, and can handle only a single positive revision in opt_rev_args. But there are several parsing problems with this:

 1. If you run `tig blame --reverse foo.c`, the `--reverse`     flag ends up in opt_rev_args (filter_options knows it's a     flag, but since it is a revision flag, it gets put     there).

    We try to access `--reverse.c:foo.c`, which is     nonsensical. Moreover, if you did specify a start-point     like `HEAD foo.c`, tig will complain that you have more     than one revision arg.

 2. If you run `tig blame --since=123`, this is converted by     `rev-parse --revs-only` to `--max-age=123`, and is     included in opt_rev_args, and you run into the same     problems as above.

 3. If you run `tig blame HEAD~20..HEAD`, the commit range     is split into two arguments, `HEAD` and `^HEAD~20`, both     of which end up in opt_rev_args. Similarly, the user can     specify this `split` form themselves.

We can fix this by further parsing `opt_rev_args`. Instead of assuming that it must contain zero or one arguments, we can pick out the "positive" ref as our starting point (and complain if there is more than one).

The rest of the rev-args we add to `%(blameargs)`, so that git-blame can act on them.
