### PR TITLE
doubledash and similar test suite linting

### DIFF
--- a/test/diff/diff-context-test
+++ b/test/diff/diff-context-test
@@ -206,8 +206,8 @@ index 65f914a..3aa4320 100644
 EOF
 
 for i in expected/*.screen; do
-	diff_file="$(basename "$i" | sed 's/[.]screen/-from-main.screen/')"
+	diff_file="$(basename -- "$i" | sed 's/[.]screen/-from-main.screen/')"
 	assert_equals "$diff_file" <<EOF
-$(cat "$i")
+$(cat < "$i")
 EOF
 done

--- a/test/diff/diff-highlight-color-test
+++ b/test/diff/diff-highlight-color-test
@@ -5,7 +5,7 @@
 
 test_require diff-highlight
 
-export PATH="$(dirname "$diff_highlight_path"):$PATH"
+export PATH="$(dirname -- "$diff_highlight_path"):$PATH"
 
 gitconfig <<EOF
 [color.diff-highlight]

--- a/test/graph/gh-490-heap-buffer-overflow-test
+++ b/test/graph/gh-490-heap-buffer-overflow-test
@@ -12,7 +12,7 @@ steps '
 
 export TIG_NO_DISPLAY=y
 
-gunzip --stdout "$source_dir/$test.gz" | tig --graph --pretty=raw 2>stderr >stdout
+gunzip --stdout -- "$source_dir/$test.gz" | tig --graph --pretty=raw 2>stderr >stdout
 
 assert_equals stderr <<EOF
 EOF

--- a/test/main/commit-title-overflow-test
+++ b/test/main/commit-title-overflow-test
@@ -26,8 +26,8 @@ test_setup_work_dir()
 	for i in $(seq 1 7); do
 		git_commit -m "${prefix0}æøå		: #1 - ASCII prefix"
 		git_commit -m "${prefix0}作者		: #2 - ASCII prefix"
-		offset=$(expr $offset + 1)
-		if [ $offset -eq 5 ]; then
+		offset="$(expr "$offset" + 1)"
+		if [ "$offset" -eq 5 ]; then
 			prefix0="${prefix0}|"
 			offset=0
 		else

--- a/test/main/filter-args-test
+++ b/test/main/filter-args-test
@@ -15,7 +15,7 @@ test_setup_work_dir()
 {
 	create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
 	git checkout -b feature/x HEAD^
-	echo '// Feature X' >> common/build.sbt
+	printf '// Feature X\n' >> common/build.sbt
 	export GIT_AUTHOR_DATE="1486403695"
 	export GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
 	git commit -a -m "Feature X"

--- a/test/main/no-matching-commmits-test
+++ b/test/main/no-matching-commmits-test
@@ -12,7 +12,7 @@ steps '
 
 in_work_dir create_dirty_workdir
 
-export GIT_AUTHOR_DATE="$(expr $author_date + $author_date_delta)"
+export GIT_AUTHOR_DATE="$(expr "$author_date" + "$author_date_delta")"
 export GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
 
 

--- a/test/main/refresh-periodic-test
+++ b/test/main/refresh-periodic-test
@@ -33,7 +33,7 @@ EOF
 
 in_work_dir create_dirty_workdir
 
-export GIT_AUTHOR_DATE="$(expr $author_date + $author_date_delta)"
+export GIT_AUTHOR_DATE="$(expr "$author_date" + "$author_date_delta")"
 export GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
 
 test_tig

--- a/test/main/refresh-test
+++ b/test/main/refresh-test
@@ -34,7 +34,7 @@ EOF
 
 in_work_dir create_dirty_workdir
 
-export GIT_AUTHOR_DATE="$(expr $author_date + $author_date_delta)"
+export GIT_AUTHOR_DATE="$(expr "$author_date" + "$author_date_delta")"
 export GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
 
 test_tig

--- a/test/main/show-changes-after-rename-test
+++ b/test/main/show-changes-after-rename-test
@@ -15,10 +15,10 @@ steps '
 git_init
 
 test_setup_work_dir() {
-	echo data >file1
+	printf 'data\n' >file1
 	git add file1
 	git_commit -m "commit1"
-	echo data >file2
+	printf 'data\n' >file2
 	git add file2
 	git rm file1
 }

--- a/test/refs/replace-test
+++ b/test/refs/replace-test
@@ -21,14 +21,14 @@ git_clone 'repo-one'
 
 test_setup_work_dir()
 {
-	replaced_id=$(git rev-parse HEAD~10)
-	replacement_id=$(git rev-parse HEAD~20)
+	replaced_id="$(git rev-parse HEAD~10)"
+	replacement_id="$(git rev-parse HEAD~20)"
 
-	replaced_no_branch_1_id=$(git rev-parse HEAD~22)
-	replacement_no_branch_1_id=$(git rev-parse HEAD~23)
+	replaced_no_branch_1_id="$(git rev-parse HEAD~22)"
+	replacement_no_branch_1_id="$(git rev-parse HEAD~23)"
 
-	replaced_no_branch_2_id=$(git rev-parse HEAD~25)
-	replacement_no_branch_2_id=$(git rev-parse HEAD~30)
+	replaced_no_branch_2_id="$(git rev-parse HEAD~25)"
+	replacement_no_branch_2_id="$(git rev-parse HEAD~30)"
 
 	git branch not-replace "$replaced_id"
 	git replace "$replaced_id" "$replacement_id"

--- a/test/refs/start-on-line-test
+++ b/test/refs/start-on-line-test
@@ -7,7 +7,7 @@ test_setup_work_dir()
 {
 	create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
 	for i in $(seq 1 40); do
-		git branch "ref-$i" master~$i
+		git branch "ref-$i" "master~$i"
 	done
 }
 

--- a/test/regressions/github-390-test
+++ b/test/regressions/github-390-test
@@ -20,7 +20,7 @@ test_setup_work_dir() {
 	pwd="$(pwd)"
 	git_init "$REMOTE_REPO"
 	cd "$REMOTE_REPO" && {
-		echo 3.14 > file
+		printf '3.14\n' > file
 		git add file
 		git_commit -m "committed"
 		cd "$pwd"

--- a/test/script/default-test
+++ b/test/script/default-test
@@ -23,7 +23,7 @@ test_tig_script 'segfault-regression-for-bc4f8e83c590058641c9e1654db300798e9cd10
 '
 
 view_open_file="view-is-open"
-touch "$view_open_file"
+touch -- "$view_open_file"
 
 tigrc <<EOF
 bind generic <F1> @sh -c 'echo "view not closed" > "$HOME/$view_open_file"'
@@ -39,7 +39,7 @@ view not closed
 EOF
 
 view_closed_file="view-is-closed"
-touch "$view_closed_file"
+touch -- "$view_closed_file"
 
 tigrc <<EOF
 bind generic <F1> @sh -c 'echo "view not closed" > "$HOME/$view_closed_file"'
@@ -53,4 +53,4 @@ test_tig_script 'view-close-should-close-tig' '
 assert_equals "$view_closed_file" <<EOF
 EOF
 
-find . -name "*.stderr" | xargs cat > stderr
+find . -name "*.stderr" -exec cat -- "{}" \; > stderr

--- a/test/stage/gh-410-test
+++ b/test/stage/gh-410-test
@@ -22,10 +22,10 @@ git_init
 
 test_setup_work_dir()
 {
-	echo "Hello" > hello.txt
+	printf 'Hello\n' > hello.txt
 	git add .
 	git_commit -m "first commit"
-	echo "Hello2" >> hello.txt
+	printf 'Hello2\n' >> hello.txt
 }
 
 test_tig status

--- a/test/stash/start-on-line-test
+++ b/test/stash/start-on-line-test
@@ -9,7 +9,7 @@ test_setup_work_dir()
 	file .git/logs/refs/stash <<EOF
 EOF
 	for i in $(seq 1 10); do
-		echo "$i" > "stashed-file-$i"
+		printf '%s\n' "$i" > "stashed-file-$i"
 		git stash save -q -u "Stash #$i"
 	done
 }

--- a/test/status/file-name-test
+++ b/test/status/file-name-test
@@ -30,7 +30,7 @@ steps '
 
 git_init
 
-touch "$work_dir/0"
+touch -- "$work_dir/0"
 
 file "$work_dir/a" <<EOF
 ø
@@ -47,8 +47,8 @@ file "$work_dir/as测试asd" <<EOF
 漢
 EOF
 
-touch "$work_dir/øå"
-touch "$work_dir/可愛いコー特集"
+touch -- "$work_dir/øå"
+touch -- "$work_dir/可愛いコー特集"
 
 test_tig status
 

--- a/test/status/on-branch-test
+++ b/test/status/on-branch-test
@@ -9,7 +9,7 @@ test_setup_work_dir()
 {
 	create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
 	git checkout -b topic-branch HEAD~4
-	echo "Topic branch" >> README.md
+	printf 'Topic branch\n' >> README.md
 	git add README.md
 	git_commit -m "Topic branch"
 	git checkout master
@@ -162,22 +162,22 @@ run_test_cases
 
 add_exec_prefix()
 {
-	code="$(cat "$1")"
+	code="$(cat < "$1")"
 	if [ -n "$code" ]; then
-		echo "$code" | sed -e 's/^[ 	]*//' -e '/^$/d' -e 's/^/:exec @/'
+		printf '%s\n' "$code" | sed -e 's/^[ 	]*//' -e '/^$/d' -e 's/^/:exec @/'
 	fi
 }
 
 tig_script "all" "
