### PR TITLE
Show tracking info in tig status

### DIFF
--- a/test/status/on-branch-tracking-info-test
+++ b/test/status/on-branch-tracking-info-test
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export LINES=10
+
+test_setup_work_dir()
+{
+	create_repo_from_tgz "$base_dir/files/refs-repo.tgz" 
+
+	git checkout -b ahead
+	echo test > test.txt
+	git add test.txt
+	git_commit -m "Ahead branch"
+	git checkout master
+
+	git checkout -b diverged HEAD~2
+	echo test > test.txt
+	git add test.txt
+	git_commit -m "Diverged branch"
+	git checkout master
+}
+
+test_case up-to-date-with-remote-master \
+	--args='status' <<EOF
+On branch master. Your branch is up-to-date with 'origin/master'.               
+Changes to be committed:                                                        
+  (no files)                                                                    
+Changes not staged for commit:                                                  
+  (no files)                                                                    
+Untracked files:                                                                
+  (no files)                                                                    
+                                                                                
+[status] Nothing to update                                                  100%
+EOF
+
+test_case behind-remote-master \
+	--args='status' \
+	--before="git reset --hard HEAD~2" \
+	--after="git reset --hard origin/master" <<EOF
+On branch master. Your branch is behind 'origin/master' by 2 commits.           
+Changes to be committed:                                                        
+  (no files)                                                                    
+Changes not staged for commit:                                                  
+  (no files)                                                                    
+Untracked files:                                                                
+  (no files)                                                                    
+                                                                                
+[status] Nothing to update                                                  100%
+EOF
+
+test_case ahead-of-remote-master \
+	--args='status' \
+	--before="git merge ahead" \
+	--after="git reset --hard origin/master" <<EOF
+On branch master. Your branch is ahead of 'origin/master' by 1 commit.          
+Changes to be committed:                                                        
+  (no files)                                                                    
+Changes not staged for commit:                                                  
+  (no files)                                                                    
+Untracked files:                                                                
+  (no files)                                                                    
+                                                                                
+[status] Nothing to update                                                  100%
+EOF
+
+test_case diverged-from-remote-master \
+	--args='status' \
+	--before="git reset --hard diverged" \
+	--after="git reset --hard origin/master" <<EOF
+On branch master. Your branch and 'origin/master' have diverged, and have 1 and 
+Changes to be committed:                                                        
+  (no files)                                                                    
+Changes not staged for commit:                                                  
+  (no files)                                                                    
+Untracked files:                                                                
+  (no files)                                                                    
+                                                                                
+[status] Nothing to update                                                  100%
+EOF
+
+run_test_cases
+
+add_exec_prefix()
+{
+	code="$(cat "$1")"
+	if [ -n "$code" ]; then
+		echo "$code" | sed -e 's/^[ 	]*//' -e '/^$/d' -e 's/^/:exec @/'
+	fi
+}
+
+tig_script "all" "
+	$(for name in $(cat test-cases); do
+		add_exec_prefix "$name-before"
+		echo :save-display all-$name.screen
+		add_exec_prefix "$name-after"
+	done)
+"
+
+test_tig status
+
+for name in $(cat test-cases); do
+	assert_equals "all-$name.screen" < "$name.expected"
+done


### PR DESCRIPTION
- Updated `tig status` to show tracking info when appropriate as suggested in #460.
- The `git rev-list` command is used to determine the difference with the remote branch instead of parsing the output of `git status`, as there's no guarantee the format of the latter will remain the same in future.
- Added new test `on-branch-tracking-info-test` based on `on-branch-test` to help ensure this new functionality works as expected.

Below is a screenshot showing the appearance of this feature:

![tig-branch-tracking-info](https://cloud.githubusercontent.com/assets/7596018/15808096/7c334a14-2b66-11e6-872e-21508801c852.PNG)