### PR TITLE
Set view->parent to NULL when view is closed.

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -324,6 +324,7 @@ view_driver(struct view *view, enum request request)
 			maximize_view(view->prev, true);
 			view->prev = view;
 			watch_unregister(&view->watch);
+			view->parent = NULL;
 			break;
 		}
 		/* Fall-through */


### PR DESCRIPTION
Fixes an issue where diff full screen diff view up/down navigation results
in moving the underlying commit rather than the diff line if the diff view
had been opened in split format (Enter key) before.