### PR TITLE
rfc: add `maxwidth` format param for fields `author`, `file-name`, `ref`

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -440,6 +440,8 @@ author::
 	- 'width' (int): Fixed width for the column. When set to a value between
 	  1 and 10, the author name will be abbreviated to the author's initials.
 	  When set to zero, the width is automatically sized to fit the content.
+	- 'maxwidth' (int): Maximum width of the column. Permit automatically
+	  sizing content, up to this limit.
 
 commit-title::
 	- 'graph' (mixed) [no|v2|v1]: Whether to show the revision graph in the
@@ -472,6 +474,8 @@ file-name::
 	  running: tig blame -C <file>.
 	- 'width' (int): Width of the column. When set to zero, the width is
 	  automatically sized to fit the content.
+	- 'maxwidth' (int): Maximum width of the column. Permit automatically
+	  sizing content, up to this limit.
 
 file-size::
 	- 'display' (mixed) [default|units|<bool>]: How to display file sizes.
@@ -503,6 +507,8 @@ ref::
 	- 'display' (bool): Whether to show the reference name.
 	- 'width' (int): Fixed width for the column. When set to zero, the width
 	  is automatically sized to fit the content.
+	- 'maxwidth' (int): Maximum width of the column. Permit automatically
+	  sizing content, up to this limit.
 
 status::
 	- 'display' (mixed) [no|short|long|<bool>]: How to display the status

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -380,7 +380,7 @@ view. Each view setting expects a space-separated list of column specifications.
 Column specifications starts with the column type, and can optionally be
 followed by a colon (`:`) and a list of column options. E.g. the following
 column specification defines an 'author' column displaying the author email and
-with a maximum width of 20 characters: `author:email,width=20`.
+with a fixed width of 20 characters: `author:email,width=20`.
 
 The first option value in a column specification is always the 'display' option.
 When no 'display' value is given, 'yes' is assumed. For 'display' options
@@ -437,8 +437,8 @@ author::
 	- 'display' (mixed) [full|abbreviated|email|email-user|<bool>]: How to
 	  display author names. If set to "abbreviated" author initials will be
 	  shown.
-	- 'width' (int): Width of the column. When set to a value between 1 and
-	  10, the author name will be abbreviated to the author's initials.
+	- 'width' (int): Fixed width for the column. When set to a value between
+	  1 and 10, the author name will be abbreviated to the author's initials.
 	  When set to zero, the width is automatically sized to fit the content.
 
 commit-title::
@@ -463,8 +463,8 @@ date::
 	  timezone. Note that relative dates always use local offsets.
 	- 'format' (string): format string to pass to strftime(3) when 'custom'
 	  display mode has been selected.
-	- 'width' (int): Width of the column. When set to zero, the width is
-	  automatically sized to fit the content.
+	- 'width' (int): Fixed width for the column. When set to zero, the width
+	  is automatically sized to fit the content.
 
 file-name::
 	- 'display' (mixed) [auto|always|<bool>]: When to display file names.
@@ -477,32 +477,32 @@ file-size::
 	- 'display' (mixed) [default|units|<bool>]: How to display file sizes.
 	  When set to "units", sizes are shown using binary prefixes, e.g. 12524
 	  bytes is shown as "12.2K".
-	- 'width' (int): Width of the filename column. When set to zero, the
-	  width is automatically sized to fit the content.
+	- 'width' (int): Fixed width for the filename column. When set to zero,
+	  the width is automatically sized to fit the content.
 
 id::
 	- 'display' (bool): Whether to show commit IDs in the main view.
-	- 'width' (int) : Width of the commit ID. When unset Tig will use the
-	  value of 'core.abbrev' if found. See git-config(1) on how to set
-	  'core.abbrev'. When set to zero the width is automatically sized to
-	  fit the content of reflog (e.g.  `ref/stash@{4}`) IDs and otherwise
+	- 'width' (int) : Fixed width for the commit ID column. When unset Tig
+	  will use the value of 'core.abbrev' if found. See git-config(1) on how
+	  to set 'core.abbrev'. When set to zero the width is automatically sized
+	  to fit the content of reflog (e.g.  `ref/stash@{4}`) IDs and otherwise
 	  default to 7.
 
 line-number::
 	- 'display' (bool): Whether to show line numbers.
 	- 'interval' (int): Interval between line numbers.
