### PR TITLE
preload last search from persistent history

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -525,12 +525,18 @@ prompt_teardown(void)
 void
 prompt_init(void)
 {
+	HIST_ENTRY *last_entry;
+
 	readline_init();
 	using_history();
 	stifle_history(HISTORY_SIZE);
 	read_history(prompt_histfile());
 	if (atexit(prompt_teardown))
 		die("Failed to register prompt_teardown");
+
+	last_entry = history_get(history_length);
+	if (last_entry)
+		string_copy(argv_env.search, last_entry->line);
 }
 #else
 char *


### PR DESCRIPTION
Following the interface of `less`, preload the last search from the persistent history at init time, so that the query is immediately available to keystroke <kbd>n</kbd> (`find-next`).

Inherent bug: as discussed in #620, the command and search histories are merged: if the last entry in the history was a command, it will be treated wrongly as a search query.  But this is not different than pressing <kbd>&lt;Up&gt;</kbd> at the search prompt currently.
