### PR TITLE
Add special call to clear the status window after user input

### DIFF
--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -25,6 +25,7 @@ extern WINDOW *status_win;
 void update_status(const char *msg, ...);
 void report(const char *msg, ...) PRINTF_LIKE(1, 2);
 void report_clear(void);
+void status_clear(void);
 
 /*
  * Display management.

--- a/src/display.c
+++ b/src/display.c
@@ -424,18 +424,29 @@ report(const char *msg, ...)
 void
 report_clear(void)
 {
-	struct view *view = display[current_view];
-
-	if (!view)
+	if (input_mode)
 		return;
 
-	if (!input_mode && !status_empty) {
-		wclear(status_win);
-		wclrtoeol(status_win);
+	if (!status_empty) {
+		werase(status_win);
 		wnoutrefresh(status_win);
 	}
 	status_empty = true;
-	update_view_title(view);
+
+	update_view_title(display[current_view]);
+}
+
+void
+status_clear(void)
+{
+	if (input_mode)
+		return;
+
+	werase(status_win);
+	wclear(status_win);
+	wnoutrefresh(status_win);
+	status_empty = true;
+	update_view_title(display[current_view]);
 }
 
 static void

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -94,7 +94,7 @@ prompt_input(const char *prompt, struct input *input)
 	}
 
 	curs_set(0);
-	report_clear();
+	status_clear();
 
 	if (status == INPUT_CANCEL)
 		return NULL;
@@ -470,6 +470,7 @@ read_prompt(const char *prompt)
 	curs_set(1);
 	line = readline(prompt);
 	curs_set(0);
+	status_clear();
 
 	if (signal(SIGINT, SIG_DFL) == SIG_ERR)
 		die("Failed to remove sigint handler");
@@ -596,8 +597,7 @@ prompt_menu(const char *prompt, const struct menu_item *items, int *selected)
 		}
 	}
 	curs_set(0);
-
-	report_clear();
+	status_clear();
 
 	return status != INPUT_CANCEL;
 }
@@ -1043,13 +1043,11 @@ open_prompt(struct view *view)
 	const char *argv[SIZEOF_ARG] = { NULL };
 	int argc = 0;
 
-	if (cmd && !argv_from_string(argv, &argc, cmd)) {
-		report("Too many arguments");
+	if (!cmd)
 		return REQ_NONE;
-	}
 
-	if (!cmd) {
-		report_clear();
+	if (!argv_from_string(argv, &argc, cmd)) {
+		report("Too many arguments");
 		return REQ_NONE;
 	}
 


### PR DESCRIPTION
Follow-up to aa84d85fef0eba5e02618e2070cf81d68f8b7bd4 to fix performance
regression noted in #649. Also cleans up open_prompt to not clear the
status window.