### PR TITLE
Make 'make configure' quieter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ $(TESTS): $(EXE) test/tools/test-graph
 # Other autoconf-related rules are hidden in config.make.in so that
 # they don't confuse Make when we aren't actually using ./configure
 configure: configure.ac acinclude.m4 tools/*.m4
-	./autogen.sh
+	$(QUIET_GEN)./autogen.sh
 
 .PHONY: all all-coverage all-debug clean clean-coverage clean-test doc \
 	doc-man doc-html dist distclean install install-doc \

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ set -e
 # done.
 
 run () {
-    echo $0: running: "$@"
+    test ${V} = 1 && echo $0: running: "$@"
     "$@"
 }
 


### PR DESCRIPTION
With this patch, 'make configure' is quieter:

$ make configure
       GEN  configure

And if V=1 is specified, then the output is more verbose:

$ make V=1 configure
./autogen.sh
./autogen.sh: running: aclocal -I tools
./autogen.sh: running: autoconf --include=tools
./autogen.sh: running: autoheader --include=tools