### PR TITLE
Update Vim bindings to include <C-f> and <C-b>

### DIFF
--- a/contrib/vim.tigrc
+++ b/contrib/vim.tigrc
@@ -22,6 +22,9 @@ bind generic gn view-next
 bind main    G  none
 bind generic G  move-last-line
 
+bind generic <C-f> move-page-down
+bind generic <C-b> move-page-up
+
 bind generic v  none
 bind generic vm view-main
 bind generic vd view-diff


### PR DESCRIPTION
These bindings are commonly used in vim and other text viewers (for example, `less`) to scroll pages at a time.

Thanks!