### PR TITLE
Persistent readline history 

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -258,6 +258,13 @@ TIGRC_USER::
 TIGRC_SYSTEM::
 	Path of the system wide configuration file.
 
+[[history-files]]
+History Files
+~~~~~~~~~~~~~~~~~~~
+
+If compiled with readline support, Tig writes a persistent command and search
+history to `~/.tig_history` or `$XDG_DATA_HOME/tig/history`.
+
 [[repo-refs]]
 Repository References
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tig.1.adoc
+++ b/doc/tig.1.adoc
@@ -241,6 +241,17 @@ FILES
 	Git configuration files. Read on start-up with the help of
 	git-config(1).
 
+'$XDG_DATA_HOME/tig/history'::
+'~/.local/share/tig/history'::
+'~/.tig_history'::
+	When compiled with readline support, Tig writes a persistent command and
+	search history. The location of the history file is determined in the
+	following way. If `$XDG_DATA_HOME` is set and `$XDG_DATA_HOME/tig/`
+	exists, store history to `$XDG_DATA_HOME/tig/history`. If
+	`$XDG_CONFIG_HOME` is empty or undefined, store history to
+	`~/.local/share/tig/history` if the directory `~/.local/share/tig/`
+	exists, and fall back to `~/.tig_history` if it does not exist.
+
 BUGS
 ----
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -24,6 +24,7 @@
 #ifdef HAVE_READLINE
 #include <readline/readline.h>
 #include <readline/history.h>
+#define HISTORY_SIZE 500
 #endif /* HAVE_READLINE */
 
 static char *
@@ -466,10 +467,44 @@ read_prompt(const char *prompt)
 	return line;
 }
 
+static const char *
+prompt_histfile(void)
+{
+	static char path[SIZEOF_STR] = "";
+	const char *xdg_data_home = getenv("XDG_DATA_HOME");
+	const char *home = getenv("HOME");
+	int fd;
+
+	if (!xdg_data_home || !*xdg_data_home) {
+		if (!string_format(path, "%s/.local/share/tig/history", home))
+			die("Failed to expand $HOME");
+	} else if (!string_format(path, "%s/tig/history", xdg_data_home))
+		die("Failed to expand $XDG_DATA_HOME");
+
+	fd = open(path, O_RDWR | O_CREAT | O_APPEND, 0666);
+	if (fd > 0)
+		close(fd);
+	else if (!string_format(path, "%s/.tig_history", home))
+		die("Failed to expand $HOME");
+
+	return path;
+}
+
+static void
+prompt_teardown(void)
+{
+	write_history(prompt_histfile());
+}
+
 void
 prompt_init(void)
 {
 	readline_init();
+	using_history();
+	stifle_history(HISTORY_SIZE);
+	read_history(prompt_histfile());
+	if (atexit(prompt_teardown))
+		die("Failed to register prompt_teardown");
 }
 #else
 char *


### PR DESCRIPTION
Persist readline history to `~/.tig_history` or `$XDG_DATA_HOME/tig/history`.

Arguably the `$XDG_DATA_HOME` part doesn't belong in `prompt.c` but this does keep `#ifdef HAVE_READLINE` tucked into a single file.

It might be preferable to persist only the "search" part of the history as `less` does.  Certainly that's the part of the feature I intend to use. However, all readline inputs are currently merged in the volatile history, and I wanted to avoid changing existing UI.

Another desirable refinement would be to take `HISTORY_SIZE` from a `~/.tigrc` option, and support disabling persistent history when set to zero.

It doesn't seem practical to provide test coverage as there isn't a reliable way to inspect the binary for its compile-time readline configuration.