### PR TITLE
Fix graph display issues

### DIFF
--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -364,7 +364,7 @@ graph_insert_parents(struct graph_v2 *graph)
 		if (graph_column_has_commit(new)) {
 			size_t match = graph_find_free_column(next_row);
 
-			if (match == next_row->size && *next_row->columns[next_row->size - 1].id) {
+			if (match == next_row->size && graph_column_has_commit(&next_row->columns[next_row->size - 1])) {
 				graph_insert_column(graph, next_row, next_row->size, new->id);
 				graph_insert_column(graph, row, row->size, "");
 				graph_insert_column(graph, prev_row, prev_row->size, "");

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -759,6 +759,27 @@ graph_symbol_forks(const struct graph_symbol *symbol)
 }
 
 static const bool
+graph_symbol_cross_merge(const struct graph_symbol *symbol)
+{
+	if (symbol->empty)
+		return false;
+
+	if (!symbol->continued_up && !symbol->new_column && !symbol->below_commit)
+		return false;
+
+	if (symbol->shift_left && symbol->continued_up_left)
+		return false;
+
+	if (symbol->next_right)
+		return false;
+
+	if (symbol->merge && symbol->continued_up && symbol->continued_right && symbol->continued_left && symbol->parent_down && !symbol->next_right)
+		return true;
+
+	return false;
+}
+
+static const bool
 graph_symbol_vertical_merge(const struct graph_symbol *symbol)
 {
 	if (symbol->empty)
@@ -976,6 +997,9 @@ graph_symbol_to_utf8(const struct graph_symbol *symbol)
 		return " ●";
 	}
 
+	if (graph_symbol_cross_merge(symbol))
+		return "─┼";
+
 	if (graph_symbol_vertical_merge(symbol))
 		return "─┤";
 
@@ -1028,6 +1052,10 @@ graph_symbol_to_chtype(const struct graph_symbol *symbol)
 		else
 			graphics[1] = 'o'; //ACS_DIAMOND; //'*';
 		return graphics;
+
+	} else if (graph_symbol_cross_merge(symbol)) {
+		graphics[0] = ACS_HLINE;
+		graphics[1] = ACS_PLUS;
 
 	} else if (graph_symbol_vertical_merge(symbol)) {
 		graphics[0] = ACS_HLINE;
@@ -1091,6 +1119,9 @@ graph_symbol_to_ascii(const struct graph_symbol *symbol)
 			return " M";
 		return " *";
 	}
+
+	if (graph_symbol_cross_merge(symbol))
+		return "-+";
 
 	if (graph_symbol_vertical_merge(symbol))
 		return "-|";

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -759,6 +759,30 @@ graph_symbol_forks(const struct graph_symbol *symbol)
 }
 
 static const bool
+graph_symbol_vertical_merge(const struct graph_symbol *symbol)
+{
+	if (symbol->empty)
+		return false;
+
+	if (!symbol->continued_up && !symbol->new_column && !symbol->below_commit)
+		return false;
+
+	if (symbol->shift_left && symbol->continued_up_left)
+		return false;
+
+	if (symbol->next_right)
+		return false;
+
+	if (!symbol->matches_commit)
+		return false;
+
+	if (symbol->merge && symbol->continued_up && symbol->continued_left && symbol->parent_down && !symbol->continued_right)
+		return true;
+
+	return false;
+}
+
+static const bool
 graph_symbol_cross_over(const struct graph_symbol *symbol)
 {
 	if (symbol->empty)
@@ -952,6 +976,9 @@ graph_symbol_to_utf8(const struct graph_symbol *symbol)
 		return " ●";
 	}
 
+	if (graph_symbol_vertical_merge(symbol))
+		return "─┤";
+
 	if (graph_symbol_cross_over(symbol))
 		return "─│";
 
@@ -1001,6 +1028,10 @@ graph_symbol_to_chtype(const struct graph_symbol *symbol)
 		else
 			graphics[1] = 'o'; //ACS_DIAMOND; //'*';
 		return graphics;
