### PR TITLE
also interpret button5 as wheel-down

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -589,7 +589,11 @@ handle_mouse_event(void)
 	if (!view)
 		return REQ_NONE;
 
+#ifdef BUTTON5_PRESSED
+	if (event.bstate & (BUTTON2_PRESSED | BUTTON5_PRESSED))
+#else
 	if (event.bstate & BUTTON2_PRESSED)
+#endif
 		return REQ_SCROLL_WHEEL_DOWN;
 
 	if (event.bstate & BUTTON4_PRESSED)


### PR DESCRIPTION
fixes #321 .  Likely this should always have been button5, instead of button2, per https://github.com/mirror/ncurses/blob/af3d0ee323cbb22d2a7596d564bf68f7307f5076/ncurses/base/lib_mouse.c#L1025 
