### PR TITLE
Fix suspension capability when calling out to external commands

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -57,6 +57,8 @@ open_external_viewer(const char *argv[], const char *dir, bool silent, bool conf
 		ok = io_run_bg(argv, dir);
 
 	} else {
+		clear();
+		refresh();
 		endwin();                  /* restore original tty modes */
 		ok = io_run_fg(argv, dir);
 		if (confirm || !ok) {
@@ -65,6 +67,11 @@ open_external_viewer(const char *argv[], const char *dir, bool silent, bool conf
 			fprintf(stderr, "Press Enter to continue");
 			getc(opt_tty);
 		}
+		nonl();		/* Disable conversion and detect newlines from input. */
+		raw();       /* Take input chars one at a time, no wait for \n */
+		noecho();       /* Don't echo input */
+		curs_set(0);
+		leaveok(stdscr, false);
 	}
 
 	if (watch_update(WATCH_EVENT_AFTER_COMMAND) && refresh) {
@@ -463,10 +470,7 @@ init_display(void)
 		die("Failed to register done_display");
 
 	/* Initialize the curses library */
-	if (!no_display && isatty(STDIN_FILENO)) {
-		cursed = !!initscr();
-		opt_tty = stdin;
-	} else {
+	{
 		/* Leave stdin and stdout alone when acting as a pager. */
 		FILE *out_tty;
 


### PR DESCRIPTION
Clear the terminal before calling out to an external command so the
altscreen won't mess up any downstream subshell management. Restore
terminal settings as per init_display when restoring. Reproducible with
example from[0]:

 - Run `tig status`
 - Press 'e' to open Vim
 - Press Ctrl-Z to suspend Vim
 - Run `fg`
 - Quit Vim

 [0] https://github.com/jonas/tig/issues/232#issuecomment-313790438

Refs: #232
cc: @commonquail