### PR TITLE
Improve blame argument behavior

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -88,8 +88,10 @@ blame_open(struct view *view, enum open_flags flags)
 
 		string_ncopy(view->env->file, opt_file_args[0], strlen(opt_file_args[0]));
 
-		opt_blame_options = opt_cmdline_args;
-		opt_cmdline_args = NULL;
+		if (opt_cmdline_args) {
+			opt_blame_options = opt_cmdline_args;
+			opt_cmdline_args = NULL;
+		}
 
 		/*
 		 * flags (like "--max-age=123") and bottom limits (like "^foo")

--- a/src/blame.c
+++ b/src/blame.c
@@ -81,16 +81,6 @@ blame_open(struct view *view, enum open_flags flags)
 	char path[SIZEOF_STR];
 	size_t i;
 
-	if (opt_blame_options) {
-		for (i = 0; opt_blame_options[i]; i++) {
-			if (prefixcmp(opt_blame_options[i], "-C"))
-				continue;
-			state->auto_filename_display = true;
-		}
-	}
-
-	blame_update_file_name_visibility(view);
-
 	if (is_initial_view(view)) {
 		/* Finish validating and setting up blame options */
 		if (!opt_file_args || opt_file_args[1])
@@ -123,6 +113,16 @@ blame_open(struct view *view, enum open_flags flags)
 			}
 		}
 	}
+
+	if (opt_blame_options) {
+		for (i = 0; opt_blame_options[i]; i++) {
+			if (prefixcmp(opt_blame_options[i], "-C"))
+				continue;
+			state->auto_filename_display = true;
+		}
+	}
+
+	blame_update_file_name_visibility(view);
 
 	if (!view->env->file[0])
 		return error("No file chosen, press %s to open tree view",


### PR DESCRIPTION
This moves the checking for `-C` to after `opt_blame_options` and (as per the tigrc man page) only sets `opt_blame_options` via the command line if command line arguments were actually given.