### PR TITLE
Distinguish between cancel action and empty string at all prompts

### DIFF
--- a/src/grep.c
+++ b/src/grep.c
@@ -101,7 +101,7 @@ grep_prompt(void)
 
 	report_clear();
 
-	if (!grep || !argv_from_string_no_quotes(argv, &argc, grep))
+	if (!grep || !*grep || !argv_from_string_no_quotes(argv, &argc, grep))
 		return false;
 	if (grep_argv)
 		argv_free(grep_argv);

--- a/src/search.c
+++ b/src/search.c
@@ -249,13 +249,13 @@ search_view(struct view *view, enum request request)
 	const char *prompt = request == REQ_SEARCH ? "/" : "?";
 	char *search = read_prompt(prompt);
 
-	if (search) {
+	if (search && *search) {
 		enum status_code code;
 
 		string_ncopy(argv_env.search, search, strlen(search));
 		code = setup_and_find_next(view, request);
 		report("%s", get_status_message(code));
-	} else if (*argv_env.search) {
+	} else if (search && *argv_env.search) {
 		find_next(view, request);
 	} else {
 		report_clear();


### PR DESCRIPTION
Fixes #627
xrefs #583 #619 #623 #632 #648

The expectations for `/` search described in #627 match the behavior of `less`, which seems like a good conservative guide.

After this PR <kbd>Ctrl-C</kbd> means "cancel without action" at every prompt, which is accomplished by
 * maintaining the distinction between null pointers and strings of length zero, representing canceled input and empty input, respectively. This is somewhat fragile but also intuitive and consistent with most of the existing code paths.
 * at the input boundary, capturing the distinction by setting a flag in the readline signal handler as discussed in #623.
 * at the input boundary, when configured without readline, changing the way `read_prompt()` calls `read_prompt_incremental()`.  Note that <kbd>Ctrl-C</kbd> is unsupported at most prompts without readline; this merely compensates for the rest of the PR, and avoids regressions when compiled without readline

Since <kbd>Ctrl-C</kbd> has been made consistent, we may as well summarize here the behavior of an empty <kbd>&lt;Enter&gt;</kbd> across various prompts:

| prompt              | empty <kbd>&lt;Enter&gt;</kbd> | changed by this PR              |
| ------------------- |------------------------------- | ------------------------------- |
| `%(prompt)`         | accepted as empty string       | **yes**, previously threw error |
| `?<command>` (y/n)  | equivalent to `N` (No)         | no                              |
| `options`           | toggle current option          | no                              |
| `:`                 | cancel without action          | no                              |
| `/`                 | recall last search query       | no                              |
| `?`                 | recall last search query       | no                              |
| `grep-view`         | cancel without action          | no                              |
| file-finder         | choose file under cursor       | no                              |

Some might consider it poor UI that empty <kbd>&lt;Enter&gt;</kbd> has many different behaviors.  But in practice these are grounded in historical TUI behaviors, and all seem natural to me, with the exception of the Y/N prompt.  <kbd>&lt;Enter&gt;</kbd> should preferably not have a meaning at Y/N, and if it does, that should be indicated to the user *eg* `Question: y/N`.
