### PR TITLE
performance: throttle titlebar screen updates during loading

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -285,7 +285,7 @@ blame_read(struct view *view, struct buffer *buf, bool force_stop)
 	if (!state->commit) {
 		state->commit = read_blame_commit(view, buf->data, state);
 		string_format(view->ref, "%s %2zd%%", view->vid,
-			      view->lines ? state->blamed * 100 / view->lines : 0);
+			      view->lines ? 5 * (size_t) (state->blamed * 20 / view->lines) : 0);
 
 	} else if (parse_blame_info(state->commit, state->author, buf->data)) {
 		bool update_view_columns = true;

--- a/src/view.c
+++ b/src/view.c
@@ -665,7 +665,10 @@ update_view_title(struct view *view)
 		wprintw(window, " - %s %d of %zd",
 					   view->ops->type,
 					   line->lineno,
-					   view->lines - view->custom_lines);
+					   MAX(line->lineno,
+					       view->pipe
+					       ? 100 * (size_t) ((view->lines - view->custom_lines) / 100)
+					       : view->lines - view->custom_lines));
 	}
 
 	if (view->pipe) {


### PR DESCRIPTION
Instead of updating the UI at maximum granularity:

* blame view progress: update titlebar stats every 5 percent
* line-oriented views: update titlebar stats every 100 lines

This little optimization turns out to give a fair gain.  In a very large repo on SSD, the main view completes 0.4 sec faster for me (8% speedup).  Across many small repos I find the gains are always measurable, though almost always less than 0.1 sec.  These values will vary by platform, repo and particularly by terminal emulator.

Even though we are still calling `wprintw()` repeatedly, ncurses is able to notice when the screen contents do not change, and optimize away unneeded writes.