### PR TITLE
Fix broken diff-highlight on some platforms

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -48,7 +48,7 @@ diff_init_highlight(struct view *view, struct diff_state *state)
 {
 	if (opt_diff_highlight) {
 		const char *argv[] = { opt_diff_highlight, NULL };
-		char * const env[] = { "GIT_CONFIG=/dev/null" };
+		char * const env[] = { "GIT_CONFIG=/dev/null", NULL };
 		struct io io;
 
 		if (io_exec(&io, IO_RP, view->dir, env, argv, view->io.pipe)) {


### PR DESCRIPTION
Fix issue with diff-highlight that the env variable is not null terminated

Refs #313

Signed-off-by: David Lin <dtwlin@google.com>