### PR TITLE
expand tig variables in echo action

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -851,10 +851,15 @@ run_prompt_command(struct view *view, const char *argv[])
 		return REQ_NONE;
 
 	} else if (!strcmp(cmd, "echo")) {
+		const char **fmt_argv = NULL;
 		char text[SIZEOF_STR] = "";
 
-		if (argv[1] && !argv_to_string(&argv[1], text, sizeof(text), " ")) {
-			report("Failed to copy echo string");
+		if (argv[1]
+		    && strlen(argv[1]) > 0
+		    && (!argv_format(view->env, &fmt_argv, &argv[1], false, true)
+			|| !argv_to_string(fmt_argv, text, sizeof(text), " ")
+			)) {
+			report("Failed to format echo string");
 			return REQ_NONE;
 		}
 


### PR DESCRIPTION
Followup to #626.

I didn't understand the series of transformations in `exec_run_request()`

 * https://github.com/jonas/tig/blob/e709657252f9fb09ff97c9cc6e2a159fc370ab27/src/prompt.c#L972-L989

so I did something simpler.  And doesn't the `exec_run_request()` logic discard empty arguments?