### PR TITLE
add a %(text) variable

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -180,6 +180,7 @@ following variables.
 |%(mainargs)		|Options from 'main-options' used by the main view.
 |%(prompt)		|Prompt for the argument value. Optionally specify a
 			 custom prompt using `"%(prompt Enter branch name: )"`
+|%(text)		|The text of the currently selected line.
 |%(repo:head)		|The name of the checked out branch, e.g. `master`
 |%(repo:head-id)	|The commit ID of the checked out branch.
 |%(repo:remote)		|The remote associated with the checked out branch,

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -618,6 +618,7 @@ following variable names, which are substituted before commands are run:
 |%(mainargs)		|Options from 'main-options' used by the main view.
 |%(prompt)		|Prompt for the argument value. Optionally specify a
 			 custom prompt using `"%(prompt Enter branch name: )"`
+|%(text)		|The text of the currently selected line.
 |%(repo:head)		|The name of the checked out branch, e.g. `master`
 |%(repo:head-id)	|The commit ID of the checked out branch.
 |%(repo:remote)		|The remote associated with the checked out branch,

--- a/include/tig/argv.h
+++ b/include/tig/argv.h
@@ -49,7 +49,8 @@ typedef unsigned long argv_number;
 	_(argv_string,	 remote,	"origin",	"") \
 	_(argv_string,	 stash,		"",		"") \
 	_(argv_string,	 status,	"",		"") \
-	_(argv_string,	 tag,		"",		"")
+	_(argv_string,	 tag,		"",		"") \
+	_(argv_string,	 text,		"",		"") \
 
 #define ARGV_ENV_FIELDS(type, name, ifempty, initval)	type name;
 

--- a/src/pager.c
+++ b/src/pager.c
@@ -165,8 +165,12 @@ pager_request(struct view *view, enum request request, struct line *line)
 void
 pager_select(struct view *view, struct line *line)
 {
+	const char *text = box_text(line);
+
+	string_ncopy(view->env->text, text, strlen(text));
+
 	if (line->type == LINE_COMMIT) {
-		string_copy_rev_from_commit_line(view->env->commit, box_text(line));
+		string_copy_rev_from_commit_line(view->env->commit, text);
 		if (!view_has_flags(view, VIEW_NO_REF))
 			string_copy_rev(view->ref, view->env->commit);
 	}


### PR DESCRIPTION
This exposes the text of the currently selected line as the %(text)
variable. Only the pager view is supported at the moment.

This is particularly handy for using Tig as a scriptable pager. For
instance, here's a dumb remote manager:

    $ echo 'bind pager <Enter> git remote show -n %(text)' >> ~/.tigrc
    $ echo 'bind pager U git remote update -p %(text)' >> ~/.tigrc
    $ git remote | tig

Pressing Enter shows remote information, pressing U fetches the remote.