### PR TITLE
add boolean ~/.tigrc option `mouse-wheel-cursor`

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -318,6 +318,13 @@ The following variables can be set:
 	Mouse support requires that ncurses itself support mouse events and that
 	you have enabled mouse support in ~/.tigrc with `set mouse = true`.
 
+'mouse-wheel-cursor' (bool)::
+
+	Whether to prefer moving the cursor to scrolling the view when using the
+	mouse wheel. Off by default. Combines well with `set mouse-scroll = 1`.
+	Mouse support requires that ncurses itself support mouse events and that
+	you have enabled mouse support in ~/.tigrc with `set mouse = true`.
+
 'refresh-mode' (mixed) [manual|auto|after-command|periodic|<bool>]::
 
 	Configures how views are refreshed based on modifications to watched

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -58,6 +58,7 @@ typedef struct view_column *view_settings;
 	_(main_view,			view_settings,		VIEW_NO_FLAGS) \
 	_(mouse,			bool,			VIEW_NO_FLAGS) \
 	_(mouse_scroll,			int,			VIEW_NO_FLAGS) \
+	_(mouse_wheel_cursor,		bool,			VIEW_NO_FLAGS) \
 	_(pager_view,			view_settings,		VIEW_NO_FLAGS) \
 	_(reference_format,		struct ref_format **,	VIEW_NO_FLAGS) \
 	_(refresh_interval,		int,			VIEW_NO_FLAGS) \

--- a/include/tig/request.h
+++ b/include/tig/request.h
@@ -96,6 +96,8 @@ enum request {
 	/* Internal requests. */
 	REQ_SCROLL_WHEEL_DOWN,
 	REQ_SCROLL_WHEEL_UP,
+	REQ_MOVE_WHEEL_DOWN,
+	REQ_MOVE_WHEEL_UP,
 
 	/* Start of the run request IDs */
 	REQ_RUN_REQUESTS

--- a/src/tig.c
+++ b/src/tig.c
@@ -171,6 +171,8 @@ view_driver(struct view *view, enum request request)
 	case REQ_MOVE_HALF_PAGE_DOWN:
 	case REQ_MOVE_FIRST_LINE:
 	case REQ_MOVE_LAST_LINE:
+	case REQ_MOVE_WHEEL_DOWN:
+	case REQ_MOVE_WHEEL_UP:
 		move_view(view, request);
 		break;
 
@@ -599,10 +601,10 @@ handle_mouse_event(void)
 #else
 	if (event.bstate & BUTTON2_PRESSED)
 #endif
-		return REQ_SCROLL_WHEEL_DOWN;
+		return opt_mouse_wheel_cursor ? REQ_MOVE_WHEEL_DOWN : REQ_SCROLL_WHEEL_DOWN;
 
 	if (event.bstate & BUTTON4_PRESSED)
-		return REQ_SCROLL_WHEEL_UP;
+		return opt_mouse_wheel_cursor ? REQ_MOVE_WHEEL_UP : REQ_SCROLL_WHEEL_UP;
 
 	if (event.bstate & BUTTON1_PRESSED) {
 		if (event.y == view->pos.lineno - view->pos.offset) {

--- a/src/view.c
+++ b/src/view.c
@@ -201,6 +201,14 @@ move_view(struct view *view, enum request request)
 		      ? view->lines - view->pos.lineno - 1 : view->height / 2;
 		break;
 
+	case REQ_MOVE_WHEEL_DOWN:
+		steps = opt_mouse_scroll;
+		break;
+
+	case REQ_MOVE_WHEEL_UP:
+		steps = -opt_mouse_scroll;
+		break;
+
 	case REQ_MOVE_UP:
 	case REQ_PREVIOUS:
 		steps = -1;

--- a/tigrc
+++ b/tigrc
@@ -119,6 +119,7 @@ set editor-line-number		= yes		# Automatically pass line number to editor? Used
 						# for opening file at specific line e.g. from a diff
 set mouse			= no		# Enable mouse support?
 set mouse-scroll		= 3		# Number of lines to scroll via the mouse
+set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?
 
 # User-defined commands
 # ---------------------


### PR DESCRIPTION
off by default.  setting this to true causes wheel actions to prefer moving the cursor, scrolling the view only when the cursor passes view boundaries.

in present form, will merge conflict with #606