### PR TITLE
raise titlebar count to highest known item on stop-loading action

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -304,6 +304,8 @@ view_driver(struct view *view, enum request request)
 			if (view->pipe)
 				report("Stopped loading the %s view", view->name),
 			end_update(view, true);
+			if (view_is_displayed(view))
+				update_view_title(view);
 		}
 		break;
 


### PR DESCRIPTION
After #622, the titlebar counts could be stuck lower than the maximum known value if the user did `stop-loading`.
