### PR TITLE
fix string corruption in file finder

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -64,7 +64,7 @@ file_finder_read(struct file_finder *finder, const char *commit)
 			break;
 		}
 
-		finder->file[files] = calloc(1, sizeof(*finder->file) + buf.size);
+		finder->file[files] = calloc(1, sizeof(struct file_finder_line) + buf.size);
 		if (!finder->file[files]) {
 			ok = false;
 			break;


### PR DESCRIPTION
~Allocate one more byte for file-finder items~ [edited]

Allocate the full `sizeof(struct file_finder_line)` rather than the size of a pointer, so that there is enough memory for the NUL terminator (and so that the NUL is pre-filled).

Otherwise `strncpy()` will take up the entire space, and tig may later read past the end.