-	$(for name in $(cat test-cases); do
+	$(cat < test-cases | while read -r name; do
 		add_exec_prefix "$name-before"
-		echo :save-display all-$name.screen
+		printf ':save-display all-%s.screen\n' "$name"
 		add_exec_prefix "$name-after"
 	done)
 "
 
 test_tig status
 
-for name in $(cat test-cases); do
+cat < test-cases | while read -r name; do
 	assert_equals "all-$name.screen" < "$name.expected"
 done

--- a/test/status/on-branch-tracking-info-test
+++ b/test/status/on-branch-tracking-info-test
@@ -10,13 +10,13 @@ test_setup_work_dir()
 	create_repo_from_tgz "$base_dir/files/refs-repo.tgz"
 
 	git checkout -b ahead
-	echo test > test.txt
+	printf 'test\n' > test.txt
 	git add test.txt
 	git_commit -m "Ahead branch"
 	git checkout master
 
 	git checkout -b diverged HEAD~2
-	echo test > test.txt
+	printf 'test\n' > test.txt
 	git add test.txt
 	git_commit -m "Diverged branch"
 	git checkout master
@@ -84,22 +84,22 @@ run_test_cases
 
 add_exec_prefix()
 {
-	code="$(cat "$1")"
+	code="$(cat < "$1")"
 	if [ -n "$code" ]; then
-		echo "$code" | sed -e 's/^[ 	]*//' -e '/^$/d' -e 's/^/:exec @/'
+		printf '%s\n' "$code" | sed -e 's/^[ 	]*//' -e '/^$/d' -e 's/^/:exec @/'
 	fi
 }
 
 tig_script "all" "
-	$(for name in $(cat test-cases); do
+	$(cat < test-cases | while read -r name; do
 		add_exec_prefix "$name-before"
-		echo :save-display all-$name.screen
+		printf ':save-display all-%s.screen\n' "$name"
 		add_exec_prefix "$name-after"
 	done)
 "
 
 test_tig status
 
-for name in $(cat test-cases); do
+cat < test-cases | while read -r name; do
 	assert_equals "all-$name.screen" < "$name.expected"
 done

--- a/test/status/refresh-test
+++ b/test/status/refresh-test
@@ -49,7 +49,7 @@ EOF
 
 in_work_dir create_dirty_workdir
 
-export GIT_AUTHOR_DATE="$(expr $author_date + $author_date_delta)"
+export GIT_AUTHOR_DATE="$(expr "$author_date" + "$author_date_delta")"
 export GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
 
 test_tig

--- a/test/tigrc/contrib-tigrc-test
+++ b/test/tigrc/contrib-tigrc-test
@@ -6,9 +6,7 @@ CONTRIB_PATH="$base_dir/../contrib/"
 
 source_tigrc_files()
 {
-	find "$CONTRIB_PATH" -name "*.tigrc" | while read file; do
-		echo "source $file";
-	done
+	find "$CONTRIB_PATH" -name "*.tigrc" -exec printf "source %s\n" "{}" \;
 }
 
 tigrc <<EOF

--- a/test/tigrc/tigrc-manpage-examples-test
+++ b/test/tigrc/tigrc-manpage-examples-test
@@ -4,11 +4,11 @@
 
 steps ":quit"
 
-mkdir snippets
+mkdir -p snippets
 
 out_file=
 
-while read line; do
+while read -r line; do
 	case "$line" in
 		"// TEST: tigrc")
 			out_file="$(mktemp snippets/tigrc.XXXXXX)"
@@ -20,27 +20,27 @@ while read line; do
 			if [ -s "$out_file" ]; then
 				out_file=
 			elif [ -e "$out_file" ]; then
-				echo >> "$out_file"
+				printf '\n' >> "$out_file"
 			fi
 			;;
 		*)
 			if [ -e "$out_file" ]; then
