### PR TITLE
reduce flicker in file finder; avoid wclear()

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -145,7 +145,7 @@ file_finder_draw(struct file_finder *finder)
 	int column;
 
 	wbkgdset(finder->win, get_line_attr(NULL, LINE_DEFAULT));
-	wclear(finder->win);
+	werase(finder->win);
 
 	for (column = 0; *line_pos && column < finder->height - 1; line_pos++) {
 		struct file_finder_line *line = *line_pos;


### PR DESCRIPTION
It may be possible to optimize some details of `file_finder_draw()`, but this small change improves performance and reduces flicker by avoiding `wclear()` as in #649.

To visualize the flicker: run `tig | pv -qL5000` and hold the <kbd>&lt;Down&gt;</kbd> key.