### PR TITLE
recognize empty readline input and clear report area

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -972,6 +972,11 @@ open_prompt(struct view *view)
 		return REQ_NONE;
 	}
 
+	if (!cmd) {
+		report_clear();
+		return REQ_NONE;
+	}
+
 	return run_prompt_command(view, argv);
 }
 


### PR DESCRIPTION
Reproducible (but not amenable to the test suite) by

```
:<Enter>
```

which leaves the `:` behind