### PR TITLE
Add smart-case option

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -281,6 +281,11 @@ The following variables can be set:
 
 	Ignore case in searches. By default, the search is case sensitive.
 
+'smart-case' (bool)::
+
+	Ignore case in searches only if search doesn't contain any uppercase
+	letters. By default, this is disabled.
+
 'mailmap' (bool)::
 
 	Read canonical name and email addresses for authors and committers from

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -49,6 +49,7 @@ typedef struct view_column *view_settings;
 	_(horizontal_scroll,		double,			VIEW_NO_FLAGS) \
 	_(id_width,			int,			VIEW_NO_FLAGS) \
 	_(ignore_case,			bool,			VIEW_NO_FLAGS) \
+	_(smart_case,			bool,			VIEW_NO_FLAGS) \
 	_(ignore_space,			enum ignore_space,	VIEW_DIFF_LIKE) \
 	_(line_graphics,		enum graphic,		VIEW_NO_FLAGS) \
 	_(log_options,			const char **,		VIEW_LOG_LIKE) \

--- a/src/search.c
+++ b/src/search.c
@@ -57,11 +57,28 @@ find_matches(struct view *view)
 
 static enum status_code find_next_match(struct view *view, enum request request);
 
+static bool contains_uppercase(const char *search)
+{
+	const char *c = search;
+	for (; *c != '\0'; ++c) {
+		if (isupper(*c))
+			return true;
+	}
+	return false;
+}
+
 static enum status_code
 setup_and_find_next(struct view *view, enum request request)
 {
 	int regex_err;
 	int regex_flags = opt_ignore_case ? REG_ICASE : 0;
+
+	if (opt_smart_case == 1) {
+		if (contains_uppercase(view->env->search))
+			regex_flags &= ~REG_ICASE;
+		else
+			regex_flags |= REG_ICASE;
+	}
 
 	if (view->regex) {
 		regfree(view->regex);

--- a/tigrc
+++ b/tigrc
@@ -107,6 +107,8 @@ set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 set refresh-mode		= auto		# Enum: manual, auto, after-command, periodic
 set refresh-interval		= 10		# Interval in seconds between refreshes
 set ignore-case			= no		# Ignore case when searching?
+set smart-case			= no		# Ignore case when searching only if search expression
+						# doesn't contains any uppercase letters?
 set wrap-search			= yes		# Wrap around to top/bottom of view when searching
 set focus-child			= yes		# Move focus to child view when opened?
 set horizontal-scroll		= 50%		# Number of columns to scroll as % of width


### PR DESCRIPTION
New option enables case-insensitive search only if current search
expression doesn't contain any uppercase letters.

This is simple solution which checks only uppercase ASCII letters.

Fixes #320