### PR TITLE
status view: 'u' selects next file

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -394,6 +394,13 @@ status_open(struct view *view, enum open_flags flags)
 		}
 	}
 
+	/* move cursor forward in unstaged&untracked list */
+	if (emptylines_above_after > 3) {
+		if (view->prev_pos.lineno < view->lines) {
+			view->prev_pos.lineno++;
+		}
+	}
+
 	/* avoid changing direction after adding first file to the staging area */
 	if (emptylines_above_after < emptylines_above_before) {
 		if (view->prev_pos.lineno > 0) {


### PR DESCRIPTION
Hi,

in the status view I find the behaviour of 'u' quirky:
- it changes "direction" after the first file is added to the staging area: the file after the added file is highlighted, while normally the file above is highlighted
- in the staging area 'u' moves the cursor "forward" while in the other two lists 'u' moves the cursor "backward": my intuition is that after pressing 'u' the next file will be selected, not the previous