### PR TITLE
bindable control characters Ctrl-C, Ctrl-V, Ctrl-S, Ctrl-@, hardcode readline Ctrl-C

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -545,6 +545,9 @@ the keybindings for the *generic* keymap, and last the default keybindings.
 Thus, the view keybindings override the generic keybindings which override the
 built-in keybindings.
 
+Keybindings at the line-entry prompt are typically governed by the readline
+library, and are configured separately in `~/.inputrc`.  See 'readline(1)'.
+
 --
 
 Keymaps::
@@ -584,8 +587,9 @@ bind main <Esc>o	options
 Note that due to the way ncurses encodes `Ctrl` key mappings, `Ctrl-m` and
 `Ctrl-i` cannot be bound as they conflict with 'Enter' and 'Tab' respectively.
 Furthermore, ncurses does not allow to distinguish between `Ctrl-f` and
-`Ctrl-F`. Finally, `Ctrl-z` is automatically used for process control and will
-suspend Tig and open a subshell (use `fg` to reenter Tig).
+`Ctrl-F`. Ncurses typically translates `Ctrl-<Space>` to `Ctrl-@`, which is
+available for binding. Finally, `Ctrl-z` is automatically used for process
+control and will suspend Tig and open a subshell (use `fg` to reenter Tig).
 
 Actions::
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -443,6 +443,10 @@ readline_init(void)
 	rl_completion_display_matches_hook = readline_display_matches;
 }
 
+static void sigint_absorb_handler(int sig) {
+	signal(SIGINT, SIG_DFL);
+}
+
 char *
 read_prompt(const char *prompt)
 {
@@ -453,7 +457,13 @@ read_prompt(const char *prompt)
 		line = NULL;
 	}
 
+	if (signal(SIGINT, sigint_absorb_handler) == SIG_ERR)
+		die("Failed to setup sigint handler");
+
 	line = readline(prompt);
+
+	if (signal(SIGINT, SIG_DFL) == SIG_ERR)
+		die("Failed to remove sigint handler");
 
 	if (line && !*line) {
 		free(line);

--- a/test/help/all-keybindings-test.expected
+++ b/test/help/all-keybindings-test.expected
@@ -25,7 +25,7 @@ View manipulation
                      R, <F5> refresh             Reload and refresh view                  
                            O maximize            Maximize the current view                
                            q view-close          Close the current view                   
-                           Q quit                Close all views and quit                 
+                 Q, <Ctrl-C> quit                Close all views and quit                 
 Cursor navigation                                                                         
                            k move-up             Move cursor one line up                  
                            j move-down           Move cursor one line down                

--- a/test/help/default-test
+++ b/test/help/default-test
@@ -50,7 +50,7 @@ View manipulation
                      R, <F5> refresh             Reload and refresh view
                            O maximize            Maximize the current view
                            q view-close          Close the current view
-                           Q quit                Close all views and quit
+                 Q, <Ctrl-C> quit                Close all views and quit
 [help] - line 1 of 112                                                       25%
 EOF
 
@@ -82,7 +82,7 @@ View manipulation
                      R, <F5> refresh             Reload and refresh view
                            O maximize            Maximize the current view
                            q view-close          Close the current view
-                           Q quit                Close all views and quit
+                 Q, <Ctrl-C> quit                Close all views and quit
 [help] - line 18 of 112                                                      25%
 EOF
 

--- a/tigrc
+++ b/tigrc
@@ -199,6 +199,7 @@ bind generic	<F5>	refresh
 bind generic	O	maximize		# Maximize the current view
 bind generic	q	view-close		# Close the current view
 bind generic	Q	quit			# Close all views and quit
+bind generic	<C-C>	quit			# Close all views and quit
 
 # View specific
 bind status	u	status-update		# Stage/unstage changes in file


### PR DESCRIPTION
* <kbd>Ctrl-C</kbd>, <kbd>Ctrl-V</kbd>, <kbd>Ctrl-S</kbd> would previously have been bindable in the main UI only if the user did some unusual things with `stty` before executing `tig`
* switching to `raw()` mode requires a special case to preserve prior <kbd>Ctrl-Z</kbd> behavior
* <kbd>C-@</kbd> (NUL) is a valid key as far as ncurses is concerned, and useful as a translation of <kbd>Ctrl-&lt;Space&gt;</kbd>
* bindings at the readline prompt are affected by this PR in that *eg* <kbd>Ctrl-S</kbd> becomes available, but the user still must configure those keys separately in `~/.inputrc`: doc that
* <kbd>Ctrl-C</kbd> at the readline prompt is a special case and cannot be bound  in `~/.inputrc`; however we can absorb the `SIGINT` to get intuitive "abort input" behavior. 
* bind <kbd>Ctrl-C</kbd> to `quit` by default in the main UI, to emulate previous behavior

The <kbd>Ctrl-C</kbd> in readline behavior has a more natural look after #618.
Fixes #583
