### PR TITLE
Fix error when running with --silent.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ set -e
 # done.
 
 run () {
-    test ${V} = 1 && echo $0: running: "$@"
+    test "${V}" = 1 && echo $0: running: "$@"
     "$@"
 }
 


### PR DESCRIPTION
Otherwise running `autogen.sh` manually, or using `make configure
--silent` will result in errors:

    ./autogen.sh: 16: test: =: unexpected operator