-	- 'width' (int): Width of the column. When set to zero, the width is
-	  automatically sized to fit the content.
+	- 'width' (int): Fixed width for the column. When set to zero, the width
+	  is automatically sized to fit the content.
 
 mode::
 	- 'display' (bool): Whether to show file modes.
-	- 'width' (int): Width of the column. When set to zero, the width is
-	  automatically sized to fit the content.
+	- 'width' (int): Fixed width for the column. When set to zero, the width
+	  is automatically sized to fit the content.
 
 ref::
 	- 'display' (bool): Whether to show the reference name.
-	- 'width' (int): Width of the column. When set to zero, the width is
-	  automatically sized to fit the content.
+	- 'width' (int): Fixed width for the column. When set to zero, the width
+	  is automatically sized to fit the content.
 
 status::
 	- 'display' (mixed) [no|short|long|<bool>]: How to display the status

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -92,6 +92,7 @@ OPTION_INFO(DEFINE_OPTION_EXTERNS)
 #define AUTHOR_COLUMN_OPTIONS(_) \
 	_(display,			enum author,		VIEW_NO_FLAGS) \
 	_(width,			int,			VIEW_NO_FLAGS) \
+	_(maxwidth,			int,			VIEW_NO_FLAGS) \
 
 #define COMMIT_TITLE_COLUMN_OPTIONS(_) \
 	_(display,			bool,			VIEW_NO_FLAGS) \
@@ -108,6 +109,7 @@ OPTION_INFO(DEFINE_OPTION_EXTERNS)
 #define FILE_NAME_COLUMN_OPTIONS(_) \
 	_(display,			enum filename,		VIEW_GREP_LIKE) \
 	_(width,			int,			VIEW_NO_FLAGS) \
+	_(maxwidth,			int,			VIEW_NO_FLAGS) \
 
 #define FILE_SIZE_COLUMN_OPTIONS(_) \
 	_(display,			enum file_size,		VIEW_NO_FLAGS) \
@@ -130,6 +132,7 @@ OPTION_INFO(DEFINE_OPTION_EXTERNS)
 #define REF_COLUMN_OPTIONS(_) \
 	_(display,			bool,			VIEW_NO_FLAGS) \
 	_(width,			int,			VIEW_NO_FLAGS) \
+	_(maxwidth,			int,			VIEW_NO_FLAGS) \
 
 #define SECTION_COLUMN_OPTIONS(_) \
 	_(type,				enum line_type,		VIEW_NO_FLAGS) \

