### PR TITLE
Redraw prompt after leaving it with C-C

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -446,6 +446,7 @@ readline_init(void)
 
 static void sigint_absorb_handler(int sig) {
 	signal(SIGINT, SIG_DFL);
+	redraw_display(true);
 }
 
 char *


### PR DESCRIPTION
Previously, '^C' was permanently shown after leaving the prompt with
C-C. This PR adds `redraw_display` to the sigint handler, in order to 
clear the prompt view after leaving.