-				echo "$line" >> "$out_file"
+				printf '%s\n' "$line" >> "$out_file"
 			fi
 			;;
 	esac
 done < "$base_dir/../doc/tigrc.5.adoc"
 
 # Create files used by the `source` example
-mkdir .tig
+mkdir -p .tig
 touch .tig/colorscheme.tigrc .tig/keybindings.tigrc
 
 tigrc <<EOF
-$(find snippets -name "tigrc.*" | xargs cat)
+$(find snippets -name "tigrc.*" -exec cat -- "{}" \;)
 EOF
 
 gitconfig <<EOF
-$(find snippets -name "gitconfig.*" | xargs cat)
+$(find snippets -name "gitconfig.*" -exec cat -- "{}" \;)
 EOF
 
 test_tig status

--- a/test/tigrc/xdg-config-home-test
+++ b/test/tigrc/xdg-config-home-test
@@ -6,7 +6,7 @@ mkdir -p "$HOME/etc/tig" "$HOME/.config/tig"
 
 check()
 {
-	name="$(echo "$1" | tr / -)"
+	name="$(printf '%s\n' "$1" | tr / -)"
 	path="$HOME/$1"
 	env="${2:-undefined}"
 
@@ -15,11 +15,11 @@ check()
 	  *) export "$env" ;;
 	esac
 
