### PR TITLE
make diff-highlight use ordinary configurable colors

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -259,7 +259,9 @@ The following variables can be set:
 
 	Whether to highlight diffs using Git's 'diff-highlight' program. Defaults
 	to false. When set to true then 'diff-highlight' is used, else the option
-	value is used as the path.
+	value is used as the path. When this option is in effect, highlighted
+	regions are governed by `color diff-add-highlight` and
+	`color diff-del-highlight`.
 
 'ignore-space' (mixed) [no|all|some|at-eol|<bool>]::
 
@@ -998,7 +1000,7 @@ Diff markup::
 Options concerning diff start, chunks and lines added and deleted.
 
 *diff-header*, *diff-chunk*, *diff-add*, *diff-add2*, *diff-del*,
-*diff-del2*
+*diff-del2*, *diff-add-highlight*, *diff-del-highlight*
 
 Enhanced Git diff markup::
 

--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -35,6 +35,8 @@ struct ref;
 	_(DIFF_OLDMODE,		"old file mode "), \
 	_(DIFF_NEWMODE,		"new file mode "), \
 	_(DIFF_SIMILARITY,	"similarity "), \
+	_(DIFF_ADD_HIGHLIGHT,	""), \
+	_(DIFF_DEL_HIGHLIGHT,	""), \
 	_(PP_MERGE,		"Merge: "), \
 	_(PP_REFS,		"Refs: "), \
 	_(PP_REFLOG,		"Reflog: "), \
@@ -95,10 +97,7 @@ struct ref;
 enum line_type {
 #define DEFINE_LINE_ENUM(type, line) LINE_##type
 	LINE_INFO(DEFINE_LINE_ENUM),
-	LINE_NONE,
-
-	LINE_DIFF_ADD_HIGHLIGHT,
-	LINE_DIFF_DEL_HIGHLIGHT
+	LINE_NONE
 };
 
 struct line_info {
@@ -139,12 +138,7 @@ static inline int
 get_line_attr(const char *prefix, enum line_type type)
 {
 	struct line_info *info = get_line_info(prefix, type);
-	int hi_attr = 0;
-
-	if (type == LINE_DIFF_ADD_HIGHLIGHT || type == LINE_DIFF_DEL_HIGHLIGHT)
-		hi_attr = A_STANDOUT;
-
-	return COLOR_PAIR(COLOR_ID(info->color_pair)) | info->attr | hi_attr;
+	return COLOR_PAIR(COLOR_ID(info->color_pair)) | info->attr;
 }
 
 #endif

--- a/src/line.c
+++ b/src/line.c
@@ -69,12 +69,6 @@ get_line_info(const char *prefix, enum line_type type)
 	struct line_info *info;
 	struct line_rule *rule;
 
-	/* XXX: Map special highligh types to avoid special settings. */
-	if (type == LINE_DIFF_ADD_HIGHLIGHT)
-		type = LINE_DIFF_ADD;
-	else if (type == LINE_DIFF_DEL_HIGHLIGHT)
-		type = LINE_DIFF_DEL;
-
 	assert(type < line_rules);
 	rule = &line_rule[type];
 	for (info = &rule->info; info; info = info->next) {

--- a/tigrc
+++ b/tigrc
@@ -377,6 +377,8 @@ color stat-untracked		magenta	default
 color help-group		blue	default
 color help-action		yellow	default
 color diff-stat			blue	default
+color diff-add-highlight	green	default standout
+color diff-del-highlight	red	default standout
 color palette-0			magenta	default
 color palette-1			yellow	default
 color palette-2			cyan	default


### PR DESCRIPTION
`diff-add-highlight` and `diff-del-highlight` become ordinary colors independently governing the fg/bg/attributes of the highlighted cells.

These entries are added to the system tigrc such that the out-of-box configuration is unchanged, though if the user previously customized some diff colors, diff highlight cells will not follow them automatically.

Rationale: independent coloring of four states matches functionality of `diff-highlight` itself. Net reduction of logic.  Dimmer colors for the backgrounded regions are a readability improvement.