+
+	} else if (graph_symbol_vertical_merge(symbol)) {
+		graphics[0] = ACS_HLINE;
+		graphics[1] = ACS_RTEE;
 
 	} else if (graph_symbol_cross_over(symbol)) {
 		graphics[0] = ACS_HLINE;
@@ -1060,6 +1091,9 @@ graph_symbol_to_ascii(const struct graph_symbol *symbol)
 			return " M";
 		return " *";
 	}
+
+	if (graph_symbol_vertical_merge(symbol))
+		return "-|";
 
 	if (graph_symbol_cross_over(symbol))
 		return "-|";

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -847,6 +847,9 @@ graph_symbol_merge(const struct graph_symbol *symbol)
 	if (symbol->parent_right)
 		return false;
 
+	if (symbol->continued_right)
+		return false;
+
 	return true;
 }
 
@@ -856,7 +859,7 @@ graph_symbol_multi_merge(const struct graph_symbol *symbol)
 	if (!symbol->parent_down)
 		return false;
 
-	if (!symbol->parent_right)
+	if (!symbol->parent_right && !symbol->continued_right)
 		return false;
 
 	return true;
@@ -892,6 +895,9 @@ graph_symbol_vertical_bar(const struct graph_symbol *symbol)
 static const bool
 graph_symbol_horizontal_bar(const struct graph_symbol *symbol)
 {
+	if (!symbol->next_right)
+		return false;
+
 	if (symbol->shift_left)
 		return true;
 

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -811,6 +811,9 @@ graph_symbol_turn_down_cross_over(const struct graph_symbol *symbol)
 	if (!symbol->continued_right)
 		return false;
 
+	if (!symbol->parent_right && !symbol->flanked)
+		return false;
+
 	if (symbol->flanked)
 		return true;
 

--- a/test/graph/00-simple-test
+++ b/test/graph/00-simple-test
@@ -17,16 +17,6 @@ commit b a
     branch1
 commit a
     init
-*   [33m5ce4f7f[m[33m ([1;36mHEAD[m[33m, [1;32mmaster[m[33m)[m Merge branch 'branch3'
-[31m|[m[32m\[m
-[31m|[m * [33mb47bfd8[m[33m ([1;32mbranch3[m[33m)[m branch3
-* [32m|[m   [33mecc01c0[m Merge branch 'branch2'
-[33m|[m[34m\[m [32m\[m
-[33m|[m * [32m|[m [33m814336c[m[33m ([1;32mbranch2[m[33m)[m branch2
-[33m|[m [32m|[m[32m/[m
-* [32m|[m [33me51b810[m[33m ([1;32mbranch1[m[33m)[m branch1
-[32m|[m[32m/[m
-* [33mde1bd54[m init
 EOF
 
 assert_equals stdout <<EOF

--- a/test/graph/06-extra-bars-test
+++ b/test/graph/06-extra-bars-test
@@ -136,7 +136,7 @@ assert_equals stdout <<EOF
 │ │ │ ● Commit M - after N
 │ │ │ ● Commit N - after O
 │ │ │ ● Commit O - after P
-●─┴─╯ │ Commit B - merge Q and R
+●─┼─╯ │ Commit B - merge Q and R
 │ ● ╭─╯ Commit R - after Q
 ●─┤ │ Commit Q - merge S and T
 │ ● │ Commit T - after S
@@ -174,7 +174,7 @@ assert_equals stdout <<EOF
 │ │ │ │ ●─╯ Commit i - after h
 │ ● │ │ │ Commit d - after h
 │ │ │ ● │ Commit r - after s
-●─┴─│─│─╯ Commit h - merge t and u
+●─┼─│─│─╯ Commit h - merge t and u
 │ │ │ ● Commit s - after v
 │ ● │ │ Commit u - after t
 │ │ │ │ ● Commit w - after x

--- a/test/graph/06-extra-bars-test
+++ b/test/graph/06-extra-bars-test
@@ -138,29 +138,29 @@ assert_equals stdout <<EOF
 │ │ │ ● Commit O - after P
 ●─┴─╯ │ Commit B - merge Q and R
 │ ● ╭─╯ Commit R - after Q
-●─╯ │ Commit Q - merge S and T
+●─┤ │ Commit Q - merge S and T
 │ ● │ Commit T - after S
 │ │ ● Commit P - after U
 │ │ ● Commit U - after V
 │ │ ● Commit V - after W
-●─╯ │ Commit S - merge X and Y
+●─┤ │ Commit S - merge X and Y
 │ │ │ ● Commit Z - after 1
 │ ● │ │ Commit Y - after X
-●─╯ │ │ Commit X - merge 2 and 3
+●─┤ │ │ Commit X - merge 2 and 3
 │ ● │ │ Commit 3 - after 2
 │ │ │ │ ● Commit 4 - after 5
 │ │ │ │ ● Commit 5 - after 6
 │ │ ● │ │ Commit W - after 7
 │ │ │ │ ● Commit 6 - after 8
 │ │ ● │ │ Commit 7 - after 9
-●─╯ │ │ │ Commit 2 - merge 0 and a
+●─┤ │ │ │ Commit 2 - merge 0 and a
 │ ● │ │ │ Commit a - after b
 │ ● │ │ │ Commit b - after c
 │ ●─│─│─│─╮ Commit c - merge d and 0
 │ │ │ │ ● │ Commit 8 - after e
 │ │ │ │ ● │ Commit e - after f
 │ │ │ │ ● │ Commit f - after g
-●─│─│─│─│─╯ Commit 0 - merge h and i
+●─│─│─│─│─┤ Commit 0 - merge h and i
 │ │ │ │ ● │ Commit g - after j
 │ │ │ │ ● │ Commit j - after k
 │ │ │ │ ● │ Commit k - after l

--- a/test/graph/10-shorter-merge-than-branch-test
+++ b/test/graph/10-shorter-merge-than-branch-test
@@ -37,7 +37,7 @@ assert_equals stdout <<EOF
 │ │ │ ● │ │ Commit D - after K
 │ │ │ │ │ ● Commit E - after F
 │ ●─│─╯ │ │ Commit K - after F
-│ ●─│─╭─╯─╯ Commit F - merge G and H
+│ ●─│─╭─╯─┤ Commit F - merge G and H
 │ ● │ │ ╭─╯ Commit G - after I
 ●─│─┴─│─╯ Commit H - after I
 ◎─┴───╯ Commit I

--- a/test/graph/11-new-branch-in-middle-test
+++ b/test/graph/11-new-branch-in-middle-test
@@ -16,7 +16,7 @@ commit E Z
 commit F G I
     Commit F - merge G and I
 commit G H I
-    Commit F - merge H and I
+    Commit G - merge H and I
 commit H I
     Commit H - after I
 commit I Z
@@ -31,7 +31,7 @@ assert_equals stdout <<EOF
 │ ● │ Commit C - after F
 │ │ ● Commit E - after Z
 ●─╯ │ Commit F - merge G and I
-●─│─│─╮ Commit F - merge H and I
+●─│─│─╮ Commit G - merge H and I
 ● │ │ │ Commit H - after I
 ●─┴─│─╯ Commit I - after Z
 ◎───╯ Commit Z

--- a/test/graph/11-new-branch-in-middle-test
+++ b/test/graph/11-new-branch-in-middle-test
@@ -30,7 +30,7 @@ assert_equals stdout <<EOF
 ● │ │ Commit B - after F
 │ ● │ Commit C - after F
 │ │ ● Commit E - after Z
-●─╯ │ Commit F - merge G and I
+●─┤ │ Commit F - merge G and I
 ●─│─│─╮ Commit G - merge H and I
 ● │ │ │ Commit H - after I
 ●─┴─│─╯ Commit I - after Z

--- a/test/graph/15-many-merges-test
+++ b/test/graph/15-many-merges-test
@@ -53,18 +53,18 @@ assert_equals stdout <<EOF
 ●─│─╮ Commit N - Merge M into L
 │ ●─╯ Commit M after K
 ●─│─╮ Commit L - Merge K into J
-│ ●─╯ Commit K - Merge J into E
+│ ●─┤ Commit K - Merge J into E
 ●─│─╯ Commit J - Merge F into I
 ●─│─│─╮ Commit I - Merge H into C
 │ │ │ ● Commit H after G
 │ │ ● │ Commit F after C
 │ ● │ │ Commit E after D
-●─│─╯ │ Commit C - Merge B into A
+●─│─┤ │ Commit C - Merge B into A
 │ ● │ │ Commit D after Q
 │ │ ● │ Commit B after R
 │ │ ● │ Commit R after A
 │ ● │ │ Commit Q after X
-●─│─╯ │ Commit A - Merge T into S
+●─│─┤ │ Commit A - Merge T into S
 │ │ ● │ Commit T after U
 │ │ ● │ Commit U after V
 │ │ ● │ Commit V after W

--- a/test/graph/15-many-merges-test
+++ b/test/graph/15-many-merges-test
@@ -45,31 +45,6 @@ commit U V
     Commit U after V
 commit V W
     Commit V after W
-*   [33mb132970[m[33m ([1;36mHEAD[m[33m)[m Merge pull request #22 in COM/compliance_checks from feature/6963/fireeye to master
-[31m|[m[32m\[m
-[31m|[m * [33ma300155[m[33m ([1;31morigin/feature/6963/fireeye[m[33m, [1;32mfeature/6963/fireeye[m[33m)[m When no lines found for info report, say so
-* [32m|[m   [33macdad90[m Merge pull request #21 in COM/compliance_checks from feature/6963/fireeye to master
-[33m|[m[32m\[m [32m\[m
-[33m|[m [32m|[m[32m/[m
-[33m|[m * [33m27ea95d[m Reduce output lines on failure and improve status messages
-* [34m|[m   [33m1c4f527[m Merge pull request #10 in COM/compliance_checks from feature/6963/fireeye to master
-[35m|[m[34m\[m [34m\[m
-[35m|[m [34m|[m[34m/[m
-[35m|[m *   [33mbcad23b[m Merge branch 'master' into feature/6963/fireeye
-[35m|[m [1;31m|[m[35m\[m
-[35m|[m [1;31m|[m[35m/[m
-[35m|[m[35m/[m[1;31m|[m
-* [1;31m|[m   [33m4d124b1[m Merge pull request #19 in COM/compliance_checks from pa_typo to master
-[1;33m|[m[1;34m\[m [1;31m\[m
-[1;33m|[m * [1;31m|[m [33m6648aeb[m fix typo
-* [1;34m|[m [1;31m|[m   [33m8bba33d[m Merge pull request #20 in COM/compliance_checks from 2012typo to master
-[1;34m|[m[1;36m\[m [1;34m\[m [1;31m\[m
-[1;34m|[m [1;36m|[m[1;34m/[m [1;31m/[m
-[1;34m|[m[1;34m/[m[1;36m|[m [1;31m|[m
-[1;34m|[m * [1;31m|[m [33m0b7d81c[m fixed typo
-* [1;36m|[m [1;31m|[m   [33m04d6735[m Merge pull request #18 in COM/compliance_checks from procurve_naid to master
-[31m|[m[32m\[m [1;36m\[m [1;31m\[m
-[31m|[m * [1;36m|[m [1;31m|[m [33md6c83d9[m Cleaned up the reference field indentation.
 EOF
 
 assert_equals stdout <<EOF

--- a/test/graph/17-more-merges-test
+++ b/test/graph/17-more-merges-test
@@ -84,7 +84,7 @@ assert_equals stdout <<EOF
 │ │ ● │ Commit D - after B
 │ ● │ │ Commit C - after F
 │ │ │ ● Commit E - after H
-●─│─╯ │ Commit B - merge H and F
+●─│─┤ │ Commit B - merge H and F
 │ ●─╯ │ Commit F - after G
 │ ● ╭─╯ Commit G - after H
 ●─┴─╯ Commit H - after I
@@ -109,7 +109,7 @@ assert_equals stdout <<EOF
 ●─│───╯ Commit U - after 3
 ●─│─┬─╮ Commit 3 - merge 4, 5, and 8
 ●─│─│─│─╮ Commit 4 - merge 6 and 5
-│ │ ●─│─╯ Commit 5 - merge 7 and 9
+│ │ ●─│─┤ Commit 5 - merge 7 and 9
 ●─│─│─│─│─╮ Commit 6 - merge A and 9
 ◎ │ │ │ │ │ Commit A
 ◎─╯ │ │ │ │ Commit L

--- a/test/graph/18-tig-test
+++ b/test/graph/18-tig-test
@@ -21,18 +21,6 @@ commit c b
     Remove enforced diff move/copy detection
 commit b a
     Optionally show commit IDs for branches and tree entries
-* [33md10dcd8[m[33m ([1;36mHEAD[m[33m)[m Do not include merges in the announcement's change log
-*   [33m7cdab00[m Merge pull request #81 from esc/fix/reading_git_colors_256
-[32m|[m[33m\[m
-[32m|[m * [33m54e8c4d[m fix: reading git colors in rang 0 255
-* [33m|[m   [33m7368b5b[m Merge pull request #80 from esc/fix/option_name_mismatch
-[34m|[m[35m\[m [33m\[m
-[34m|[m * [33m|[m [33m0431cd2[m fix: the manpage says 'read-git-colors'
-[34m|[m [33m|[m[33m/[m
-* [33m|[m [33m82458a4[m Reenable copy/rename detection in the status view
-[33m|[m[33m/[m
-* [33m6d276a6[m Remove enforced diff move/copy detection
-* [33mc5aaa84[m Optionally show commit IDs for branches and tree entries
 EOF
 
 assert_equals stdout <<EOF

--- a/test/graph/20-tig-all-long-test
+++ b/test/graph/20-tig-all-long-test
@@ -742,10 +742,10 @@ assert_equals stdout <<EOF
 ● │ Fix mistake in tigrc: line-graphic expects utf8, not utf-8
 ●─│─╮ Merge pull request #37 from v0n/abbrev_commit_hash
 │ │ ● string_copy_rev: chop rev on first space (if any)
-●─│─╯ Merge pull request #36 from tsibley/reload-diff-view-on-toggle
+●─│─┤ Merge pull request #36 from tsibley/reload-diff-view-on-toggle
 │ │ ● Reload the view on a diff-like option change
 │ │ ● Doc typo
-●─│─╯ Merge pull request #34 from tsibley/combined-diff-coloring
+●─│─┤ Merge pull request #34 from tsibley/combined-diff-coloring
 │ │ ● [GH #32] Only color +/- in the second column when in a combined diff
 ●─│─╯ Only reload the view after changing diff options for diff-like views
 ● │ Document how to submit bugs

--- a/test/graph/regression/horizontal-artifact-test
+++ b/test/graph/regression/horizontal-artifact-test
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Graph test: regression test for "─╭" instead of " ╭"
+
+. libtest.sh
+
+test_graph <<EOF
+commit A3 A1 A2
+    Commit A3 - merge A1 and A2
+commit B2 A1 B1
+    Commit B2 - merge A1 and B1
+commit C2 A1 C1
+    Commit C2 - merge A1 and C1
+commit A1 R
+    Commit A1 - after R
+commit D2 R D1
+    Commit D2 - merge R and D1
+commit D1 R
+    Commit D1 - after R
+commit A2 R
+    Commit A2 - after R
+commit B1 R
+    Commit B1 - after R
+commit C1 R
+    Commit C1 - after R
+commit R
+    Commit R
+EOF
+
+assert_equals stdout <<EOF
+●─╮ Commit A3 - merge A1 and A2
+│ │ ●─╮ Commit B2 - merge A1 and B1
+│ │ │ │ ●─╮ Commit C2 - merge A1 and C1
+●─│─┴─│─╯ │ Commit A1 - after R
+│ │─╭─╯─╭─╯ ●─╮ Commit D2 - merge R and D1
+│ │ │ ╭─╯ ╭─╯ ● Commit D1 - after R
+│ ● │ │ ╭─╯ ╭─╯ Commit A2 - after R
+│ │ ● │ │ ╭─╯ Commit B1 - after R
+│ │ │ ● │ │ Commit C1 - after R
+◎─┴─┴─┴─┴─╯ Commit R
+EOF

--- a/test/graph/regression/horizontal-artifact-test
+++ b/test/graph/regression/horizontal-artifact-test
@@ -32,7 +32,7 @@ assert_equals stdout <<EOF
 │ │ ●─╮ Commit B2 - merge A1 and B1
 │ │ │ │ ●─╮ Commit C2 - merge A1 and C1
 ●─│─┴─│─╯ │ Commit A1 - after R
-│ │─╭─╯─╭─╯ ●─╮ Commit D2 - merge R and D1
+│ │ ╭─╯ ╭─╯ ●─╮ Commit D2 - merge R and D1
 │ │ │ ╭─╯ ╭─╯ ● Commit D1 - after R
 │ ● │ │ ╭─╯ ╭─╯ Commit A2 - after R
 │ │ ● │ │ ╭─╯ Commit B1 - after R

--- a/test/graph/regression/horizontal-bar-wrong-2-test
+++ b/test/graph/regression/horizontal-bar-wrong-2-test
@@ -34,7 +34,7 @@ assert_equals stdout <<EOF
 │ │ │ ● Commit D - after A2
 │ │ │ │ ● Commit E - after A2
 ●─┴─╯ │ │ Commit A3 - after A2
-●─────┴─╯ Commit A2 - merge A1 and F
+●─┬───┴─╯ Commit A2 - merge A1 and F
 │ ● Commit F - after R
 ● │ Commit A1 - after R
 ◎─╯ Commit R

--- a/test/graph/regression/horizontal-bar-wrong-2-test
+++ b/test/graph/regression/horizontal-bar-wrong-2-test
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Graph test: regression test for "─┬" instead of "──"
+
+. libtest.sh
+
+test_graph <<EOF
+commit A4 A3
+    Commit A4 - after A3
+commit B A3
+    Commit B - after A3
+commit C A3
+    Commit C - after A3
+commit D A2
+    Commit D - after A2
+commit E A2
+    Commit E - after A2
+commit A3 A2
+    Commit A3 - after A2
+commit A2 A1 F
+    Commit A2 - merge A1 and F
+commit F R
+    Commit F - after R
+commit A1 R
+    Commit A1 - after R
+commit R
+    Commit R
+EOF
+
+assert_equals stdout <<EOF
+● Commit A4 - after A3
+│ ● Commit B - after A3
+│ │ ● Commit C - after A3
+│ │ │ ● Commit D - after A2
+│ │ │ │ ● Commit E - after A2
+●─┴─╯ │ │ Commit A3 - after A2
+●─────┴─╯ Commit A2 - merge A1 and F
+│ ● Commit F - after R
+● │ Commit A1 - after R
+◎─╯ Commit R
+EOF


### PR DESCRIPTION
These commits fix a couple of graph display issues. Most issues have been found by running the graph drawing code on a large repo. The added regression tests are initially committed in wrong state and then fixed up to make it easier to visualize the issues they fix.

It also adds two new drawing types for merge commits that are also used as the parent for several other  commits.