-	mkdir -p "$(dirname "$path")"
+	mkdir -p "$(dirname -- "$path")"
 	tig_script "case-$name" '<Ctrl-t>'
 	echo "bind generic <Ctrl-t> @sh -c 'echo $name >> $HOME/$TEST_NAME.out'" > "$path"
 	test_tig status
-	echo "$name" > "$TEST_NAME.out.expected"
+	printf '%s\n' "$name" > "$TEST_NAME.out.expected"
 	assert_equals "$TEST_NAME.out" < "$TEST_NAME.out.expected"
 	assert_equals "$TEST_NAME.stderr" < /dev/null
 }

--- a/test/tools/libgit.sh
+++ b/test/tools/libgit.sh
@@ -41,7 +41,7 @@ git_init()
 	dir="${1:-$work_dir}"
 
 	if [ ! -d "$dir/.git" ]; then
-		git init -q "$dir"
+		git init -q -- "$dir"
 		(cd "$dir" && git_config)
 	fi
 }
@@ -51,9 +51,9 @@ git_add()
 	[ -d .git ] || die "git_add called outside of git repo"
 	path="$1"; shift
 
-	mkdir -p "$(dirname "$path")"
+	mkdir -p -- "$(dirname -- "$path")"
 	file "$path" "$@"
-	git add "$path"
+	git add -- "$path"
 }
 
 git_commit()
@@ -77,12 +77,12 @@ create_dirty_workdir()
 	git init -q .
 	git_config
 
-	echo "*.o" > .gitignore
-	echo "*~" > .git/info/exclude
+	printf '*.o\n' > .gitignore
+	printf '*~\n' > .git/info/exclude
 
 	for file in a b.c "d~" e/f "g h" i.o .j "h~/k"; do
