### PR TITLE
add echo action

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -487,6 +487,7 @@ Prompt
 |:script <file>		|Execute commands from `<file>`.
 |:exec <flags><args...> |Execute command using `<args>` with external
 			 user-defined command option flags defined in `<flags>`.
+|:echo <args...>        |Display text in the status bar.
 |=============================================================================
 
 [[external-commands]]

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -239,6 +239,7 @@ readline_action_generator(const char *text, int state)
 		"save-display",
 		"save-options",
 		"exec",
+		"echo",
 #define REQ_GROUP(help)
 #define REQ_(req, help)	#req
 		REQ_INFO,
@@ -842,6 +843,17 @@ run_prompt_command(struct view *view, const char *argv[])
 			report("goto requires an argument");
 		else
 			goto_id(view, argv[1], true, true);
+		return REQ_NONE;
+
+	} else if (!strcmp(cmd, "echo")) {
+		char text[SIZEOF_STR] = "";
+
+		if (argv[1] && !argv_to_string(&argv[1], text, sizeof(text), " ")) {
+			report("Failed to copy echo string");
+			return REQ_NONE;
+		}
+
+		report("%s", text);
 		return REQ_NONE;
 
 	} else if (!strcmp(cmd, "save-display")) {


### PR DESCRIPTION
Untestable since `save-display` ignores the status area.

Usecase:

```
bind blame   O  @open '%(file)'
bind blob    O  @open '%(file)'
bind diff    O  @open '%(file)'
bind grep    O  @open '%(file)'
bind stage   O  @open '%(file)'
bind status  O  @open '%(file)'
bind tree    O  @open '%(file)'
bind help    O  :echo 'Nothing to open'
bind log     O  :echo 'Nothing to open'
bind main    O  :echo 'Nothing to open'
bind pager   O  :echo 'Nothing to open'
bind refs    O  :echo 'Nothing to open'
bind stash   O  :echo 'Nothing to open'
```
