### PR TITLE
Add navigation between merge commits

### DIFF
--- a/include/tig/graph.h
+++ b/include/tig/graph.h
@@ -39,6 +39,7 @@ struct graph {
 			   const char *id, const char *parents, bool is_boundary);
 	bool (*add_parent)(struct graph *graph, const char *parent);
 	bool (*render_parents)(struct graph *graph, struct graph_canvas *canvas);
+	bool (*is_merge)(struct graph_canvas *canvas);
 
 	void (*foreach_symbol)(const struct graph *graph, const struct graph_canvas *canvas, graph_symbol_iterator_fn fn, void *data);
 

--- a/include/tig/request.h
+++ b/include/tig/request.h
@@ -54,6 +54,8 @@
 	REQ_(MOVE_HALF_PAGE_UP,	"Move cursor one page up"), \
 	REQ_(MOVE_FIRST_LINE,	"Move cursor to first line"), \
 	REQ_(MOVE_LAST_LINE,	"Move cursor to last line"), \
+	REQ_(MOVE_NEXT_MERGE,	"Move cursor to next merge commit"), \
+	REQ_(MOVE_PREV_MERGE,	"Move cursor to previous merge commit"), \
 	\
 	REQ_GROUP("Scrolling") \
 	REQ_(SCROLL_LINE_UP,	"Scroll one line up"), \

--- a/include/tig/search.h
+++ b/include/tig/search.h
@@ -19,6 +19,7 @@
 void reset_search(struct view *view);
 void search_view(struct view *view, enum request request);
 void find_next(struct view *view, enum request request);
+void find_merge(struct view *view, enum request request);
 bool grep_text(struct view *view, const char *text[]);
 
 #endif

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -714,6 +714,12 @@ graph_render_parents(struct graph *graph_ref, struct graph_canvas *canvas)
 }
 
 static bool
+is_merge(struct graph_canvas *canvas)
+{
+	return !!canvas->symbols->merge;
+}
+
+static bool
 graph_add_commit(struct graph *graph_ref, struct graph_canvas *canvas,
 		 const char *id, const char *parents, bool is_boundary)
 {
@@ -1109,6 +1115,7 @@ init_graph_v2(void)
 	api->done_rendering = done_graph_rendering;
 	api->add_commit = graph_add_commit;
 	api->add_parent = graph_add_parent;
+	api->is_merge = is_merge;
 	api->render_parents = graph_render_parents;
 	api->foreach_symbol = graph_foreach_symbol;
 	api->symbol_to_ascii = graph_symbol_to_ascii;

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 #include "tig/stage.h"
 #include "tig/main.h"
 #include "tig/diff.h"
+#include "tig/search.h"
 
 /*
  * Main view backend
@@ -534,6 +535,11 @@ main_request(struct view *view, enum request request, struct line *line)
 
 	case REQ_PARENT:
 		goto_id(view, "%(commit)^", true, false);
+		break;
+
+	case REQ_MOVE_NEXT_MERGE:
+	case REQ_MOVE_PREV_MERGE:
+		find_merge(view, request);
 		break;
 
 	default:

--- a/src/search.c
+++ b/src/search.c
@@ -210,7 +210,7 @@ find_next_merge(struct view *view, enum request request)
 		return error("Unknown search request");
 	}
 
-	if (!view->matched_lines && find_merges(view))
+	if (!view->matched_lines && !find_merges(view))
 		return ERROR_OUT_OF_MEMORY;
 
 	code = find_next_match_line(view, direction, false);

--- a/src/search.c
+++ b/src/search.c
@@ -207,7 +207,7 @@ find_next_merge(struct view *view, enum request request)
 		break;
 
 	default:
-		return error("Unknown search request");
+		return error("Invalid request searching for next merge");
 	}
 
 	if (!view->matched_lines && !find_merges(view))

--- a/src/search.c
+++ b/src/search.c
@@ -69,7 +69,7 @@ find_merges(struct view *view)
 		if (!view->ops->get_column_data(view, line, &column_data))
 			continue;
 
-		if (!column_data.graph->is_merge(canvas))
+		if (column_data.graph && !column_data.graph->is_merge(canvas))
 			continue;
 
 		if (!realloc_unsigned_ints(&view->matched_line, view->matched_lines, 1))

--- a/src/tig.c
+++ b/src/tig.c
@@ -294,7 +294,7 @@ view_driver(struct view *view, enum request request)
 
 	case REQ_MOVE_NEXT_MERGE:
 	case REQ_MOVE_PREV_MERGE:
-		find_merge(view, request);
+		report("Moving between merge commits is not supported by the %s view", view->name);
 		break;
 
 	case REQ_STOP_LOADING:

--- a/src/tig.c
+++ b/src/tig.c
@@ -292,6 +292,11 @@ view_driver(struct view *view, enum request request)
 		find_next(view, request);
 		break;
 
+	case REQ_MOVE_NEXT_MERGE:
+	case REQ_MOVE_PREV_MERGE:
+		find_merge(view, request);
+		break;
+
 	case REQ_STOP_LOADING:
 		foreach_view(view, i) {
 			if (view->pipe)


### PR DESCRIPTION
Allow skipping forward and backward between merge commits by means of
two actions “move-next-merge” and “move-prev-merge”. The search
considers all lines containing the merge symbol.
