### PR TITLE
fix graphs where the same commit is hit by a merge and a branch

### DIFF
--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -859,6 +859,15 @@ graph_symbol_multi_merge(const struct graph_symbol *symbol)
 	return true;
 }
 
+
+static const bool
+graph_symbol_merge_branch(const struct graph_symbol *symbol)
+{
+
+	return graph_symbol_turn_left(symbol) && graph_symbol_merge(symbol);
+}
+
+
 static const bool
 graph_symbol_vertical_bar(const struct graph_symbol *symbol)
 {
@@ -949,6 +958,9 @@ graph_symbol_to_utf8(const struct graph_symbol *symbol)
 	if (graph_symbol_vertical_bar(symbol))
 		return " │";
 
+	if (graph_symbol_merge_branch(symbol))
+		return "─┤";
+
 	if (graph_symbol_turn_left(symbol))
 		return "─╯";
 
@@ -1000,6 +1012,10 @@ graph_symbol_to_chtype(const struct graph_symbol *symbol)
 	} else if (graph_symbol_vertical_bar(symbol)) {
 		graphics[0] = ' ';
 		graphics[1] = ACS_VLINE;
+
+	} else if (graph_symbol_merge_branch(symbol)) {
+		graphics[0] = ACS_HLINE;
+		graphics[1] = ACS_RTEE;
 
 	} else if (graph_symbol_turn_left(symbol)) {
 		graphics[0] = ACS_HLINE;
@@ -1057,6 +1073,9 @@ graph_symbol_to_ascii(const struct graph_symbol *symbol)
 
 	if (graph_symbol_vertical_bar(symbol))
 		return " |";
+
+	if (graph_symbol_merge_branch(symbol))
+		return "-|";
 
 	if (graph_symbol_turn_left(symbol))
 		return "-'";


### PR DESCRIPTION
Trying to fix graphs where the same commit is hit by a merge and a new branch, but the graph gives the impression the commit is not merged.

The old case rendered this result. Not that the bottom branch looks
like it terminates without being merged:

````
 ● Update NEWS with post 2.1.1 changes
 ●─╮ Merge pull request #457 from vivien/text-variable
 │ ● add a %(text) variable
 ●─╯ Merge pull request #439 from peff/fix-blame-args
 │ ● blame: allow user to specify rev arguments to blame
 ●─╯ Update OSX make config to find brew installed ncurses
 ● Remove unneeded calls to {def,reset}_prog_mode
````

With fix I get this:

````
 ● Update NEWS with post 2.1.1 changes
 ●─╮ Merge pull request #457 from vivien/text-variable
 │ ● add a %(text) variable
 ●─┤ Merge pull request #439 from peff/fix-blame-args
 │ ● blame: allow user to specify rev arguments to blame
 ●─╯ Update OSX make config to find brew installed ncurses
 ● Remove unneeded calls to {def,reset}_prog_mode
````

Related to https://github.com/jonas/tig/issues/419

My current solution is not nice: it depends on the order of evaluation in the
graph_symbol_to_XXX() functions so that the new case of graph_symbol_merge_branch()
is hit before graph_symbol_turn_left() or graph_symbol_merge() do.

The graph-generating code is complex, and I have not spent enough time in it to
know for sure my fix does not mess up other situations.