### PR TITLE
WIP remove "expected" test outputs during setup

### DIFF
--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -433,6 +433,7 @@ test_tig()
 	if [ -n "$trace" ]; then
 		export TIG_TRACE="$HOME/${prefix}tig-trace"
 	fi
+	rm -f -- "expected/stdin" "expected/stderr"
 	touch "${prefix}stdin" "${prefix}stderr"
 	if [ -n "$debugger" ]; then
 		echo "*** Running tests in '$(pwd)/$work_dir'"


### PR DESCRIPTION
I needed this change, or something similar, for a pending PR with multiple testcases in one script — and it seems sensible.

I'm not 100% certain that `$prefix` doesn't also touch `expected/stdin`.