### PR TITLE
Reorganize checking of libraries for termcap functions

### DIFF
--- a/tools/ax_lib_readline.m4
+++ b/tools/ax_lib_readline.m4
@@ -33,17 +33,19 @@ _bash_needmsg=
 fi
 AC_CACHE_VAL(bash_cv_termcap_lib,
 [AC_CHECK_FUNC(tgetent, bash_cv_termcap_lib=libc,
-  [AC_CHECK_LIB(termcap, tgetent, bash_cv_termcap_lib=libtermcap,
-    [AC_CHECK_LIB(tinfo, tgetent, bash_cv_termcap_lib=libtinfo,
-        bash_cv_termcap_lib=gnutermcap
 if test "$ax_cv_curses_which" = "ncursesw"; then
-        [AC_CHECK_LIB(ncursesw, tgetent, bash_cv_termcap_lib=libncursesw)]
+	[AC_CHECK_LIB(ncursesw, tgetent, bash_cv_termcap_lib=libncursesw)]
 elif test "$ax_cv_curses_which" = "ncurses"; then
-        [AC_CHECK_LIB(ncurses, tgetent, bash_cv_termcap_lib=libncurses)]
+	[AC_CHECK_LIB(ncurses, tgetent, bash_cv_termcap_lib=libncurses)]
 elif test "$ax_cv_curses_which" = "plaincurses"; then
-        [AC_CHECK_LIB(curses, tgetent, bash_cv_termcap_lib=libcurses)]
+	[AC_CHECK_LIB(curses, tgetent, bash_cv_termcap_lib=libcurses)]
+else
+	[AC_CHECK_LIB(termcap, tgetent, bash_cv_termcap_lib=libtermcap,
+		[AC_CHECK_LIB(tinfo, tgetent, bash_cv_termcap_lib=libtinfo,
+			bash_cv_termcap_lib=gnutermcap
+	)])]
 fi
-)])])])
+)])
 if test "X$_bash_needmsg" = "Xyes"; then
 AC_MSG_CHECKING(which library has the termcap functions)
 fi


### PR DESCRIPTION
This fixes found issue on FreeBSD operating system, where libtermcap.so is a link to libncurses.so:

```
% readlink /usr/lib/libtermcap.so
libncurses.so
```

and -lncurses links before -lncursesw, which causes display issues for wide characters:

```
% ldd -a /usr/local/bin/tig | sed -e 's| (.*)$||'
/usr/local/bin/tig:
    libreadline.so.6 => /usr/local/lib/libreadline.so.6
    libncurses.so.8 => /lib/libncurses.so.8
    libncursesw.so.8 => /lib/libncursesw.so.8
    libc.so.7 => /lib/libc.so.7
/usr/local/lib/libreadline.so.6:
    libncurses.so.8 => /lib/libncurses.so.8
    libc.so.7 => /lib/libc.so.7
/lib/libncurses.so.8:
    libc.so.7 => /lib/libc.so.7
/lib/libncursesw.so.8:
    libc.so.7 => /lib/libc.so.7
```

After applied patch:

```
% ldd -a /usr/local/bin/tig | sed -e 's| (.*)$||'
/usr/local/bin/tig:
    libreadline.so.6 => /usr/local/lib/libreadline.so.6
    libncursesw.so.8 => /lib/libncursesw.so.8
    libc.so.7 => /lib/libc.so.7
/usr/local/lib/libreadline.so.6:
    libncurses.so.8 => /lib/libncurses.so.8
    libc.so.7 => /lib/libc.so.7
/lib/libncursesw.so.8:
    libc.so.7 => /lib/libc.so.7
/lib/libncurses.so.8:
    libc.so.7 => /lib/libc.so.7
```

Previously, it was fixed with following patch, which reorders CURSES_LIB and LIBS for LDLIBS in config.make.in file:
https://github.com/freebsd/freebsd-ports/blob/d8fc42250fa5ee5973645df18ec1dbee39087e11/devel/tig/files/patch-config.make.in
but even in this case, the ldd output shows linked libncurses.so library, after libncursesw.so, of course.