-		dir="$(dirname "$file")"
-		[ -n "$dir" ] && mkdir -p "$dir"
+		dir="$(dirname -- "$file")"
+		[ -n "$dir" ] && mkdir -p -- "$dir"
 		printf "%s\n%s" "$file" "$(seq 1 10)" > "$file"
 	done
 
@@ -103,7 +103,7 @@ create_worktree()
 	(cd "$worktree_base_dir" && {
 		create_repo_from_tgz "$base_dir/files/repo-one.tgz" &&
 		git branch dev
-		git worktree add "$work_dir_abs" dev
+		git worktree add -- "$work_dir_abs" dev
 	})
 }
 

--- a/test/tools/setup-conflict.sh
+++ b/test/tools/setup-conflict.sh
@@ -5,9 +5,9 @@
 git reset --hard
 
 change() {
-	echo "$@" > conflict-file
+	printf '%s\n' "$*" > conflict-file
 	git add conflict-file
-	git_commit --message="Change: $@"
+	git_commit --message="Change: $*"
 }
 
 change "a"

--- a/test/tools/show-results.sh
+++ b/test/tools/show-results.sh
@@ -21,12 +21,12 @@ if [ -n "${BASH_VERSION:-}" ]; then
 	IFS=$' \n\t'
 fi
 
-tests="$(find test/ -name ".test-result" | wc -l)"
-asserts="$(find test/ -name ".test-result" | xargs grep '\[\(OK\|FAIL\)\]' | wc -l)"
-failures="$(find test/ -name ".test-result" | xargs grep FAIL | wc -l || true)"
-skipped="$(find test/ -name ".test-skipped" | wc -l || true)"
+tests="$(find test/ -name ".test-result" | grep -c . || true)"
+asserts="$(find test/ -name ".test-result" -exec cat -- "{}" \; | grep -c '^ *\[\(OK\|FAIL\)\]' || true)"
+failures="$(find test/ -name ".test-result" -exec cat -- "{}" \; | grep -c '^ *\[FAIL\]' || true)"
+skipped="$(find test/ -name ".test-skipped" | grep -c . || true)"
 
-if [ "$((failures))" = 0 ]; then
+if [ "$failures" = 0 ]; then
 	printf "Passed %d assertions in %d tests" "$asserts" "$tests"
 else
 	printf "Failed %d of %d assertions in %d tests" "$failures" "$asserts" "$tests"
@@ -36,5 +36,5 @@ if [ "$skipped" != 0 ]; then
 	printf " (%d skipped)" "$skipped"
 fi
 
-echo
+printf '\n'
 exit "$failures"

--- a/test/tree/file-name-test
+++ b/test/tree/file-name-test
@@ -27,12 +27,12 @@ steps '
 
 test_setup_work_dir()
 {
-	mkdir -- "-- foo bar"
+	mkdir -p -- "-- foo bar"
 	touch -- "-- foo bar/-- boo far"
 	touch -- "-- foo bar/as测试asd"
 
-	mkdir -- "-foo"
-	echo OK >"-foo/-bar"
+	mkdir -p -- "-foo"
+	printf 'OK\n' > "-foo/-bar"
 	touch -- "-foo/-bar"
 
 	git add .


### PR DESCRIPTION
Not sure you will agree with all of these.  A few cases border on POSIX matters but most are defensive driving WRT whitespace and punctuation.  No functional change.

* doubledash before constructs which may lead with dash
* `cat <` idiom similar to doubledash
* further quoting to avoid word splitting
* prefer `find ... -exec` over `xargs`. `xargs` splits on space and `xargs -0` is non-POSIX
* `while read -r` over `for ... $(cat ...)` to split on linefeed not space
* `mkdir` with `-p` unless `mkdir` is subject of test
* `$*` over `$@` when meaning is concatenation (somewhat pedantic)
* `printf` over `echo` as it is better behaved/defined
* `grep -c` over `wc -l` avoids leading whitespace
* `grep` over `sed`
* constrain grep FAIL/OK patterns to beginning-of-line
* typo in valgrind parameter key
* whitespace
