### PR TITLE
report_clear() efficiency, plus clear after grep

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -430,9 +430,8 @@ report_clear(void)
 		return;
 
 	if (!input_mode && !status_empty) {
-		wclear(status_win);
-		wclrtoeol(status_win);
-		wnoutrefresh(status_win);
+		werase(status_win);
+		doupdate();
 	}
 	status_empty = true;
 	update_view_title(view);

--- a/src/grep.c
+++ b/src/grep.c
@@ -99,6 +99,8 @@ grep_prompt(void)
 	int argc = 0;
 	char *grep = read_prompt("grep: ");
 
+	report_clear();
+
 	if (!grep || !argv_from_string_no_quotes(argv, &argc, grep))
 		return false;
 	if (grep_argv)

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -474,6 +474,9 @@ read_prompt(const char *prompt)
 	if (signal(SIGINT, SIG_DFL) == SIG_ERR)
 		die("Failed to remove sigint handler");
 
+	/* readline can leave the virtual cursor out-of-place */
+	set_cursor_pos(0, 0);
+
 	if (line && !*line) {
 		free(line);
 		line = NULL;


### PR DESCRIPTION
2b384f69b introduced a performance regression due to use of `wclear()`, which dirties the entire screen.  This can be seen in the form of flickering: enter the main view and hold down <kbd>&lt;Up&gt;</kbd>.

The core issue being addressed in 2b384f69b is that readline can leave an incorrect cursor position in virtual window `newscr` (which can be inspected using `getyx()`).

So, explicitly reset the `newscr` cursor position post-readline, which enables switching to the much more efficient `werase()` for erasing the status area.

Incidentally fix the missed case of `report_clear()` after a grep prompt.