### PR TITLE
Add command line aliases for `tig refs`

### DIFF
--- a/doc/tig.1.adoc
+++ b/doc/tig.1.adoc
@@ -56,6 +56,12 @@ log::
 refs::
 	Start up in refs view.
 
+branch::
+	Start up in refs view. Here for compatibility with the 'git branch' command.
+
+tag::
+	Start up in refs view. Here for compatibility with the 'git tag' command.
+
 stash::
 	Start up in stash view.
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -470,7 +470,7 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 	} else if (!strcmp(subcommand, "stash")) {
 		request = REQ_VIEW_STASH;
 
-	} else if (!strcmp(subcommand, "refs")) {
+	} else if (!strcmp(subcommand, "refs") || !strcmp(subcommand, "branch") || !strcmp(subcommand, "tag")) {
 		request = REQ_VIEW_REFS;
 
 	} else {


### PR DESCRIPTION
I find myself typing `tig branch` to show the branches a lot. Therefore I added a command line option as an alias for `tig refs`. I also added `tig tag` for completeness.

I assume there is a (minor) change needed for bash completion but I could find out how to do that myself. Hopefully someone with more knowledge of bash completion can fix that.
