### PR TITLE
Show signature in diff view

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -25,7 +25,7 @@ static bool
 diff_open(struct view *view, enum open_flags flags)
 {
 	const char *diff_argv[] = {
-		"git", "show", encoding_arg, "--pretty=fuller", "--root",
+		"git", "show", "--show-signature", encoding_arg, "--pretty=fuller", "--root",
 			"--patch-with-stat", use_mailmap_arg(),
 			show_notes_arg(), diff_context_arg(), ignore_space_arg(),
 			"%(diffargs)", "%(cmdlineargs)", "--no-color", "%(commit)",

--- a/src/log.c
+++ b/src/log.c
@@ -64,7 +64,7 @@ static bool
 log_open(struct view *view, enum open_flags flags)
 {
 	const char *log_argv[] = {
-		"git", "log", encoding_arg, commit_order_arg(), "--cc",
+		"git", "log", "--show-signature", encoding_arg, commit_order_arg(), "--cc",
 			"--stat", "%(logargs)", "%(cmdlineargs)", "%(revargs)",
 			"--no-color", "--", "%(fileargs)", NULL
 	};


### PR DESCRIPTION
With the recent introduction of GPG signing support in Github, I feel like this is a good time to introduce support for showing signatures in tig.

Currently I've added this in the diff and log view. 

I couldn't figure out where options are defined to make this an option the use can enable and disable - was hoping for some feedback on that.