### PR TITLE
allow Ctrl-C to terminate file-finder prompt

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -256,6 +256,12 @@ file_finder_input_handler(struct input *input, struct key *key)
 		file_finder_draw(finder);
 		return INPUT_SKIP;
 
+	case REQ_BACK:
+	case REQ_PARENT:
+	case REQ_VIEW_CLOSE:
+	case REQ_VIEW_CLOSE_NO_QUIT:
+		return INPUT_CANCEL;
+
 	default:
 		if (key_to_value(key) == 0) {
 			argv_append(&finder->search, key->data.bytes);

--- a/test/help/all-keybindings-test.expected
+++ b/test/help/all-keybindings-test.expected
@@ -68,6 +68,8 @@ Option toggling:
                            $ :toggle commit-title-overflow                                
                            % :toggle file-filter                                          
 [-] search bindings                                                                       
+View manipulation
+                    <Ctrl-C> view-close          Close the current view
 Searching                                                                                 
   <Down>, <Ctrl-N>, <Ctrl-J> find-next           Find next search match                   
     <Up>, <Ctrl-P>, <Ctrl-K> find-prev           Find previous search match               
@@ -114,6 +116,4 @@ External commands:
                                                                                           
                                                                                           
                                                                                           
-                                                                                          
-                                                                                          
-[help] - line 1 of 112                                                                100%
+[help] - line 1 of 114                                                                100%

--- a/test/help/default-test
+++ b/test/help/default-test
@@ -51,7 +51,7 @@ View manipulation
                            O maximize            Maximize the current view
                            q view-close          Close the current view
                  Q, <Ctrl-C> quit                Close all views and quit
-[help] - line 1 of 112                                                       25%
+[help] - line 1 of 114                                                       24%
 EOF
 
 assert_equals 'help-search.screen' <<EOF
@@ -83,7 +83,7 @@ View manipulation
                            O maximize            Maximize the current view
                            q view-close          Close the current view
                  Q, <Ctrl-C> quit                Close all views and quit
-[help] - line 18 of 112                                                      25%
+[help] - line 18 of 114                                                      24%
 EOF
 
 assert_equals 'help-collapsed.screen' <<EOF

--- a/test/help/user-command-test
+++ b/test/help/user-command-test
@@ -47,13 +47,13 @@ External commands:
                              cc !git commit
                              ca @?git commit --amend --no-edit
 [-] search bindings
+View manipulation
+                       <Ctrl-C> view-close          Close the current view
 Searching
      <Down>, <Ctrl-N>, <Ctrl-J> find-next           Find next search match
        <Up>, <Ctrl-P>, <Ctrl-K> find-prev           Find previous search match
 [-] main bindings
 Cursor navigation
                               G move-last-line      Move cursor to last line
-Option toggling:
-                              F :toggle commit-title-refs
-[help] - line 78 of 138                                                                          76%
+[help] - line 78 of 140                                                                          75%
 EOF

--- a/tigrc
+++ b/tigrc
@@ -254,6 +254,7 @@ bind search	<C-J>	find-next
 bind search	<Up>	find-prev
 bind search	<C-P>	find-prev
 bind search	<C-K>	find-prev
+bind search	<C-C>	view-close
 
 # Option manipulation
 bind generic	o	options			# Open the options menu


### PR DESCRIPTION
This is a special case with its own input handler.  It's also a little annoying that <kbd>C-C</kbd> appears in the help screen for some cases and not for others.

Incidentally it is difficult to figure out that the `search` keymap applies to the file-finder rather than the `/` search.