### PR TITLE
remove dependency on GNU sed newline handling in test suite

### DIFF
--- a/test/stage/split-chunk-test
+++ b/test/stage/split-chunk-test
@@ -17,7 +17,7 @@ steps '
 '
 
 in_work_dir create_dirty_workdir
-in_work_dir sed -i -e 's/[36]/edited-too/' a
+in_work_dir sh -c 'printf "a CHANGED\n1\n2\nedited-too\n4\n5\nedited-too\n7\n8" > a'
 
 test_tig status
 


### PR DESCRIPTION
The issue is that POSIX sed always fills in a trailing newline, whereas GNU sed maintains the input more faithfully.

This is a small file and it seems just as easy to write it with a literal `printf`.

After #609 this will be sufficient for the test suite to run on OS X and likely any BSD derivative.