### PR TITLE
set cursor coord when not updating prompt contents

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -49,6 +49,8 @@ prompt_input(const char *prompt, struct input *input)
 		last_buf_length = buf_length;
 		if (offset >= 0)
 			update_status("%s%.*s", prompt, pos, input->buf);
+		else
+			wmove(status_win, 0, buf_length);
 
 		if (get_input(offset, &key) == OK) {
 			int len = strlen(key.data.bytes);


### PR DESCRIPTION
Sometimes `offset` can be -1, while it is also true that screen contents have changed.  Example keystrokes from the main view: <kbd>f</kbd><kbd>&lt;Down&gt;</kbd>, which enters the file-finder, moves the tig cursor, and leaves the terminal cursor out of place.