--- a/src/draw.c
+++ b/src/draw.c
@@ -242,7 +242,8 @@ static bool
 draw_author(struct view *view, struct view_column *column, const struct ident *author)
 {
 	bool trim = author_trim(column->width);
-	const char *text = mkauthor(author, column->opt.author.width, column->opt.author.display);
+	const char *text = mkauthor(author, MAX(column->opt.author.width, column->opt.author.maxwidth),
+				    column->opt.author.display);
 
 	if (column->opt.author.display == AUTHOR_NO)
 		return false;

--- a/src/view.c
+++ b/src/view.c
@@ -1436,10 +1436,12 @@ view_column_info_update(struct view *view, struct line *line)
 	for (column = view->columns; column; column = column->next) {
 		const char *text = view_column_text(view, &column_data, column);
 		int width = 0;
+		int maxwidth = 0;
 
 		switch (column->type) {
 		case VIEW_COLUMN_AUTHOR:
 			width = column->opt.author.width;
+			maxwidth = width == 0 ? column->opt.author.maxwidth : 0;
 			break;
 
 		case VIEW_COLUMN_COMMIT_TITLE:
@@ -1451,6 +1453,7 @@ view_column_info_update(struct view *view, struct line *line)
 
 		case VIEW_COLUMN_FILE_NAME:
 			width = column->opt.file_name.width;
+			maxwidth = width == 0 ? column->opt.file_name.maxwidth : 0;
 			break;
 
 		case VIEW_COLUMN_FILE_SIZE:
@@ -1483,6 +1486,7 @@ view_column_info_update(struct view *view, struct line *line)
 
 		case VIEW_COLUMN_REF:
 			width = column->opt.ref.width;
+			maxwidth = width == 0 ? column->opt.ref.maxwidth : 0;
 			break;
 
 		case VIEW_COLUMN_SECTION:
@@ -1497,6 +1501,9 @@ view_column_info_update(struct view *view, struct line *line)
 
 		if (*text && !width)
 			width = utf8_width(text);
+
+		if ((maxwidth > 0) && (width > maxwidth))
+			width = maxwidth;
 
 		if (width > column->width) {
 			column->width = width;

--- a/test/tigrc/width-test
+++ b/test/tigrc/width-test
@@ -129,6 +129,52 @@ c819b08eb5b05dde4df5        10| 2013-11-26 23:39     Jonas Fonseca        * Extr
 [main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 48                                                                                                                                     29%
 EOF
 
+test_case main-maxwidths-5 \
+	--script='
+	:set main-view = id:yes,width=5 line-number:yes,interval=5,width=5 date:default,width=5 author:full,maxwidth=5 commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
+ee912     1| 2014- JFons * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
+a1dcf      | 2014- JFons * Add type parameter for js.Dynamic
+296fc      | 2014- JFons * Move classes under org.scalajs.benchmark package scope
+b4ad8      | 2014- JFons * Bump Scala.js version to 0.3-SNAPSHOT
+4a68c     5| 2014- JFons * Integrate app code into the benchmark infrastructure
+e59a9      | 2014- JFons M-. Merge pull request #4 from phaller/patch-1
+940ef      | 2014- PHall | * Fix link to Dart benchmark harness
+110e0      | 2013- JFons *-' Update links to reflect project name change
+894a5      | 2013- JFons * Use Scala.js 0.2-SNAPSHOT
+c819b    10| 2013- JFons * Extract the benchmark list variable name; fix push to use scoped variable
+5bd6d      | 2013- JFons * Solve the easiest sudoku grid
+988c7      | 2013- JFons * Disable phantomjs by default
+5d84a      | 2013- JFons * Exclude Sudoku when running all benchmarks
+5d806      | 2013- JFons * Fix reference setup to work for node
+[main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 48                                                                                                                                     29%
+EOF
+
+test_case main-maxwidths-20 \
+	--script='
+	:set main-view = id:yes,width=20 line-number:yes,interval=5,width=20 date:default,width=20 author:full,maxwidth=20 commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
+ee912870202200a0b9cf         1| 2014-03-01 17:26     Jonas Fonseca  * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
+a1dcf1aaa11470978db1          | 2014-03-01 15:59     Jonas Fonseca  * Add type parameter for js.Dynamic
+296fc90ba2c47ba3d2b6          | 2014-01-16 22:51     Jonas Fonseca  * Move classes under org.scalajs.benchmark package scope
+b4ad81f17b4c3fc33ed5          | 2014-01-16 17:43     Jonas Fonseca  * Bump Scala.js version to 0.3-SNAPSHOT
+4a68cf3c338f5724d838         5| 2014-01-16 17:39     Jonas Fonseca  * Integrate app code into the benchmark infrastructure
+e59a941c4e7d51cd172e          | 2014-01-16 07:47     Jonas Fonseca  M-. Merge pull request #4 from phaller/patch-1
+940efafc379db7c6df99          | 2014-01-16 15:32     Philipp Haller | * Fix link to Dart benchmark harness
+110e090f815f40d649f5          | 2013-12-17 00:02     Jonas Fonseca  *-' Update links to reflect project name change
+894a53e03a017642abdc          | 2013-12-03 23:35     Jonas Fonseca  * Use Scala.js 0.2-SNAPSHOT
+c819b08eb5b05dde4df5        10| 2013-11-26 23:39     Jonas Fonseca  * Extract the benchmark list variable name; fix push to use scoped variable
+5bd6df6603f25ff035f1          | 2013-11-26 23:31     Jonas Fonseca  * Solve the easiest sudoku grid
+988c77aad5798f1e087e          | 2013-11-26 23:22     Jonas Fonseca  * Disable phantomjs by default
+5d84af022bc87ef13c29          | 2013-11-26 22:55     Jonas Fonseca  * Exclude Sudoku when running all benchmarks
+5d80606b72b490e213a0          | 2013-11-26 22:52     Jonas Fonseca  * Fix reference setup to work for node
+[main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 48                                                                                                                                     29%
+EOF
+
 ### tree-view
 
 test_case tree-widths-default \
@@ -373,6 +419,54 @@ ee912870202200a0b9cf master               Jonas Fonseca        WIP: Upgrade to 0
 [refs] All references                                                                                                                                                                               100%
 EOF
 
+test_case refs-maxwidths-5 \
+	--script='
+	:set refs-view = id:yes,width=5 ref:yes,maxwidth=5 author:yes,maxwidth=5 commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
+      All r
+ee912 maste JFons WIP: Upgrade to 0.4-SNAPSHOT and DCE
+
+
+
+
+
+
+
+
+
+
+
+
+[refs] All references                                                                                                                                                                               100%
+EOF
+
+test_case refs-maxwidths-20 \
+	--script='
+	:set refs-view = id:yes,width=20 ref:yes,maxwidth=20 author:yes,maxwidth=20 commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
+                     All references
+ee912870202200a0b9cf master Jonas Fonseca WIP: Upgrade to 0.4-SNAPSHOT and DCE
+
+
+
+
+
+
+
+
+
+
+
+
+[refs] All references                                                                                                                                                                               100%
+EOF
+
 ### grep-view
 
 test_case grep-widths-default \
@@ -478,6 +572,56 @@ EOF
 test_case grep-widths-20 \
 	--script='
 	:set grep-view = file-name:yes,width=20 line-number:yes,interval=1,width=20 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
+LICENSE                      5| Redistribution and use in source and binary forms, with or without modification,
+LICENSE                      8|     * Redistributions of source code must retain the above copyright notice,
+README.md                   27| time you save a source file, a compilation of the project is triggered.
+common/reference/de~       633|  * Extract a plan for resatisfaction starting from the given source
+common/reference/de~       649|  * Assume: sources are all satisfied.
+common/reference/de~       651| Planner.prototype.makePlan = function (sources) {
+common/reference/de~       654|   var todo = sources;
+common/reference/de~       671|   var sources = new OrderedCollection();
+common/reference/de~       676|       sources.add(c);
+common/reference/de~       678|   return this.makePlan(sources);
+common/reference/ri~         2| // Redistribution and use in source and binary forms, with or without
+common/reference/ri~         6| //     * Redistributions of source code must retain the above copyright
+common/reference/tr~        45| Object.extend = function(destination, source) {
+common/reference/tr~        46|   for (var property in source) {
+[grep] LICENSE - line 1 of 24                                                                                                                                                                        58%
+EOF
+
+test_case grep-maxwidths-5 \
+	--script='
+	:set grep-view = file-name:yes,maxwidth=5 line-number:yes,interval=1,width=5 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
+LICE~     5| Redistribution and use in source and binary forms, with or without modification,
+LICE~     8|     * Redistributions of source code must retain the above copyright notice,
+READ~    27| time you save a source file, a compilation of the project is triggered.
+comm~   633|  * Extract a plan for resatisfaction starting from the given source
+comm~   649|  * Assume: sources are all satisfied.
+comm~   651| Planner.prototype.makePlan = function (sources) {
+comm~   654|   var todo = sources;
+comm~   671|   var sources = new OrderedCollection();
+comm~   676|       sources.add(c);
+comm~   678|   return this.makePlan(sources);
+comm~     2| // Redistribution and use in source and binary forms, with or without
+comm~     6| //     * Redistributions of source code must retain the above copyright
+comm~    45| Object.extend = function(destination, source) {
+comm~    46|   for (var property in source) {
+[grep] LICENSE - line 1 of 24                                                                                                                                                                        58%
+EOF
+
+test_case grep-maxwidths-20 \
+	--script='
+	:set grep-view = file-name:yes,maxwidth=20 line-number:yes,interval=1,width=20 text
 	:g
 	source<Enter>
 	:refresh

--- a/tigrc
+++ b/tigrc
@@ -14,6 +14,8 @@
 #   author
 #    - display (enum) [no|full|abbreviated|email|email-user]
 #					: Show author information?
+#    - width (int)			: Fixed width when nonzero
+#
 #   commit-title
 #    - display (bool)			: Show the commit title?
 #    - graph (enum) [no|v2|v1]		: Show the commit graph? (main view only)
@@ -25,25 +27,32 @@
 #					: Show dates?
 #    - local (bool)			: Show local dates?
 #    - format (string)			: Custom strftime(3) format
+#    - width (int)			: Fixed width when nonzero
 #
 #   file-name
 #    - display (enum) [no|always|auto]	: Show file names?
+#    - width (int)			: Fixed width when nonzero
 #
 #   file-size
 #    - display (enum) [no|default|units]	: Show file sizes?
+#    - width (int)			: Fixed width when nonzero
 #
 #   id
 #    - display (bool)			: Show commit/tree ID?
+#    - width (int)			: Fixed width when nonzero
 #
 #   line-number
 #    - display (bool)			: Show line numbers?
 #    - interval (int)			: Interval between line numbers; defaults to 5
+#    - width (int)			: Fixed width when nonzero
 #
 #   mode
 #    - display (bool)			: Show file modes?
+#    - width (int)			: Fixed width when nonzero
 #
 #   ref
 #    - display (bool)			: Show ref names?
+#    - width (int)			: Fixed width when nonzero
 #
 #   status
 #    - display (enum) [no|short|long]	: Show status label?
@@ -52,9 +61,6 @@
 #    - display (bool)			: Show text?
 #    - commit-title-overflow (boolint)	: Highlight overflow in log and diff view?
 #
-# All columns also support a width option to configure the max width of
-# the column. Use zero (the default value) to auto-size the column based
-# on the content.
 
 set blame-view	= date:default author:full file-name:auto id:yes,color line-number:no,interval=5 text
 set grep-view	= file-name:no line-number:yes,interval=1 text

--- a/tigrc
+++ b/tigrc
@@ -15,6 +15,7 @@
 #    - display (enum) [no|full|abbreviated|email|email-user]
 #					: Show author information?
 #    - width (int)			: Fixed width when nonzero
+#    - maxwidth (int)			: Autosize limit
 #
 #   commit-title
 #    - display (bool)			: Show the commit title?
@@ -32,6 +33,7 @@
 #   file-name
 #    - display (enum) [no|always|auto]	: Show file names?
 #    - width (int)			: Fixed width when nonzero
+#    - maxwidth (int)			: Autosize limit
 #
 #   file-size
 #    - display (enum) [no|default|units]	: Show file sizes?
@@ -53,6 +55,7 @@
 #   ref
 #    - display (bool)			: Show ref names?
 #    - width (int)			: Fixed width when nonzero
+#    - maxwidth (int)			: Autosize limit
 #
 #   status
 #    - display (enum) [no|short|long]	: Show status label?

--- a/tigrc
+++ b/tigrc
@@ -42,6 +42,9 @@
 #   mode
 #    - display (bool)			: Show file modes?
 #
+#   ref
+#    - display (bool)			: Show ref names?
+#
 #   status
 #    - display (enum) [no|short|long]	: Show status label?
 #


### PR DESCRIPTION
Rationale: certain columns are derived from data sources which are free and difficult to tame.  I regularly use a repo containing a commit with a mangled `author` field of length 575 characters.  Once merged into a shared repo, this is not practical to alter.  There are similar length issues with formalized branch names in large organizations.

The `width` parameter is rigid, and was somewhat misleadingly documented. `author,width=30` wastes screen when opening any other repo, whereas `author,maxwidth=30` is reasonable in all cases.

But I'm not sure about the interface proposed in this PR.  Perhaps you would rather
 * change `width` to behave as maximum width, following the existing documentation, or
 * have `maxwidth` available on all fields where `width` is possible, or
 * have `maxwidth` functionality implemented under the existing `width` param with something like `width=<10` or `width=-10`
