### PR TITLE
independent throttle increment for each view

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -645,6 +645,9 @@ update_view_title(struct view *view)
 	WINDOW *window = view->title;
 	struct line *line = &view->line[view->pos.lineno];
 	unsigned int view_lines, lines;
+	int update_increment = view_has_flags(view, VIEW_LOG_LIKE | VIEW_GREP_LIKE)
+			       ? 100
+			       : view_has_flags(view, VIEW_DIFF_LIKE) ? 10 : 1;
 
 	assert(view_is_displayed(view));
 
@@ -667,7 +670,8 @@ update_view_title(struct view *view)
 					   line->lineno,
 					   MAX(line->lineno,
 					       view->pipe
-					       ? 100 * (size_t) ((view->lines - view->custom_lines) / 100)
+					       ? update_increment *
+						 (size_t) ((view->lines - view->custom_lines) / update_increment)
 					       : view->lines - view->custom_lines));
 	}
 


### PR DESCRIPTION
#622 introduced a regression, which is most visible in a complex blame or tree view: "line 1 of N" or "file 1 of N" is not flushed to the maximum value until the read completes.

The worst case is the tree view in a large repo, which can easily stick on "file 1 of 1" for more than a minute.

This PR addresses the issue by making the granularity of throttling independent for each view.  I'm not sure this is the best fix, though it is generally intuitive that heuristics may adjust per-view.

Perhaps the magic numbers would be as `#define`s with self-documenting names. If so, I wasn't sure if it would be better to scatter them through the per-view headers, or collect the values together.