### PR TITLE
pick up diff-highlight colors from git-colors

### DIFF
--- a/tigrc
+++ b/tigrc
@@ -412,6 +412,9 @@ set git-colors = \
 	diff.old=diff-del \
 	diff.new=diff-add \
 	\
+	diff-highlight.oldHighlight=diff-del-highlight \
+	diff-highlight.newHighlight=diff-add-highlight \
+	\
 	grep.filename=grep.file \
 	grep.linenumber=grep.line-number \
 	grep.separator=grep.delimiter \


### PR DESCRIPTION
Should have been in #625, didn't realize it was this easy.