### PR TITLE
erase status line at exit time

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -440,8 +440,13 @@ report_clear(void)
 static void
 done_display(void)
 {
-	if (cursed)
+	if (cursed) {
+		if (status_win) {
+			werase(status_win);
+			doupdate();
+		}
 		endwin();
+	}
 	cursed = false;
 }
 


### PR DESCRIPTION
for users without altscreen-capable terminals
fixes #589

steps to duplicate original issue
 * run xterm
 * ctrl-middleclick on xterm, making sure that "Enable alternate screen switching" is unchecked in the popup menu
 * run bash inside of xterm
 * `export PS1='> '`
 * `tig`
 * issue keystrokes <kbd>&lt;up&gt;</kbd> <kbd>Q</kbd>
