### PR TITLE
visually distinguish merges vs ordinary commits in utf8 graph

### DIFF
--- a/src/graph-v1.c
+++ b/src/graph-v1.c
@@ -357,7 +357,7 @@ graph_symbol_to_utf8(const struct graph_symbol *symbol)
 			return " ◎";
 		else if (symbol->merge)
 			return " ●";
-		return " ●";
+		return " ∙";
 	}
 
 	if (symbol->merge) {

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -1039,7 +1039,7 @@ graph_symbol_to_utf8(const struct graph_symbol *symbol)
 			return " ◎";
 		else if (symbol->merge)
 			return " ●";
-		return " ●";
+		return " ∙";
 	}
 
 	if (graph_symbol_cross_merge(symbol))

--- a/test/diff/diff-stat-split-test
+++ b/test/diff/diff-stat-split-test
@@ -19,33 +19,33 @@ in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
 test_tig
 
 assert_equals 'diff-stat.screen' <<EOF
-2014-03-01 17:26 Jonas Fonseca      ● [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE        |commit ee912870202200a0b9cf4fd86ba57243212d341e
-2014-03-01 15:59 Jonas Fonseca      ● Add type parameter for js.Dynamic                    |Refs: [master]
-2014-01-16 22:51 Jonas Fonseca      ● Move classes under org.scalajs.benchmark package scop|Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
-2014-01-16 17:43 Jonas Fonseca      ● Bump Scala.js version to 0.3-SNAPSHOT                |AuthorDate: Sat Mar 1 17:26:01 2014 -0500
-2014-01-16 17:39 Jonas Fonseca      ● Integrate app code into the benchmark infrastructure |Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
+2014-03-01 17:26 Jonas Fonseca      ∙ [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE        |commit ee912870202200a0b9cf4fd86ba57243212d341e
+2014-03-01 15:59 Jonas Fonseca      ∙ Add type parameter for js.Dynamic                    |Refs: [master]
+2014-01-16 22:51 Jonas Fonseca      ∙ Move classes under org.scalajs.benchmark package scop|Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
+2014-01-16 17:43 Jonas Fonseca      ∙ Bump Scala.js version to 0.3-SNAPSHOT                |AuthorDate: Sat Mar 1 17:26:01 2014 -0500
+2014-01-16 17:39 Jonas Fonseca      ∙ Integrate app code into the benchmark infrastructure |Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
 2014-01-16 07:47 Jonas Fonseca      ●─╮ Merge pull request #4 from phaller/patch-1         |CommitDate: Sat Mar 1 17:26:01 2014 -0500
-2014-01-16 15:32 Philipp Haller     │ ● Fix link to Dart benchmark harness                 |
-2013-12-17 00:02 Jonas Fonseca      ●─╯ Update links to reflect project name change        |    WIP: Upgrade to 0.4-SNAPSHOT and DCE
-2013-12-03 23:35 Jonas Fonseca      ● Use Scala.js 0.2-SNAPSHOT                            |---
-2013-11-26 23:39 Jonas Fonseca      ● Extract the benchmark list variable name; fix push to| common/benchmark-runner.sh                                           |  5 +++--
-2013-11-26 23:31 Jonas Fonseca      ● Solve the easiest sudoku grid                        | common/src/main/scala/org/scalajs/benchmark/Benchmark.scala          | 11 +++++------
-2013-11-26 23:22 Jonas Fonseca      ● Disable phantomjs by default                         | common/src/main/scala/org/scalajs/benchmark/BenchmarkApp.scala       |  2 +-
-2013-11-26 22:55 Jonas Fonseca      ● Exclude Sudoku when running all benchmarks           | common/start-benchmark.js                                            |  9 +++++++--
-2013-11-26 22:52 Jonas Fonseca      ● Fix reference setup to work for node                 | deltablue/exports.js                                                 | 13 -------------
-2013-11-26 22:03 Jonas Fonseca      ● Move benchmark registration to Scala                 | .../src/main/scala/org/scalajs/benchmark/deltablue/DeltaBlue.scala   |  7 +++++++
-2013-11-26 20:13 Jonas Fonseca      ● Rename projects to be grouped together in Eclipse    | project/Build.scala                                                  | 13 ++++---------
-2013-11-19 21:56 Jonas Fonseca      ● sudoku: use iterator instead of Try()                | project/build.sbt                                                    |  5 ++++-
-2013-11-11 21:56 Jonas Fonseca      ● Add verification of sudoku solutions                 | richards/exports.js                                                  | 13 -------------
-2013-11-11 21:50 Jonas Fonseca      ● Use stream to halt when first sudoku solution has bee| .../src/main/scala/org/scalajs/benchmark/richards/Richards.scala     |  3 +++
-2013-11-11 01:11 Jonas Fonseca      ● Add initial version of sudoku benchmark              | run.sh                                                               |  2 +-
-2013-11-05 23:20 Jonas Fonseca      ● Reformat code using Scala IDE                        | sudoku/exports.js                                                    | 13 -------------
-2013-11-05 20:41 Jonas Fonseca      ● Update exports.js files to use new Scala.js class nam| sudoku/src/main/scala/org/scalajs/benchmark/sudoku/Sudoku.scala      |  2 ++
-2013-11-03 23:48 Jonas Fonseca      ● Add support for PhantomJS                            | tracer/exports.js                                                    | 13 -------------
-2013-11-03 23:11 Jonas Fonseca      ● Make the engine stubs file optional                  | tracer/index-dev.html                                                |  2 +-
-2013-11-03 22:44 Jonas Fonseca      ● Refactor the benchmark shell code                    | tracer/index.html                                                    |  2 +-
+2014-01-16 15:32 Philipp Haller     │ ∙ Fix link to Dart benchmark harness                 |
+2013-12-17 00:02 Jonas Fonseca      ∙─╯ Update links to reflect project name change        |    WIP: Upgrade to 0.4-SNAPSHOT and DCE
+2013-12-03 23:35 Jonas Fonseca      ∙ Use Scala.js 0.2-SNAPSHOT                            |---
+2013-11-26 23:39 Jonas Fonseca      ∙ Extract the benchmark list variable name; fix push to| common/benchmark-runner.sh                                           |  5 +++--
+2013-11-26 23:31 Jonas Fonseca      ∙ Solve the easiest sudoku grid                        | common/src/main/scala/org/scalajs/benchmark/Benchmark.scala          | 11 +++++------
+2013-11-26 23:22 Jonas Fonseca      ∙ Disable phantomjs by default                         | common/src/main/scala/org/scalajs/benchmark/BenchmarkApp.scala       |  2 +-
+2013-11-26 22:55 Jonas Fonseca      ∙ Exclude Sudoku when running all benchmarks           | common/start-benchmark.js                                            |  9 +++++++--
+2013-11-26 22:52 Jonas Fonseca      ∙ Fix reference setup to work for node                 | deltablue/exports.js                                                 | 13 -------------
+2013-11-26 22:03 Jonas Fonseca      ∙ Move benchmark registration to Scala                 | .../src/main/scala/org/scalajs/benchmark/deltablue/DeltaBlue.scala   |  7 +++++++
+2013-11-26 20:13 Jonas Fonseca      ∙ Rename projects to be grouped together in Eclipse    | project/Build.scala                                                  | 13 ++++---------
+2013-11-19 21:56 Jonas Fonseca      ∙ sudoku: use iterator instead of Try()                | project/build.sbt                                                    |  5 ++++-
+2013-11-11 21:56 Jonas Fonseca      ∙ Add verification of sudoku solutions                 | richards/exports.js                                                  | 13 -------------
+2013-11-11 21:50 Jonas Fonseca      ∙ Use stream to halt when first sudoku solution has bee| .../src/main/scala/org/scalajs/benchmark/richards/Richards.scala     |  3 +++
+2013-11-11 01:11 Jonas Fonseca      ∙ Add initial version of sudoku benchmark              | run.sh                                                               |  2 +-
+2013-11-05 23:20 Jonas Fonseca      ∙ Reformat code using Scala IDE                        | sudoku/exports.js                                                    | 13 -------------
+2013-11-05 20:41 Jonas Fonseca      ∙ Update exports.js files to use new Scala.js class nam| sudoku/src/main/scala/org/scalajs/benchmark/sudoku/Sudoku.scala      |  2 ++
+2013-11-03 23:48 Jonas Fonseca      ∙ Add support for PhantomJS                            | tracer/exports.js                                                    | 13 -------------
+2013-11-03 23:11 Jonas Fonseca      ∙ Make the engine stubs file optional                  | tracer/index-dev.html                                                |  2 +-
+2013-11-03 22:44 Jonas Fonseca      ∙ Refactor the benchmark shell code                    | tracer/index.html                                                    |  2 +-
 2013-10-29 17:29 Jonas Fonseca      ●─╮ Merge pull request #2 from sjrd/patch-2            | tracer/src/main/scala/org/scalajs/benchmark/tracer/Tracer.scala      |  3 +++
-2013-10-29 18:48 Sébastien Doeraene │ ● Remove workaround to support Node.js.              | 17 files changed, 42 insertions(+), 76 deletions(-)
-2013-10-29 18:46 Sébastien Doeraene │ ● Update for new groupId and package structure of Sca|
+2013-10-29 18:48 Sébastien Doeraene │ ∙ Remove workaround to support Node.js.              | 17 files changed, 42 insertions(+), 76 deletions(-)
+2013-10-29 18:46 Sébastien Doeraene │ ∙ Update for new groupId and package structure of Sca|
 [main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 48                        58%|[diff] ee912870202200a0b9cf4fd86ba57243212d341e - line 1 of 367                        7%
 EOF

--- a/test/graph/00-simple-test
+++ b/test/graph/00-simple-test
@@ -22,8 +22,8 @@ EOF
 assert_equals stdout <<EOF
 ●─╮ Merge branch 'branch3'
 ●─│─╮ Merge branch 'branch2'
-│ ● │ branch3
-│ │ ● branch2
-● │ │ branch1
+│ ∙ │ branch3
+│ │ ∙ branch2
+∙ │ │ branch1
 ◎─┴─╯ init
 EOF

--- a/test/graph/01-merge-from-left-test
+++ b/test/graph/01-merge-from-left-test
@@ -20,7 +20,7 @@ EOF
 assert_equals stdout <<EOF
 ●─╮ Commit A - Merge C into B
 │ ●─╮ Commit C - Merge D into B
-●─╯ │ Commit B after E
-● ╭─╯ Commit E after D
+∙─╯ │ Commit B after E
+∙ ╭─╯ Commit E after D
 ◎─╯ Commit D
 EOF

--- a/test/graph/02-duplicate-parent-test
+++ b/test/graph/02-duplicate-parent-test
@@ -28,11 +28,11 @@ EOF
 assert_equals stdout <<EOF
 ●─╮ Commit A - Merge C into B
 ●─│─╮ Commit B - Merge E into C
-●─╯ │ Commit C after D
-│ ●─╯ Commit E after D
-●─╯ Commit D after F
+∙─╯ │ Commit C after D
+│ ∙─╯ Commit E after D
+∙─╯ Commit D after F
 ●─╮ Commit F - Merge H into G
 ●─│─╮ Commit G - Merge I into H
-│ │ ● Commit I after H
+│ │ ∙ Commit I after H
 ◎─┴─╯ Commit H
 EOF

--- a/test/graph/03-octo-merge-test
+++ b/test/graph/03-octo-merge-test
@@ -19,8 +19,8 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─╮ Commit A - Merges B, C, and D
-│ ● │ Commit C after E
+│ ∙ │ Commit C after E
 │ ●─│─╮ Commit E - Merges D and B
-●─│─│─╯ Commit B after D
+∙─│─│─╯ Commit B after D
 ◎─┴─╯ Commit D
 EOF

--- a/test/graph/04-missing-bar-test
+++ b/test/graph/04-missing-bar-test
@@ -24,9 +24,9 @@ EOF
 assert_equals stdout <<EOF
 ●─╮ Commit A - Merge B and C
 ●─│─╮ Commit B - Merge D and E
-│ ● │ Commit C after F
+│ ∙ │ Commit C after F
 │ ●─│─╮ Commit F - Merge G and D
-●─│─│─╯ Commit D after G
-●─╯ │ Commit G after E
+∙─│─│─╯ Commit D after G
+∙─╯ │ Commit G after E
 ◎───╯ Commit E
 EOF

--- a/test/graph/05-extra-pipe-test
+++ b/test/graph/05-extra-pipe-test
@@ -21,9 +21,9 @@ EOF
 
 assert_equals stdout <<EOF
 ●─╮ Commit A - merge B and C
-│ ● Commit C after D
+│ ∙ Commit C after D
 ●─│─╮ Commit B - merge E and D
-│ ●─╯ Commit D after F
+│ ∙─╯ Commit D after F
 ◎ │ Commit E
 ◎─╯ Commit F
 EOF

--- a/test/graph/06-extra-bars-test
+++ b/test/graph/06-extra-bars-test
@@ -123,60 +123,60 @@ EOF
 
 assert_equals stdout <<EOF
 ●─╮ Commit A - merge B and C
-│ ● Commit C - after B
-│ │ ● Commit D - after B
-│ │ │ ● Commit E - after F
-│ │ │ ● Commit F - after G
-│ │ │ ● Commit G - after H
-│ │ │ ● Commit H - after I
-│ │ │ ● Commit I - after J
-│ │ │ ● Commit J - after K
-│ │ │ ● Commit K - after L
-│ │ │ ● Commit L - after M
-│ │ │ ● Commit M - after N
-│ │ │ ● Commit N - after O
-│ │ │ ● Commit O - after P
+│ ∙ Commit C - after B
+│ │ ∙ Commit D - after B
+│ │ │ ∙ Commit E - after F
+│ │ │ ∙ Commit F - after G
+│ │ │ ∙ Commit G - after H
+│ │ │ ∙ Commit H - after I
+│ │ │ ∙ Commit I - after J
+│ │ │ ∙ Commit J - after K
+│ │ │ ∙ Commit K - after L
+│ │ │ ∙ Commit L - after M
+│ │ │ ∙ Commit M - after N
+│ │ │ ∙ Commit N - after O
+│ │ │ ∙ Commit O - after P
 ●─┼─╯ │ Commit B - merge Q and R
-│ ● ╭─╯ Commit R - after Q
+│ ∙ ╭─╯ Commit R - after Q
 ●─┤ │ Commit Q - merge S and T
-│ ● │ Commit T - after S
-│ │ ● Commit P - after U
-│ │ ● Commit U - after V
-│ │ ● Commit V - after W
+│ ∙ │ Commit T - after S
+│ │ ∙ Commit P - after U
+│ │ ∙ Commit U - after V
+│ │ ∙ Commit V - after W
 ●─┤ │ Commit S - merge X and Y
-│ │ │ ● Commit Z - after 1
-│ ● │ │ Commit Y - after X
+│ │ │ ∙ Commit Z - after 1
+│ ∙ │ │ Commit Y - after X
 ●─┤ │ │ Commit X - merge 2 and 3
-│ ● │ │ Commit 3 - after 2
-│ │ │ │ ● Commit 4 - after 5
-│ │ │ │ ● Commit 5 - after 6
-│ │ ● │ │ Commit W - after 7
-│ │ │ │ ● Commit 6 - after 8
-│ │ ● │ │ Commit 7 - after 9
+│ ∙ │ │ Commit 3 - after 2
+│ │ │ │ ∙ Commit 4 - after 5
+│ │ │ │ ∙ Commit 5 - after 6
+│ │ ∙ │ │ Commit W - after 7
+│ │ │ │ ∙ Commit 6 - after 8
+│ │ ∙ │ │ Commit 7 - after 9
 ●─┤ │ │ │ Commit 2 - merge 0 and a
-│ ● │ │ │ Commit a - after b
-│ ● │ │ │ Commit b - after c
+│ ∙ │ │ │ Commit a - after b
+│ ∙ │ │ │ Commit b - after c
 │ ●─│─│─│─╮ Commit c - merge d and 0
-│ │ │ │ ● │ Commit 8 - after e
-│ │ │ │ ● │ Commit e - after f
-│ │ │ │ ● │ Commit f - after g
+│ │ │ │ ∙ │ Commit 8 - after e
+│ │ │ │ ∙ │ Commit e - after f
+│ │ │ │ ∙ │ Commit f - after g
 ●─│─│─│─│─┤ Commit 0 - merge h and i
-│ │ │ │ ● │ Commit g - after j
-│ │ │ │ ● │ Commit j - after k
-│ │ │ │ ● │ Commit k - after l
-│ │ │ │ ● │ Commit l - after m
-│ │ │ │ ● │ Commit m - after n
-│ │ │ │ ● │ Commit n - after o
-│ │ │ │ ● │ Commit o - after p
-│ │ │ │ ● │ Commit p - after 1
-│ │ ● │ │ │ Commit 9 - after q
-│ │ │ ●─╯ │ Commit 1 - after r
-│ │ │ │ ●─╯ Commit i - after h
-│ ● │ │ │ Commit d - after h
-│ │ │ ● │ Commit r - after s
+│ │ │ │ ∙ │ Commit g - after j
+│ │ │ │ ∙ │ Commit j - after k
+│ │ │ │ ∙ │ Commit k - after l
+│ │ │ │ ∙ │ Commit l - after m
+│ │ │ │ ∙ │ Commit m - after n
+│ │ │ │ ∙ │ Commit n - after o
+│ │ │ │ ∙ │ Commit o - after p
+│ │ │ │ ∙ │ Commit p - after 1
+│ │ ∙ │ │ │ Commit 9 - after q
+│ │ │ ∙─╯ │ Commit 1 - after r
+│ │ │ │ ∙─╯ Commit i - after h
+│ ∙ │ │ │ Commit d - after h
+│ │ │ ∙ │ Commit r - after s
 ●─┼─│─│─╯ Commit h - merge t and u
-│ │ │ ● Commit s - after v
-│ ● │ │ Commit u - after t
-│ │ │ │ ● Commit w - after x
-│ │ │ │ ● Commit x - after y
+│ │ │ ∙ Commit s - after v
+│ ∙ │ │ Commit u - after t
+│ │ │ │ ∙ Commit w - after x
+│ │ │ │ ∙ Commit x - after y
 EOF

--- a/test/graph/07-multi-collapse-test
+++ b/test/graph/07-multi-collapse-test
@@ -25,11 +25,11 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─┬─┬─╮ Commit A - merge B, C, D, E, and F
-│ ● │ │ │ Commit C - after B
-●─╯ │ │ │ Commit B - after H
-│ ╭─╯ │ ● Commit F - after G
-● │ ╭─╯ │ Commit H - after D
-●─╯ │ ╭─╯ Commit D - after E
-●───╯ │ Commit E - after G
+│ ∙ │ │ │ Commit C - after B
+∙─╯ │ │ │ Commit B - after H
+│ ╭─╯ │ ∙ Commit F - after G
+∙ │ ╭─╯ │ Commit H - after D
+∙─╯ │ ╭─╯ Commit D - after E
+∙───╯ │ Commit E - after G
 ◎─────╯ Commit G
 EOF

--- a/test/graph/08-multi-collapse-2-test
+++ b/test/graph/08-multi-collapse-2-test
@@ -27,12 +27,12 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─┬─┬─┬─╮ Commit A - merge Z, B, C, D, E, and F
-│ │ ● │ │ │ Commit C - after B
-│ ●─╯ │ │ │ Commit B - after H
-│ │ ╭─╯ │ ● Commit F - after G
-│ ● │ ╭─╯ │ Commit H - after D
-│ ●─╯ │ ╭─╯ Commit D - after E
-│ ●───╯ │ Commit E - after G
-│ ●─────╯ Commit G - after Z
+│ │ ∙ │ │ │ Commit C - after B
+│ ∙─╯ │ │ │ Commit B - after H
+│ │ ╭─╯ │ ∙ Commit F - after G
+│ ∙ │ ╭─╯ │ Commit H - after D
+│ ∙─╯ │ ╭─╯ Commit D - after E
+│ ∙───╯ │ Commit E - after G
+│ ∙─────╯ Commit G - after Z
 ◎─╯ Commit Z
 EOF

--- a/test/graph/09-parallel-siblings-test
+++ b/test/graph/09-parallel-siblings-test
@@ -29,10 +29,10 @@ assert_equals stdout <<EOF
 ●─┬─╮ Commit A - merge Z, B, and C
 │ ●─│─╮ Commit B - merge D and C
 │ ●─│─│─╮ Commit D - merge C and E
-│ ● │ │ │ Commit E - after Z
-●─╯ │ │ │ Commit Z - after Y
-● ╭─╯ │ │ Commit Y - after X
-● │ ╭─╯ │ Commit X - after W
-● │ │ ╭─╯ Commit W - after C
+│ ∙ │ │ │ Commit E - after Z
+∙─╯ │ │ │ Commit Z - after Y
+∙ ╭─╯ │ │ Commit Y - after X
+∙ │ ╭─╯ │ Commit X - after W
+∙ │ │ ╭─╯ Commit W - after C
 ◎─┴─┴─╯ Commit C
 EOF

--- a/test/graph/10-shorter-merge-than-branch-test
+++ b/test/graph/10-shorter-merge-than-branch-test
@@ -31,14 +31,14 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─┬─┬─┬─╮ Commit A - merge H, B, C, D, and E
-│ ● │ │ │ │ Commit B - after K
-│ │ ● │ │ │ Commit C - after H
-│ │ │ │ ● │ Commit J - after I
-│ │ │ ● │ │ Commit D - after K
-│ │ │ │ │ ● Commit E - after F
-│ ●─│─╯ │ │ Commit K - after F
+│ ∙ │ │ │ │ Commit B - after K
+│ │ ∙ │ │ │ Commit C - after H
+│ │ │ │ ∙ │ Commit J - after I
+│ │ │ ∙ │ │ Commit D - after K
+│ │ │ │ │ ∙ Commit E - after F
+│ ∙─│─╯ │ │ Commit K - after F
 │ ●─│─╭─╯─┤ Commit F - merge G and H
-│ ● │ │ ╭─╯ Commit G - after I
-●─│─┴─│─╯ Commit H - after I
+│ ∙ │ │ ╭─╯ Commit G - after I
+∙─│─┴─│─╯ Commit H - after I
 ◎─┴───╯ Commit I
 EOF

--- a/test/graph/11-new-branch-in-middle-test
+++ b/test/graph/11-new-branch-in-middle-test
@@ -27,12 +27,12 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─╮ Commit A - merge B, C, and E
-● │ │ Commit B - after F
-│ ● │ Commit C - after F
-│ │ ● Commit E - after Z
+∙ │ │ Commit B - after F
+│ ∙ │ Commit C - after F
+│ │ ∙ Commit E - after Z
 ●─┤ │ Commit F - merge G and I
 ●─│─│─╮ Commit G - merge H and I
-● │ │ │ Commit H - after I
-●─┴─│─╯ Commit I - after Z
+∙ │ │ │ Commit H - after I
+∙─┴─│─╯ Commit I - after Z
 ◎───╯ Commit Z
 EOF

--- a/test/graph/12-cross-over-collapse-test
+++ b/test/graph/12-cross-over-collapse-test
@@ -27,12 +27,12 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─╮ Commit A - merge B, D, and E
-● │ │ Commit B - after F
-│ ● │ Commit D - after F
-│ │ ● Commit E - after Z
-●─╯ │ Commit F - after I
+∙ │ │ Commit B - after F
+│ ∙ │ Commit D - after F
+│ │ ∙ Commit E - after Z
+∙─╯ │ Commit F - after I
 ●─╭─╯─╮ Commit F - merge H and I
-● │ ╭─╯ Commit H - after I
-●─│─╯ Commit I - after Z
+∙ │ ╭─╯ Commit H - after I
+∙─│─╯ Commit I - after Z
 ◎─╯ Commit Z
 EOF

--- a/test/graph/13-collapse-parallel-branches-with-different-middle-branch-test
+++ b/test/graph/13-collapse-parallel-branches-with-different-middle-branch-test
@@ -29,13 +29,13 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─┬─┬─╮ Commit A - merge B, C, D, E, and F
-│ │ ● │ │ Commit D - after I
-│ │ │ ● │ Commit E - after J
-│ │ │ │ ● Commit F - after I
-● │ │ │ │ Commit B - after C
-●─╯ │ │ │ Commit C - after G
-● ╭─╯ │ │ Commit G - after H
-● │ ╭─╯ │ Commit H - after I
-●─┴─│───╯ Commit I - after J
+│ │ ∙ │ │ Commit D - after I
+│ │ │ ∙ │ Commit E - after J
+│ │ │ │ ∙ Commit F - after I
+∙ │ │ │ │ Commit B - after C
+∙─╯ │ │ │ Commit C - after G
+∙ ╭─╯ │ │ Commit G - after H
+∙ │ ╭─╯ │ Commit H - after I
+∙─┴─│───╯ Commit I - after J
 ◎───╯ Commit J
 EOF

--- a/test/graph/14-long-collapse-line-test
+++ b/test/graph/14-long-collapse-line-test
@@ -49,23 +49,23 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─┬─┬─┬─╮ Commit A - merge B, C, D, E, F, and G
-│ ● │ │ │ │ Commit C - after B
-│ │ ● │ │ │ Commit D - after B
-│ │ │ ● │ │ Commit E - after B
-│ │ │ │ ● │ Commit F - after B
-●─┴─┴─┴─╯ │ Commit B - after H
+│ ∙ │ │ │ │ Commit C - after B
+│ │ ∙ │ │ │ Commit D - after B
+│ │ │ ∙ │ │ Commit E - after B
+│ │ │ │ ∙ │ Commit F - after B
+∙─┴─┴─┴─╯ │ Commit B - after H
 ●─╭───────╯─╮ Commit H - merge I and G
-● │ ╭───────╯ Commit I - after J
-│ ●─╯ Commit G - after J
-●─╯ Commit J - after K
+∙ │ ╭───────╯ Commit I - after J
+│ ∙─╯ Commit G - after J
+∙─╯ Commit J - after K
 ●─┬─┬─┬─┬─╮ Commit K - merge L, M, N, O, P, and Q
-│ ● │ │ │ │ Commit M - after L
-│ │ ● │ │ │ Commit N - after L
-│ │ │ ● │ │ Commit O - after L
-│ │ │ │ ● │ Commit P - after L
-●─┴─┴─┴─╯ │ Commit L - after R
+│ ∙ │ │ │ │ Commit M - after L
+│ │ ∙ │ │ │ Commit N - after L
+│ │ │ ∙ │ │ Commit O - after L
+│ │ │ │ ∙ │ Commit P - after L
+∙─┴─┴─┴─╯ │ Commit L - after R
 ●─╭───────╯─╮ Commit R - merge S and T
-● │ ╭───────╯ Commit S - after Q
-│ │ ● Commit T - after Q
+∙ │ ╭───────╯ Commit S - after Q
+│ │ ∙ Commit T - after Q
 ◎─┴─╯ Commit Q
 EOF

--- a/test/graph/15-many-merges-test
+++ b/test/graph/15-many-merges-test
@@ -49,23 +49,23 @@ EOF
 
 assert_equals stdout <<EOF
 ●─╮ Commit P - Merge O into N
-│ ● Commit O after M
+│ ∙ Commit O after M
 ●─│─╮ Commit N - Merge M into L
-│ ●─╯ Commit M after K
+│ ∙─╯ Commit M after K
 ●─│─╮ Commit L - Merge K into J
 │ ●─┤ Commit K - Merge J into E
 ●─│─╯ Commit J - Merge F into I
 ●─│─│─╮ Commit I - Merge H into C
-│ │ │ ● Commit H after G
-│ │ ● │ Commit F after C
-│ ● │ │ Commit E after D
+│ │ │ ∙ Commit H after G
+│ │ ∙ │ Commit F after C
+│ ∙ │ │ Commit E after D
 ●─│─┤ │ Commit C - Merge B into A
-│ ● │ │ Commit D after Q
-│ │ ● │ Commit B after R
-│ │ ● │ Commit R after A
-│ ● │ │ Commit Q after X
+│ ∙ │ │ Commit D after Q
+│ │ ∙ │ Commit B after R
+│ │ ∙ │ Commit R after A
+│ ∙ │ │ Commit Q after X
 ●─│─┤ │ Commit A - Merge T into S
-│ │ ● │ Commit T after U
-│ │ ● │ Commit U after V
-│ │ ● │ Commit V after W
+│ │ ∙ │ Commit T after U
+│ │ ∙ │ Commit U after V
+│ │ ∙ │ Commit V after W
 EOF

--- a/test/graph/16-changes-test
+++ b/test/graph/16-changes-test
@@ -16,8 +16,8 @@ commit XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 EOF
 
 assert_equals stdout <<EOF
-● Staged changes
-● Unstaged changes
-● First commit
+∙ Staged changes
+∙ Unstaged changes
+∙ First commit
 ◎ Last commit
 EOF

--- a/test/graph/17-more-merges-test
+++ b/test/graph/17-more-merges-test
@@ -81,18 +81,18 @@ EOF
 
 assert_equals stdout <<EOF
 ●─┬─┬─╮ Commit A - merge B, C, D, and E
-│ │ ● │ Commit D - after B
-│ ● │ │ Commit C - after F
-│ │ │ ● Commit E - after H
+│ │ ∙ │ Commit D - after B
+│ ∙ │ │ Commit C - after F
+│ │ │ ∙ Commit E - after H
 ●─│─┤ │ Commit B - merge H and F
-│ ●─╯ │ Commit F - after G
-│ ● ╭─╯ Commit G - after H
-●─┴─╯ Commit H - after I
+│ ∙─╯ │ Commit F - after G
+│ ∙ ╭─╯ Commit G - after H
+∙─┴─╯ Commit H - after I
 ●─┬─┬─┬─┬─╮ Commit I - merge J, K, L, M, P, and O
-│ ● │ │ │ │ Commit K - after J
-●─╯ │ │ │ │ Commit J - after N
-● ╭─╯ │ │ │ Commit N - after O
-●─│─╭─╯─│─╯ Commit O - after Q
+│ ∙ │ │ │ │ Commit K - after J
+∙─╯ │ │ │ │ Commit J - after N
+∙ ╭─╯ │ │ │ Commit N - after O
+∙─│─╭─╯─│─╯ Commit O - after Q
 ●─│─│─╭─╯─╮ Commit Q - merge R and S
 ●─│─│─│─╭─╯─╮ Commit R - merge T and U
 ●─│─│─│─│─╭─╯─╮ Commit T - merge V and W
@@ -100,13 +100,13 @@ assert_equals stdout <<EOF
 ●─│─│─│─│─│─│─╭─╯─╮ Commit X - merge Y and Z
 │ │ │ │ │ │ ◎─╯ ╭─╯ Commit W
 │ │ ●─│─│─│─╭───╯─┬─╮ Commit M - merge Y, 1, and 2
-│ │ │ ● │ │ │ ╭───╯ │ Commit P - after Y
-│ │ │ │ │ │ ● │ ╭───╯ Commit Z - after Y
-●─│─┴─┴─│─│─╯ │ │ Commit Y - after 1
-●─│─╭───╯─│───╯ │ Commit 1 - after 2
-●─│─│─╭───╯─────╯ Commit 2 - after S
-●─│─╯ │ Commit S - after U
-●─│───╯ Commit U - after 3
+│ │ │ ∙ │ │ │ ╭───╯ │ Commit P - after Y
+│ │ │ │ │ │ ∙ │ ╭───╯ Commit Z - after Y
+∙─│─┴─┴─│─│─╯ │ │ Commit Y - after 1
+∙─│─╭───╯─│───╯ │ Commit 1 - after 2
+∙─│─│─╭───╯─────╯ Commit 2 - after S
+∙─│─╯ │ Commit S - after U
+∙─│───╯ Commit U - after 3
 ●─│─┬─╮ Commit 3 - merge 4, 5, and 8
 ●─│─│─│─╮ Commit 4 - merge 6 and 5
 │ │ ●─│─┤ Commit 5 - merge 7 and 9

--- a/test/graph/18-tig-test
+++ b/test/graph/18-tig-test
@@ -24,12 +24,12 @@ commit b a
 EOF
 
 assert_equals stdout <<EOF
-● Do not include merges in the announcement's change log
+∙ Do not include merges in the announcement's change log
 ●─╮ Merge pull request #81 from esc/fix/reading_git_colors_256
 ●─│─╮ Merge pull request #80 from esc/fix/option_name_mismatch
-● │ │ Reenable copy/rename detection in the status view
-│ │ ● fix: the manpage says 'read-git-colors'
-│ ● │ fix: reading git colors in rang 0 255
-●─┴─╯ Remove enforced diff move/copy detection
-● Optionally show commit IDs for branches and tree entries
+∙ │ │ Reenable copy/rename detection in the status view
+│ │ ∙ fix: the manpage says 'read-git-colors'
+│ ∙ │ fix: reading git colors in rang 0 255
+∙─┴─╯ Remove enforced diff move/copy detection
+∙ Optionally show commit IDs for branches and tree entries
 EOF

--- a/test/graph/19-tig-all-test
+++ b/test/graph/19-tig-all-test
@@ -294,38 +294,38 @@ EOF
 
 assert_equals stdout <<EOF
 ●─╮ On fix-graph: debug printout stuff
-│ ● index on fix-graph: 85e82d0 One more fix
-●─╯ One more fix
-● Another fix
-● Use pre-generated next row
-● Add function to pre-generate next row
-● A little more broken to make it better
-● Always insert extra columns at the end
-● Works for first test case
-● Better, but missing some lines still
-● A little better at the top, a little worse at the bottom
-● Fix reloading diffs of staged and unstaged changes
-● Fix map size assertion in parse_enum
-│ ● Move view draw methods to draw module
-│ ● Move option handling code to options.c
-│ ● Move option declarations to separate files
-│ ● Use symbols to track diff and log argument formatting
-│ ● Group environment-based options
-│ ● Move refs helpers to refs module
-│ ● Move repository information to repo.[ch]
-│ ● Add tool to generate doc from data structures
-│ ● Move view declarations to view.h
-│ ● Move keybinding and run requests to keys.[ch]
-│ ● Move line and color code to line.c
-│ ● Move line definitions to line.h
-│ ● Move request handling code to request.c
-│ ● Move request definitions to request.h
-│ ● Move view macro to tig.h
-│ ● Move enums and various utility methods to util module
-●─╯ Refactor defined enum maps to contain size information
-● Detect renames when generating the announcement
-● Fix warning about uninitialized lineno variable
-● Set the commit reference when opening the blame view from the blob view
-● Fix clean rule to remove DocBook XML files in doc/
-● Fix and improve inter-document linking
+│ ∙ index on fix-graph: 85e82d0 One more fix
+∙─╯ One more fix
+∙ Another fix
+∙ Use pre-generated next row
+∙ Add function to pre-generate next row
+∙ A little more broken to make it better
+∙ Always insert extra columns at the end
+∙ Works for first test case
+∙ Better, but missing some lines still
+∙ A little better at the top, a little worse at the bottom
+∙ Fix reloading diffs of staged and unstaged changes
+∙ Fix map size assertion in parse_enum
+│ ∙ Move view draw methods to draw module
+│ ∙ Move option handling code to options.c
+│ ∙ Move option declarations to separate files
+│ ∙ Use symbols to track diff and log argument formatting
+│ ∙ Group environment-based options
+│ ∙ Move refs helpers to refs module
+│ ∙ Move repository information to repo.[ch]
+│ ∙ Add tool to generate doc from data structures
+│ ∙ Move view declarations to view.h
+│ ∙ Move keybinding and run requests to keys.[ch]
+│ ∙ Move line and color code to line.c
+│ ∙ Move line definitions to line.h
+│ ∙ Move request handling code to request.c
+│ ∙ Move request definitions to request.h
+│ ∙ Move view macro to tig.h
+│ ∙ Move enums and various utility methods to util module
+∙─╯ Refactor defined enum maps to contain size information
+∙ Detect renames when generating the announcement
+∙ Fix warning about uninitialized lineno variable
+∙ Set the commit reference when opening the blame view from the blob view
+∙ Fix clean rule to remove DocBook XML files in doc/
+∙ Fix and improve inter-document linking
 EOF

--- a/test/graph/20-tig-all-long-test
+++ b/test/graph/20-tig-all-long-test
@@ -7,1905 +7,1905 @@
 test_graph < "$source_dir/$test.in"
 
 assert_equals stdout <<EOF
-● tig-2.0.2
-● Fix release script to work for patch versions
-● Fix documentation of author width option
-● Move cursor to the first line when :0 is entered
-│ ● Experimental support for key combos
-│ │ ● Preserve the cursor position when changing the diff context
-●─┴─╯ Improve documentation of view settings in tigrc(5)
-● Improve warning for obsolete view UI options
-● Only use the delimiter character for trimmed and unscrollable text
+∙ tig-2.0.2
+∙ Fix release script to work for patch versions
+∙ Fix documentation of author width option
+∙ Move cursor to the first line when :0 is entered
+│ ∙ Experimental support for key combos
+│ │ ∙ Preserve the cursor position when changing the diff context
+∙─┴─╯ Improve documentation of view settings in tigrc(5)
+∙ Improve warning for obsolete view UI options
+∙ Only use the delimiter character for trimmed and unscrollable text
 ●─╮ Merge remote-tracking branch 'vivien/compat/strndup'
-│ ● argv: revert part of a3079e2
-● │ Ignore 'gui.encoding' and 'i18n.commitencoding' when set to 'UTF-8'
-● │ Use buffer for reading view data
-│ ● compat: add proper work-around for missing strndup
-● │ Use buffer when reading data using io_get()
-●─╯ Fix infinite loop when parsing view columns
-● Never show any actions for a hidden keymap
-● Group option toggle bindings together in the help view
-● Rewrite index diffing to use git-status
-● Improve display of commas and spaces in the help view
-● Fix auto-abbreviation of author names
-│ ● Update for version tig-2.0.1
+│ ∙ argv: revert part of a3079e2
+∙ │ Ignore 'gui.encoding' and 'i18n.commitencoding' when set to 'UTF-8'
+∙ │ Use buffer for reading view data
+│ ∙ compat: add proper work-around for missing strndup
+∙ │ Use buffer when reading data using io_get()
+∙─╯ Fix infinite loop when parsing view columns
+∙ Never show any actions for a hidden keymap
+∙ Group option toggle bindings together in the help view
+∙ Rewrite index diffing to use git-status
+∙ Improve display of commas and spaces in the help view
+∙ Fix auto-abbreviation of author names
+│ ∙ Update for version tig-2.0.1
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-2.0.1
-● │ Improve pretty printing of ',' in the help view
-● │ fix <LessThan> binding support
-● │ Prevent throwing errors if single '^'(circumflex) is used in config
-● │ Fix compilation error in watch.c
-│ ● Update for version tig-2.0
+∙─│─╯ tig-2.0.1
+∙ │ Improve pretty printing of ',' in the help view
+∙ │ fix <LessThan> binding support
+∙ │ Prevent throwing errors if single '^'(circumflex) is used in config
+∙ │ Fix compilation error in watch.c
+│ ∙ Update for version tig-2.0
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-2.0
-● │ Fix typo in refresh-mode: manuel -> manual
-● │ Update NEWS for release
-● │ Show key mappings in the help view using the new syntax
-● │ Change default keybindings
-● │ Don't complete any settings in the section column
-● │ Improve auto-refreshing of views to use various update info
-● │ Add refresh-mode to only update after returning from a command
-● │ Improve error message for unsupported key combos
-● │ Automatically close empty stage views after refreshing
-● │ Mark the help view as refreshable
-● │ Make file-backed blob views refreshable
-● │ Fix line number reporting for configuration errors
-● │ Auto-refresh views when changes are detected in the repository
-● │ Unify view refresh checking
-● │ Tidyup tigrc(5) option descriptions
-● │ Remove unused variable
-● │ Move index update and diff utilities to repo module
-● │ Change key mapping syntax to support key combos
-● │ Test the built-in config for syntax errors
-● │ Load built-in config when TIGRC_SYSTEM is defined but empty
-● │ Fix segfault when no system tigrc is loaded
+∙─│─╯ tig-2.0
+∙ │ Fix typo in refresh-mode: manuel -> manual
+∙ │ Update NEWS for release
+∙ │ Show key mappings in the help view using the new syntax
+∙ │ Change default keybindings
+∙ │ Don't complete any settings in the section column
+∙ │ Improve auto-refreshing of views to use various update info
+∙ │ Add refresh-mode to only update after returning from a command
+∙ │ Improve error message for unsupported key combos
+∙ │ Automatically close empty stage views after refreshing
+∙ │ Mark the help view as refreshable
+∙ │ Make file-backed blob views refreshable
+∙ │ Fix line number reporting for configuration errors
+∙ │ Auto-refresh views when changes are detected in the repository
+∙ │ Unify view refresh checking
+∙ │ Tidyup tigrc(5) option descriptions
+∙ │ Remove unused variable
+∙ │ Move index update and diff utilities to repo module
+∙ │ Change key mapping syntax to support key combos
+∙ │ Test the built-in config for syntax errors
+∙ │ Load built-in config when TIGRC_SYSTEM is defined but empty
+∙ │ Fix segfault when no system tigrc is loaded
 ●─│─╮ Merge pull request #278 from swegener/for-upstream
-│ │ ● read built-in config with continuation support
-●─│─╯ Move git color mappings to tigrc
-● │ Allow tigrc commands to span multiple lines
-● │ Update tigrc(5) to reflect new view header color
-● │ Fix refreshing of the stage view after updates
-● │ Add %(remote) and %(tag) variables
-● │ Remove dead initializations
-│ │ ● Change default keybindings
-│ │ ● Don't complete any settings in the section column
-●─│─╯ Toggling of the column name will toggle the display setting
-● │ Rename the 'show' column setting to 'display'
-● │ Improve staged diffs to detect copying and not show unmerged files
-● │ Make diff stat line parsing more robust
-● │ Use stage view to show changes commits
-● │ Refactor refresh code between stage and status view
-● │ Move stage status information to the stage module
-● │ Add changes commits in main_open
-● │ Fix collapsing of unmerged entries in the status view
-● │ Fix backspace in the prompt
-● │ Add long status label type
-● │ Use blame commit filename instead of view vid buffer
-● │ Read git diff.context option
-● │ Do not set diff-context option by default
-● │ Unify jump-to-commit feature using the view ID column
-● │ Add reflog member to the column_data struct
-● │ Introduce common section color
-● │ Introduce common header color
-● │ Fix documentation for the file color
-● │ Parse color.grep.{filename,linenumber,separator} from git config
-● │ Use "--" as the separator in the grep view
-● │ Rewrite git color parsing to support multiple mappings per color
-● │ Align relative dates to the right
-● │ Use status messages in the prompt code
-● │ Fix column option parsing by prefixing option names with the column name
-● │ Expose toggle_prompt_name() as enum_name_prefixed()
-● │ Unify enum_name and enum_name_static
-● │ Fix parsing of show-notes option
-● │ Really parse --notes command line argument
-● │ Add support for toggling the mouse option
-● │ Remove bold formatting from view column section in tigrc(5)
-● │ Add mapping for --author-date-order to commit-order
-● │ Fix width calculation of the pager views' line number column
-● │ Fix compilation failure when readline is enabled
-● │ Switch status view to use column-based drawing backend
-● │ Move commit title drawing to draw_commit_title
-● │ Move ref column drawing to draw_ref
-● │ Pass column to draw_mode and honor the show and width settings
-● │ Make view columns configurable
-● │ Colorize Tagger and TaggerDate lines
-● │ Parse --no-notes and --notes arguments given on the command line
-● │ Use OPTION_INFO data for parsing options
-● │ Rename the variable used for the filename-width option
-● │ Classify title-overflow option as a view column option
-● │ Use column option when checking whether to redraw after reflog width change
-● │ Use column option when checking whether to grep commit refs
-● │ Use column option when checking whether to sort by ID
-● │ Fix option name for toggling of reference display in the option menu
-● │ Refactor toggling of commit title overflow
-● │ log: add '_' to the list of --graph characters
-● │ Fix all remaining mentions of branch keymap to refs keymap
-● │ Extend reference-format setting to support hiding refs based on type
-● │ Update %(branch) when a branch is selected
-● │ Add bindings for \`!\` to delete branch and drop stash
-● │ log: add support for --graph
-● │ Switch log, diff and stage views to use column-based draw backend
-● │ log: colour the diff stat
-● │ diff: move diff stat drawing to a common function
-● │ diff: move diff stat addition to a common function
-● │ view: replace line user_flags with no_commit_refs and commit_title flags
-● │ keys: rename key_input_to_unicode to key_to_unicode
-● │ display: correctly recognize Ctrl-y as a key
-● │ prompt: expose API to incrementally receive key events
-● │ prompt: introduce struct input to hold the context
-● │ keys: prepare to read multi key combos
-● │ prompt: extract default edit keybindings to separate method
-● │ keys: rename struct key_input to struct key
-● │ view: add common utility for generating column text
-● │ grep: allow to toggle whether to group by file name
-● │ grep: use column-based drawing
-● │ blame: switch to use view_column_draw
-● │ view: make options private to each view
-● │ Add config.h as a dependency for all object files
-● │ prefer the already linked curses lib for termcap
-● │ special case count_digits for zero
-● │ Fix clang format string warnings
-● │ Improve autoconf checking for readline on Mac OS X
-● │ tree: don't assume path to parent is the second view line
-● │ view: move all line number logic to view column
-● │ view: use columns for grep view
-● │ view: use columns for pager based views
-● │ Add missing tools/ax_lib_readline.m4 file
-● │ Fix warning about unused read_prompt_handler
+│ │ ∙ read built-in config with continuation support
+∙─│─╯ Move git color mappings to tigrc
+∙ │ Allow tigrc commands to span multiple lines
+∙ │ Update tigrc(5) to reflect new view header color
+∙ │ Fix refreshing of the stage view after updates
+∙ │ Add %(remote) and %(tag) variables
+∙ │ Remove dead initializations
+│ │ ∙ Change default keybindings
+│ │ ∙ Don't complete any settings in the section column
+∙─│─╯ Toggling of the column name will toggle the display setting
+∙ │ Rename the 'show' column setting to 'display'
+∙ │ Improve staged diffs to detect copying and not show unmerged files
+∙ │ Make diff stat line parsing more robust
+∙ │ Use stage view to show changes commits
+∙ │ Refactor refresh code between stage and status view
+∙ │ Move stage status information to the stage module
+∙ │ Add changes commits in main_open
+∙ │ Fix collapsing of unmerged entries in the status view
+∙ │ Fix backspace in the prompt
+∙ │ Add long status label type
+∙ │ Use blame commit filename instead of view vid buffer
+∙ │ Read git diff.context option
+∙ │ Do not set diff-context option by default
+∙ │ Unify jump-to-commit feature using the view ID column
+∙ │ Add reflog member to the column_data struct
+∙ │ Introduce common section color
+∙ │ Introduce common header color
+∙ │ Fix documentation for the file color
+∙ │ Parse color.grep.{filename,linenumber,separator} from git config
+∙ │ Use "--" as the separator in the grep view
+∙ │ Rewrite git color parsing to support multiple mappings per color
+∙ │ Align relative dates to the right
+∙ │ Use status messages in the prompt code
+∙ │ Fix column option parsing by prefixing option names with the column name
+∙ │ Expose toggle_prompt_name() as enum_name_prefixed()
+∙ │ Unify enum_name and enum_name_static
+∙ │ Fix parsing of show-notes option
+∙ │ Really parse --notes command line argument
+∙ │ Add support for toggling the mouse option
+∙ │ Remove bold formatting from view column section in tigrc(5)
+∙ │ Add mapping for --author-date-order to commit-order
+∙ │ Fix width calculation of the pager views' line number column
+∙ │ Fix compilation failure when readline is enabled
+∙ │ Switch status view to use column-based drawing backend
+∙ │ Move commit title drawing to draw_commit_title
+∙ │ Move ref column drawing to draw_ref
+∙ │ Pass column to draw_mode and honor the show and width settings
+∙ │ Make view columns configurable
+∙ │ Colorize Tagger and TaggerDate lines
+∙ │ Parse --no-notes and --notes arguments given on the command line
+∙ │ Use OPTION_INFO data for parsing options
+∙ │ Rename the variable used for the filename-width option
+∙ │ Classify title-overflow option as a view column option
+∙ │ Use column option when checking whether to redraw after reflog width change
+∙ │ Use column option when checking whether to grep commit refs
+∙ │ Use column option when checking whether to sort by ID
+∙ │ Fix option name for toggling of reference display in the option menu
+∙ │ Refactor toggling of commit title overflow
+∙ │ log: add '_' to the list of --graph characters
+∙ │ Fix all remaining mentions of branch keymap to refs keymap
+∙ │ Extend reference-format setting to support hiding refs based on type
+∙ │ Update %(branch) when a branch is selected
+∙ │ Add bindings for \`!\` to delete branch and drop stash
+∙ │ log: add support for --graph
+∙ │ Switch log, diff and stage views to use column-based draw backend
+∙ │ log: colour the diff stat
+∙ │ diff: move diff stat drawing to a common function
+∙ │ diff: move diff stat addition to a common function
+∙ │ view: replace line user_flags with no_commit_refs and commit_title flags
+∙ │ keys: rename key_input_to_unicode to key_to_unicode
+∙ │ display: correctly recognize Ctrl-y as a key
+∙ │ prompt: expose API to incrementally receive key events
+∙ │ prompt: introduce struct input to hold the context
+∙ │ keys: prepare to read multi key combos
+∙ │ prompt: extract default edit keybindings to separate method
+∙ │ keys: rename struct key_input to struct key
+∙ │ view: add common utility for generating column text
+∙ │ grep: allow to toggle whether to group by file name
+∙ │ grep: use column-based drawing
+∙ │ blame: switch to use view_column_draw
+∙ │ view: make options private to each view
+∙ │ Add config.h as a dependency for all object files
+∙ │ prefer the already linked curses lib for termcap
+∙ │ special case count_digits for zero
+∙ │ Fix clang format string warnings
+∙ │ Improve autoconf checking for readline on Mac OS X
+∙ │ tree: don't assume path to parent is the second view line
+∙ │ view: move all line number logic to view column
+∙ │ view: use columns for grep view
+∙ │ view: use columns for pager based views
+∙ │ Add missing tools/ax_lib_readline.m4 file
+∙ │ Fix warning about unused read_prompt_handler
 ●─│─╮ Merge branch 'readline'
-│ │ ● Introduce the GNU Readline support
-● │ │ branch: use reference comparator from refdb module for sorting
-● │ │ view: fix number comparision
-● │ │ view: fix comparison of modes when sorting by file name
-● │ │ view: limit sorting to only the branch and tree view
-● │ │ tree: update line number when inserting tree entries
-● │ │ log: pass all filter arguments from command line to git-log
-● │ │ view: add auto-sizing logic for the ID column
-● │ │ Fix crash when tigrc is absent
-● │ │ main: use open_in_pager_mode()
-● │ │ io: show stderr for external commands run via the prompt
-● │ │ io: ad io_flags enum to better handle IO_RD modes
-● │ │ blame: move functionality to colorize ID to draw_id()
-● │ │ blame: improve handling of file name visibility
-● │ │ blame: detect file name display on the fly
-● │ │ view: rename toggle option variables
-● │ │ view: move prompt toggle lookup to separate method
-● │ │ view: move find_enum_map to enum module
-● │ │ Improve configuration error messages
-● │ │ view: use common infrastructure for remapping obsolete request names
-● │ │ view: ensure that width variable is always initialized
-● │ │ view: clean up mode handling in view_column_draw
-● │ │ view: make the date width adaptive
-● │ │ view: introduce column specific options
-● │ │ view: introduce struct view_column
-● │ │ view: rename view_columns_ method to have view_column_ prefix
-● │ │ view: rename enum view_column to view_column_type
-● │ │ view: rename struct view_columns to view_column_data
-│ │ ● display: expose status_win and opt_tty
-│ │ ● argv: introduce argv_format_arg()
-●─│─╯ search: replace stage-next action with predefined search prompt command
-● │ search: show number of matches and the current match index
-● │ view: fix drawing of ID column
-● │ tigrc: revert unintended removal of stage-next
-● │ refs: update documentation to reflect branch view renaming
-● │ refs: show list of tags and use numeric sort order by default
-● │ refs: make reference formats configurable
-● │ refs: move ref format string lookup to separate method
-● │ refs: replace flags with reference enum type
-● │ draw: make methods only used internally static
-● │ draw: move view_columns_draw to draw module
-● │ view: remove refs and graphs from the view column enum
-● │ main: fix segfault introduced in last change
-● │ main: use --pretty=raw format if reflog output is requested
-● │ options: enable graph when --graph is passed
-● │ argv: separate git log parameters from diff parameters
-● │ repo: workaround empty --show-prefix output from certain git versions
-● │ refs: use refs_ prefix for internal methods and variables
-● │ refs: rename branch view to refs view
-● │ refs: rename refs module to refdb
-● │ tree: use directory and file line types
-● │ tree: add directory color type for use by draw_filename
-● │ options: reuse color name parser for obsolete color mappings
-● │ Check return value from signal()
-● │ Use email instead of name as the key in the author ident cache
-● │ blame: parse author email to support author toggling
-● │ prompt: fix cursor position for prompts longer than one character
-● │ help: support refreshing to show new bindings added via the prompt
-● │ Refactor loading of views that are not associated with any view state
-● │ Fix calculation of line number for first line in file
-● │ Skip confirmation step when editor reports no error
-● │ configure: only pass bug email to AC_INIT
-● │ view: clean up utf8_width() API
-● │ view: adjust file name width automatically
-● │ view: update branch view columns when commit data is loaded
-● │ view: fix regression when loading the help view
-● │ view: calculate column width using utf8_width()
-● │ view: adjust author width automatically
-● │ view: implement view columns for blame view and use for grepping
-● │ view: recalculate widths when options are toggled
-● │ tree: update columns width when commit data has been loaded
-● │ view: never reset the private state when changing between views
-● │ view: extract code for checking whether to refresh a view
-● │ main: use custom pretty format to speed up loading
-● │ view: add line-number column type to allow natural sorting order
-● │ view: use view columns infra for the main and stash views
-● │ view: rename view columns title to commit title
-● │ view: add draw infrastructure for column based views
-● │ view: rewrite branch_read to read commit info in one shot
-● │ view: move io_memchr() to the io module
-● │ view: add more view column types for the branch and tree view
-● │ view: add generic grep implementation based on view columns
-● │ view: rename sort_field enum to view_column
-● │ view: make columns method and sort fields part of view ops
-● │ view: move sort comparision to view module
-● │ stage: fix call to string_copy with string pointer
-● │ view: make views[] array private
-● │ view: move keymap definition out from view_ops
-● │ view: remove VIEW() macro
-● │ view: add custom open methods for each view
-● │ view: move view declarations to respective modules
-● │ Add compatibility mappings for obsolete color names
-● │ Fix segfaults for :toggle commands without arguments
-● │ prompt: print sort field and order information when toggled
-● │ prompt: convert sort actions to :toggle commands
-│ │ ● Restrict cursor navigation to actionable lines
-●─│─╯ grep: fix detection of initial view in open_grep_view()
-● │ Fix toggle binding for show-filename
-● │ Restore prompt position behavior
-● │ status: fix staging of untracked directories
-● │ help: show external command flags before the command
-● │ help: display internal commands in a separate group
-● │ Allow prompt toggle commands to both reset display and reload
-● │ Support unicode characters for :<key>
-● │ Fix regression in handling of :<key>
-● │ Fix blame opening from (un)staged changes diff view (part II)
-● │ Remove redundant lines
-● │ Fix blame opening from (un)staged changes diff view
-● │ Set COLUMNS env variable after vertical split calculation
-● │ prompt: convert diff-context actions to :toggle commands
-● │ prompt: use :toggle binding for diff context manipulation
-● │ prompt: introduce :toggle command
-● │ prompt: add file-filter option
-● │ prompt: refactor enum name utilities
-● │ prompt: introduce a macro for listing all enums
-● │ prompt: allow search patterns with spaces in them
-● │ prompt: pass argv parameter to run_prompt_command
-● │ prompt: move code to new prompt module
-● │ prompt: refactor the jump-to-commit implementation
-● │ prompt: move report() call from argv_format() to call site
-● │ Remove input field from struct run_request
-● │ Move run request flags parsing to add_run_request
-● │ Rewrite the help view
-● │ Fix loading of git command output in the pager view
-● │ Resize and redraw the display after prompt :set commands
-● │ Remove field width digit from draw line number format string
-● │ Rewrite stage-update-line to include the diff context from the chunk
-● │ Fix install script to not print anything in verbose mode
-● │ Make iscommit take const string
-● │ help: fix display of external commands
-● │ grep: use --full-name so it works from sub-directories
-● │ Fix prompt-based searching to always use initial search request
-● │ Extend key bindings for prompt commands to support predefined searches
-● │ Check cmd argument upfront in run_prompt_command
-● │ Travis tests: compile with verbose flag using both clang and gcc
-● │ Travis tests: minor reorganization
-● │ Fix rendering in non-UTF8 terminals
-● │ Do not ignore characters that cannot be transliterated
-● │ Fallback to use file(1) to determine file encoding
-● │ Warn about conflicting keybindings using Ctrl
-● │ Add docbook-utils to the list of required packages for travis
+│ │ ∙ Introduce the GNU Readline support
+∙ │ │ branch: use reference comparator from refdb module for sorting
+∙ │ │ view: fix number comparision
+∙ │ │ view: fix comparison of modes when sorting by file name
+∙ │ │ view: limit sorting to only the branch and tree view
+∙ │ │ tree: update line number when inserting tree entries
+∙ │ │ log: pass all filter arguments from command line to git-log
+∙ │ │ view: add auto-sizing logic for the ID column
+∙ │ │ Fix crash when tigrc is absent
+∙ │ │ main: use open_in_pager_mode()
+∙ │ │ io: show stderr for external commands run via the prompt
+∙ │ │ io: ad io_flags enum to better handle IO_RD modes
+∙ │ │ blame: move functionality to colorize ID to draw_id()
+∙ │ │ blame: improve handling of file name visibility
+∙ │ │ blame: detect file name display on the fly
+∙ │ │ view: rename toggle option variables
+∙ │ │ view: move prompt toggle lookup to separate method
+∙ │ │ view: move find_enum_map to enum module
+∙ │ │ Improve configuration error messages
+∙ │ │ view: use common infrastructure for remapping obsolete request names
+∙ │ │ view: ensure that width variable is always initialized
+∙ │ │ view: clean up mode handling in view_column_draw
+∙ │ │ view: make the date width adaptive
+∙ │ │ view: introduce column specific options
+∙ │ │ view: introduce struct view_column
+∙ │ │ view: rename view_columns_ method to have view_column_ prefix
+∙ │ │ view: rename enum view_column to view_column_type
+∙ │ │ view: rename struct view_columns to view_column_data
+│ │ ∙ display: expose status_win and opt_tty
+│ │ ∙ argv: introduce argv_format_arg()
+∙─│─╯ search: replace stage-next action with predefined search prompt command
+∙ │ search: show number of matches and the current match index
+∙ │ view: fix drawing of ID column
+∙ │ tigrc: revert unintended removal of stage-next
+∙ │ refs: update documentation to reflect branch view renaming
+∙ │ refs: show list of tags and use numeric sort order by default
+∙ │ refs: make reference formats configurable
+∙ │ refs: move ref format string lookup to separate method
+∙ │ refs: replace flags with reference enum type
+∙ │ draw: make methods only used internally static
+∙ │ draw: move view_columns_draw to draw module
+∙ │ view: remove refs and graphs from the view column enum
+∙ │ main: fix segfault introduced in last change
+∙ │ main: use --pretty=raw format if reflog output is requested
+∙ │ options: enable graph when --graph is passed
+∙ │ argv: separate git log parameters from diff parameters
+∙ │ repo: workaround empty --show-prefix output from certain git versions
+∙ │ refs: use refs_ prefix for internal methods and variables
+∙ │ refs: rename branch view to refs view
+∙ │ refs: rename refs module to refdb
+∙ │ tree: use directory and file line types
+∙ │ tree: add directory color type for use by draw_filename
+∙ │ options: reuse color name parser for obsolete color mappings
+∙ │ Check return value from signal()
+∙ │ Use email instead of name as the key in the author ident cache
+∙ │ blame: parse author email to support author toggling
+∙ │ prompt: fix cursor position for prompts longer than one character
+∙ │ help: support refreshing to show new bindings added via the prompt
+∙ │ Refactor loading of views that are not associated with any view state
+∙ │ Fix calculation of line number for first line in file
+∙ │ Skip confirmation step when editor reports no error
+∙ │ configure: only pass bug email to AC_INIT
+∙ │ view: clean up utf8_width() API
+∙ │ view: adjust file name width automatically
+∙ │ view: update branch view columns when commit data is loaded
+∙ │ view: fix regression when loading the help view
+∙ │ view: calculate column width using utf8_width()
+∙ │ view: adjust author width automatically
+∙ │ view: implement view columns for blame view and use for grepping
+∙ │ view: recalculate widths when options are toggled
+∙ │ tree: update columns width when commit data has been loaded
+∙ │ view: never reset the private state when changing between views
+∙ │ view: extract code for checking whether to refresh a view
+∙ │ main: use custom pretty format to speed up loading
+∙ │ view: add line-number column type to allow natural sorting order
+∙ │ view: use view columns infra for the main and stash views
+∙ │ view: rename view columns title to commit title
+∙ │ view: add draw infrastructure for column based views
+∙ │ view: rewrite branch_read to read commit info in one shot
+∙ │ view: move io_memchr() to the io module
+∙ │ view: add more view column types for the branch and tree view
+∙ │ view: add generic grep implementation based on view columns
+∙ │ view: rename sort_field enum to view_column
+∙ │ view: make columns method and sort fields part of view ops
+∙ │ view: move sort comparision to view module
+∙ │ stage: fix call to string_copy with string pointer
+∙ │ view: make views[] array private
+∙ │ view: move keymap definition out from view_ops
+∙ │ view: remove VIEW() macro
+∙ │ view: add custom open methods for each view
+∙ │ view: move view declarations to respective modules
+∙ │ Add compatibility mappings for obsolete color names
+∙ │ Fix segfaults for :toggle commands without arguments
+∙ │ prompt: print sort field and order information when toggled
+∙ │ prompt: convert sort actions to :toggle commands
+│ │ ∙ Restrict cursor navigation to actionable lines
+∙─│─╯ grep: fix detection of initial view in open_grep_view()
+∙ │ Fix toggle binding for show-filename
+∙ │ Restore prompt position behavior
+∙ │ status: fix staging of untracked directories
+∙ │ help: show external command flags before the command
+∙ │ help: display internal commands in a separate group
+∙ │ Allow prompt toggle commands to both reset display and reload
+∙ │ Support unicode characters for :<key>
+∙ │ Fix regression in handling of :<key>
+∙ │ Fix blame opening from (un)staged changes diff view (part II)
+∙ │ Remove redundant lines
+∙ │ Fix blame opening from (un)staged changes diff view
+∙ │ Set COLUMNS env variable after vertical split calculation
+∙ │ prompt: convert diff-context actions to :toggle commands
+∙ │ prompt: use :toggle binding for diff context manipulation
+∙ │ prompt: introduce :toggle command
+∙ │ prompt: add file-filter option
+∙ │ prompt: refactor enum name utilities
+∙ │ prompt: introduce a macro for listing all enums
+∙ │ prompt: allow search patterns with spaces in them
+∙ │ prompt: pass argv parameter to run_prompt_command
+∙ │ prompt: move code to new prompt module
+∙ │ prompt: refactor the jump-to-commit implementation
+∙ │ prompt: move report() call from argv_format() to call site
+∙ │ Remove input field from struct run_request
+∙ │ Move run request flags parsing to add_run_request
+∙ │ Rewrite the help view
+∙ │ Fix loading of git command output in the pager view
+∙ │ Resize and redraw the display after prompt :set commands
+∙ │ Remove field width digit from draw line number format string
+∙ │ Rewrite stage-update-line to include the diff context from the chunk
+∙ │ Fix install script to not print anything in verbose mode
+∙ │ Make iscommit take const string
+∙ │ help: fix display of external commands
+∙ │ grep: use --full-name so it works from sub-directories
+∙ │ Fix prompt-based searching to always use initial search request
+∙ │ Extend key bindings for prompt commands to support predefined searches
+∙ │ Check cmd argument upfront in run_prompt_command
+∙ │ Travis tests: compile with verbose flag using both clang and gcc
+∙ │ Travis tests: minor reorganization
+∙ │ Fix rendering in non-UTF8 terminals
+∙ │ Do not ignore characters that cannot be transliterated
+∙ │ Fallback to use file(1) to determine file encoding
+∙ │ Warn about conflicting keybindings using Ctrl
+∙ │ Add docbook-utils to the list of required packages for travis
 ●─│─╮ Merge pull request #252 from dmalikov/travis-support
-● │ │ Add quiet make mode
-● │ │ Add multibyte support to struct key_input
-● │ │ Introduce struct key_input
-● │ │ Remove end parameter from utf8_char_length
-● │ │ Disable graph rendering for -G and --grep=
-│ │ ● Add travis support, remove failed test
-●─│─╯ Always handle options linked to git arguments
-● │ Add method accessor for --show-notes argument
-● │ Introduce methods for accessing dynamic arguments
-● │ Fix include of "config.h"
-● │ tigrc(5): also document Ctrl-i conflicting with Tab
-● │ tigrc(5): document Ctrl and ESC key mappings
-● │ make-builtin-config.sh: trim trailing space before comments
-● │ Remove the RUN_REQUEST_FORCE flag
-● │ Switch to vertical split when the display width exceeds 160 columns
-● │ Move allocation helper and misc utils to util module
-● │ Remove string macros which are defined in the header file
-● │ Move string and utf8 utilities to new string module
-● │ Move header files to include/tig
-● │ Alphabetize and tidyup .gitignore
-● │ Remove debug io_trace calls
-● │ Improve opening of the blame view from the grep view
-● │ Add support for opening grep view from any view
-● │ Add grep view as a front-end to git-grep(1)
-● │ Add support for view specific colors
-● │ Update draw header
-● │ Macrotize argument env variables
-● │ Rename view_env to argv_env and format_argv to argv_format
-● │ Move format_argv to argv module
-● │ Move argument array helpers to new argv module
-● │ Fix memory corruption causing tree entry modes to be displayed incorrectly
-● │ Restore the die_callback so die messages are displayed properly
-● │ Improve support for -Ssearch in the main view
+∙ │ │ Add quiet make mode
+∙ │ │ Add multibyte support to struct key_input
+∙ │ │ Introduce struct key_input
+∙ │ │ Remove end parameter from utf8_char_length
+∙ │ │ Disable graph rendering for -G and --grep=
+│ │ ∙ Add travis support, remove failed test
+∙─│─╯ Always handle options linked to git arguments
+∙ │ Add method accessor for --show-notes argument
+∙ │ Introduce methods for accessing dynamic arguments
+∙ │ Fix include of "config.h"
+∙ │ tigrc(5): also document Ctrl-i conflicting with Tab
+∙ │ tigrc(5): document Ctrl and ESC key mappings
+∙ │ make-builtin-config.sh: trim trailing space before comments
+∙ │ Remove the RUN_REQUEST_FORCE flag
+∙ │ Switch to vertical split when the display width exceeds 160 columns
+∙ │ Move allocation helper and misc utils to util module
+∙ │ Remove string macros which are defined in the header file
+∙ │ Move string and utf8 utilities to new string module
+∙ │ Move header files to include/tig
+∙ │ Alphabetize and tidyup .gitignore
+∙ │ Remove debug io_trace calls
+∙ │ Improve opening of the blame view from the grep view
+∙ │ Add support for opening grep view from any view
+∙ │ Add grep view as a front-end to git-grep(1)
+∙ │ Add support for view specific colors
+∙ │ Update draw header
+∙ │ Macrotize argument env variables
+∙ │ Rename view_env to argv_env and format_argv to argv_format
+∙ │ Move format_argv to argv module
+∙ │ Move argument array helpers to new argv module
+∙ │ Fix memory corruption causing tree entry modes to be displayed incorrectly
+∙ │ Restore the die_callback so die messages are displayed properly
+∙ │ Improve support for -Ssearch in the main view
 ●─│─╮ Merge pull request #247 from peff/no-diff-boundary
-│ │ ● remove \`--boundary\` from \`%(cmdlineargs)\`
-●─│─╯ Add macro to check if initial views failed to load
-● │ Add io_trace method for debug printing to trace file
-● │ Move blame option handling to blame module
-● │ Fix pager mode error message
-● │ Get rid of the signal handler all together
-● │ Do not call endwin nor exit from signal handler
-● │ Remove view_ops define and #include view backend header files
-● │ Move stash view to new stash module
-● │ Move main view to new main module
-● │ Move stage view to new stage module
-● │ Move status view to new status module
-● │ Move branch view to new branch module
-● │ Move blame view to new blame module
-● │ Move blob view to new blob module
-● │ Move tree view to new tree module
-● │ Move help view to new help module
-● │ Move diff view to new diff module
-● │ Move log view to new log module
-● │ Move pager core to new pager module
-● │ Move view parsing code to new parse module
-● │ Move common view code to view module
-● │ Move display and status code to new display module
-● │ Move apply_step to tig header
-● │ Add title window field to struct view and move window declarations
-● │ Add struct view_env for storing shared state between views
-● │ Move view->id to view->ops->id
-● │ Remove opt_lineno in favour of opt_goto_line
-● │ Move drawing methods to new draw module
+│ │ ∙ remove \`--boundary\` from \`%(cmdlineargs)\`
+∙─│─╯ Add macro to check if initial views failed to load
+∙ │ Add io_trace method for debug printing to trace file
+∙ │ Move blame option handling to blame module
+∙ │ Fix pager mode error message
+∙ │ Get rid of the signal handler all together
+∙ │ Do not call endwin nor exit from signal handler
+∙ │ Remove view_ops define and #include view backend header files
+∙ │ Move stash view to new stash module
+∙ │ Move main view to new main module
+∙ │ Move stage view to new stage module
+∙ │ Move status view to new status module
+∙ │ Move branch view to new branch module
+∙ │ Move blame view to new blame module
+∙ │ Move blob view to new blob module
+∙ │ Move tree view to new tree module
+∙ │ Move help view to new help module
+∙ │ Move diff view to new diff module
+∙ │ Move log view to new log module
+∙ │ Move pager core to new pager module
+∙ │ Move view parsing code to new parse module
+∙ │ Move common view code to view module
+∙ │ Move display and status code to new display module
+∙ │ Move apply_step to tig header
+∙ │ Add title window field to struct view and move window declarations
+∙ │ Add struct view_env for storing shared state between views
+∙ │ Move view->id to view->ops->id
+∙ │ Remove opt_lineno in favour of opt_goto_line
+∙ │ Move drawing methods to new draw module
 ●─│─╮ Merge pull request #244 from tullmann/patch-1
-● │ │ Move option loading to new options module
-│ │ ● Update INSTALL.adoc
-● │ │ Instanciate option variables using a macro
-● │ │ Rename option variables to match their option names
-● │ │ Fix title-overflow regression by special casing it inside toggle_option
-●─│─╯ Parse git's combined diff format so edit works for unmerged files
-● │ Add missing return value to the doc-gen tool's main method
-● │ Move struct line to view header and fix includes
-● │ Fix vertical split regression by hardcoding the split parameter
-● │ Fix author and date annotation of renamed entries in the tree view
-● │ Update copyright and use jonas.fonseca@gmail.com as main contact email
-● │ Add tool to generate doc from data structures
-● │ Move refs helpers to refs module
-● │ Move repository information to new repo module
-● │ Move view declarations to new view header
-● │ Move keybinding and run requests to new keys module
-● │ Move line info and color code to new line module
-● │ Move request code to new request module
-● │ Move view macro to include/tig.h
-● │ Move Git data formatters and parsers to util module
-● │ Move enum definitions to new types module
-● │ Move source files to src and include folder
-● │ Delete contrib/tigrc now obsolete by tigrc
-● │ Move default settings to tigrc
-● │ Move default color settings to tigrc
-● │ Add tigrc copy as a fallback inside the binary
-● │ Move default keybindings including shell commands to external tigrc file
-● │ Move test-graph tool to the test folder
-● │ Fix graph rendering of staged and unstaged changes
-● │ Minor code tidyup
-● │ Add support for specifying custom prompt for %(prompt)
-● │ Abandon the %(prompt) when the user escapes it
-● │ Only refresh views that support it after running a shell command
-● │ Fix log view to handle repositories containing a file named HEAD
-● │ Update %(branch) to point to current branch in the main view
-● │ Improve opening of blame view from the stage view
-● │ Don't open blame view for untracked files in the status and stage view
-● │ Fix diff-options to only be considered for the diff view
-● │ Fix staged view when file called "HEAD" exists
-● │ Pass arguments in filter_options()
-● │ Parse -U argument and update internal diff context state
-● │ Disable graph drawing for reverse log order
-● │ Preprocess known toggleable options arguments in filter_options
-● │ Rewrite much of the graph code
-● │ Add ZSH autocomplete compatibility
-● │ Fix lookup of run requests
-● │ Fix off-by-one error for status code message lookup
-● │ Actually disable mouse support
-● │ Disable mouse support by default since it breaks copying text from the terminal
-● │ Fix diff stat highlighting of file with no changes
-● │ Add mouse support
-● │ Fix run request ID offset to never conflict with internal request IDs
-● │ Fix diff stat hightlighting for files with no changes
-● │ Add toggle=vertical=split action to dynamically change the split orientation
-● │ Align the view scroll percentage to the right
-● │ Fix issue with creation of .deps directory after upgrade to Mac OS 10.9
-● │ Add "auto" vertical-split
-● │ graph: uncomment is_boundary propagation
-● │ parse commit marks more leniently
-● │ Fix reloading diffs of staged and unstaged changes
-● │ Fix map size assertion in parse_enum
-● │ Refactor defined enum maps to contain size information
-● │ Detect renames when generating the announcement
-● │ Fix warning about uninitialized lineno variable
-● │ Set the commit reference when opening the blame view from the blob view
-● │ Fix clean rule to remove DocBook XML files in doc/
-● │ Fix and improve inter-document linking
-● │ Rename README, INSTALL, and NEWS to end in .adoc
-● │ Use .adoc as the extension for AsciiDoc files in doc/
-● │ Merge the content of BUGS into the README file
-● │ Fix regression in add_line_at making line numbers start atf 0 instead of 1
-● │ Fix regression in diff_get_lineno
-● │ Fix regression making diff parsing fail when opening the blame view
-● │ Make blame_draw check if the filename is NULL instead of empty
-● │ Handle diffs with no newline at end of file
-● │ Add support for splitting chunks in the stage view
-● │ Add common utility for parsing chunk headers
-● │ Introduce a path cache and use it for the blame view
-● │ Fix blame_go_back to copy the whole file path
-● │ Fix handling of combining characters in utf8_length() when reserve==TRUE.
-● │ Implement navigating back to previous view state in the blame view
-● │ Create a commit view history API based on the tree view stack
-● │ Free all cached list of reference when reloading the references
-● │ Move warn and die to the util module
-● │ Move error messages to new util module
-● │ Move get_temp_dir to io module
-● │ Move encoding utilities to the io module
-● │ Fix regression making the status view inaccessible for new repositories
-● │ Fix \`make dist\` to support versions with more than 2 digit groups
-● │ tig(1): document the Git commands supported by the pager mode
-● │ Load main view from any --pretty=raw output given on stdin
-● │ Refactor the pager mode handling
-● │ Simplify checking of --stdin argument
-● │ Generalize and move parsing of reflog info into main_read
-● │ Use memset to clear the format buffer
-● │ Add toggling for display of files in untracked directories
-● │ Improve option toggling to update all displayed view
-● │ Pass CFLAGS to linker
-● │ Move release scripts, test programs and maintainer files to new tools directory
-● │ Switch to automatically generate dependencies
-● │ Disabled colors last when passing user supplied arguments to Git
-● │ Optionally load HEAD when loading references
-● │ Load HEAD ID and symbolic name as part of the repo info
-● │ Add auto-configuration for Cygwin
-● │ Rewrite the toggle menu setup macro code to fix compile error
-● │ Fix stash diff display after deleting a stash
-● │ Make digit counting reusable
-● │ Make the prompt for user-defined commands tell when Tig will exit
-● │ User-defined commands no longer need to be prefixed with '!'
-● │ tigrc(5): rework the keybinding section
-│ ● Update for version tig-1.2.1
+∙ │ │ Move option loading to new options module
+│ │ ∙ Update INSTALL.adoc
+∙ │ │ Instanciate option variables using a macro
+∙ │ │ Rename option variables to match their option names
+∙ │ │ Fix title-overflow regression by special casing it inside toggle_option
+∙─│─╯ Parse git's combined diff format so edit works for unmerged files
+∙ │ Add missing return value to the doc-gen tool's main method
+∙ │ Move struct line to view header and fix includes
+∙ │ Fix vertical split regression by hardcoding the split parameter
+∙ │ Fix author and date annotation of renamed entries in the tree view
+∙ │ Update copyright and use jonas.fonseca@gmail.com as main contact email
+∙ │ Add tool to generate doc from data structures
+∙ │ Move refs helpers to refs module
+∙ │ Move repository information to new repo module
+∙ │ Move view declarations to new view header
+∙ │ Move keybinding and run requests to new keys module
+∙ │ Move line info and color code to new line module
+∙ │ Move request code to new request module
+∙ │ Move view macro to include/tig.h
+∙ │ Move Git data formatters and parsers to util module
+∙ │ Move enum definitions to new types module
+∙ │ Move source files to src and include folder
+∙ │ Delete contrib/tigrc now obsolete by tigrc
+∙ │ Move default settings to tigrc
+∙ │ Move default color settings to tigrc
+∙ │ Add tigrc copy as a fallback inside the binary
+∙ │ Move default keybindings including shell commands to external tigrc file
+∙ │ Move test-graph tool to the test folder
+∙ │ Fix graph rendering of staged and unstaged changes
+∙ │ Minor code tidyup
+∙ │ Add support for specifying custom prompt for %(prompt)
+∙ │ Abandon the %(prompt) when the user escapes it
+∙ │ Only refresh views that support it after running a shell command
+∙ │ Fix log view to handle repositories containing a file named HEAD
+∙ │ Update %(branch) to point to current branch in the main view
+∙ │ Improve opening of blame view from the stage view
+∙ │ Don't open blame view for untracked files in the status and stage view
+∙ │ Fix diff-options to only be considered for the diff view
+∙ │ Fix staged view when file called "HEAD" exists
+∙ │ Pass arguments in filter_options()
+∙ │ Parse -U argument and update internal diff context state
+∙ │ Disable graph drawing for reverse log order
+∙ │ Preprocess known toggleable options arguments in filter_options
+∙ │ Rewrite much of the graph code
+∙ │ Add ZSH autocomplete compatibility
+∙ │ Fix lookup of run requests
+∙ │ Fix off-by-one error for status code message lookup
+∙ │ Actually disable mouse support
+∙ │ Disable mouse support by default since it breaks copying text from the terminal
+∙ │ Fix diff stat highlighting of file with no changes
+∙ │ Add mouse support
+∙ │ Fix run request ID offset to never conflict with internal request IDs
+∙ │ Fix diff stat hightlighting for files with no changes
+∙ │ Add toggle=vertical=split action to dynamically change the split orientation
+∙ │ Align the view scroll percentage to the right
+∙ │ Fix issue with creation of .deps directory after upgrade to Mac OS 10.9
+∙ │ Add "auto" vertical-split
+∙ │ graph: uncomment is_boundary propagation
+∙ │ parse commit marks more leniently
+∙ │ Fix reloading diffs of staged and unstaged changes
+∙ │ Fix map size assertion in parse_enum
+∙ │ Refactor defined enum maps to contain size information
+∙ │ Detect renames when generating the announcement
+∙ │ Fix warning about uninitialized lineno variable
+∙ │ Set the commit reference when opening the blame view from the blob view
+∙ │ Fix clean rule to remove DocBook XML files in doc/
+∙ │ Fix and improve inter-document linking
+∙ │ Rename README, INSTALL, and NEWS to end in .adoc
+∙ │ Use .adoc as the extension for AsciiDoc files in doc/
+∙ │ Merge the content of BUGS into the README file
+∙ │ Fix regression in add_line_at making line numbers start atf 0 instead of 1
+∙ │ Fix regression in diff_get_lineno
+∙ │ Fix regression making diff parsing fail when opening the blame view
+∙ │ Make blame_draw check if the filename is NULL instead of empty
+∙ │ Handle diffs with no newline at end of file
+∙ │ Add support for splitting chunks in the stage view
+∙ │ Add common utility for parsing chunk headers
+∙ │ Introduce a path cache and use it for the blame view
+∙ │ Fix blame_go_back to copy the whole file path
+∙ │ Fix handling of combining characters in utf8_length() when reserve==TRUE.
+∙ │ Implement navigating back to previous view state in the blame view
+∙ │ Create a commit view history API based on the tree view stack
+∙ │ Free all cached list of reference when reloading the references
+∙ │ Move warn and die to the util module
+∙ │ Move error messages to new util module
+∙ │ Move get_temp_dir to io module
+∙ │ Move encoding utilities to the io module
+∙ │ Fix regression making the status view inaccessible for new repositories
+∙ │ Fix \`make dist\` to support versions with more than 2 digit groups
+∙ │ tig(1): document the Git commands supported by the pager mode
+∙ │ Load main view from any --pretty=raw output given on stdin
+∙ │ Refactor the pager mode handling
+∙ │ Simplify checking of --stdin argument
+∙ │ Generalize and move parsing of reflog info into main_read
+∙ │ Use memset to clear the format buffer
+∙ │ Add toggling for display of files in untracked directories
+∙ │ Improve option toggling to update all displayed view
+∙ │ Pass CFLAGS to linker
+∙ │ Move release scripts, test programs and maintainer files to new tools directory
+∙ │ Switch to automatically generate dependencies
+∙ │ Disabled colors last when passing user supplied arguments to Git
+∙ │ Optionally load HEAD when loading references
+∙ │ Load HEAD ID and symbolic name as part of the repo info
+∙ │ Add auto-configuration for Cygwin
+∙ │ Rewrite the toggle menu setup macro code to fix compile error
+∙ │ Fix stash diff display after deleting a stash
+∙ │ Make digit counting reusable
+∙ │ Make the prompt for user-defined commands tell when Tig will exit
+∙ │ User-defined commands no longer need to be prefixed with '!'
+∙ │ tigrc(5): rework the keybinding section
+│ ∙ Update for version tig-1.2.1
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-1.2.1
-● │ Use capitalized Git and Tig when talking about the systems in general
-● │ Simplify the install goal and rename \$(PROGS) to \$(EXE)
-● │ Fix regression that skipped commits with no messages
-● │ Remove the dont_free line struct flag in favor of custom help_done
-● │ Free graph symbols when reloading the main view
-● │ Bypass all graph calls and memory allocations when the graph is disabled
-● │ Postpone ref list lookup to the draw phase
-● │ Dynamically allocate commit titles to reduce memory usage
-● │ Ignore generated HTML files in the whole tree
-● │ Show blob sizes in the tree view
-● │ Improve the installation instructions
-● │ Add work-around for building manpages with Homebrew-based xmlto
-● │ Ignore *.swp files and restrict to only ignore top-level config.make
-● │ Fix HTML doc installation
-● │ Fix path to sysconfdir-based gitconfig in tig(1)
-● │ Fix submodule-related setup to properly check setenv return value
-● │ Rework README to include the list of online resources
-● │ Fix man page install
-● │ Move documentation to doc directory
-│ ● Update for version tig-1.2
+∙─│─╯ tig-1.2.1
+∙ │ Use capitalized Git and Tig when talking about the systems in general
+∙ │ Simplify the install goal and rename \$(PROGS) to \$(EXE)
+∙ │ Fix regression that skipped commits with no messages
+∙ │ Remove the dont_free line struct flag in favor of custom help_done
+∙ │ Free graph symbols when reloading the main view
+∙ │ Bypass all graph calls and memory allocations when the graph is disabled
+∙ │ Postpone ref list lookup to the draw phase
+∙ │ Dynamically allocate commit titles to reduce memory usage
+∙ │ Ignore generated HTML files in the whole tree
+∙ │ Show blob sizes in the tree view
+∙ │ Improve the installation instructions
+∙ │ Add work-around for building manpages with Homebrew-based xmlto
+∙ │ Ignore *.swp files and restrict to only ignore top-level config.make
+∙ │ Fix HTML doc installation
+∙ │ Fix path to sysconfdir-based gitconfig in tig(1)
+∙ │ Fix submodule-related setup to properly check setenv return value
+∙ │ Rework README to include the list of online resources
+∙ │ Fix man page install
+∙ │ Move documentation to doc directory
+│ ∙ Update for version tig-1.2
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-1.2
-● │ Remove release-docs/ during distclean
-● │ Only warn about missing curses configuration once
-● │ remove useless call to strdup() in get_temp_dir()
-● │ Move all checks for the log view commit context to log_select
-● │ Fix %(prompt) variable formatting
-● │ Revert "Scroll diff with arrow keys in log view"
-● │ Display correct diff the context in split log view
-● │ Add log_select function to find commit from context in log view
-● │ Provide proper work-around for missing setenv()
-● │ Provide mkstemps() work-around for platforms lacking it
-● │ Add example showing how to show display submodule log in diffs
-● │ Fix %(commit) assignment in the diff view
-● │ Add utility method to help copy commit ID to revision buffer
-● │ stash: Highlight the diffstat of combined diffs
-● │ stash: Ensure that the whole stash@{_} text is shown
-● │ stash: Refactor ID drawing method
-● │ stash: Use main view infrastructure for the stash view
-● │ iconv: Consolidate convert methods into one single backend
-● │ iconv: Remove unnecessary length argument to encoding_iconv
-● │ iconv: Convert characters before trimming text before rendering
-● │ iconv: Move draw_chars encoding code to IO module
-● │ iconv: Ignore unrepresentable characters when transliterating
-● │ Only set LINES and COLUMNS environment variables for external commands
-● │ Crop text when title-overflow is enabled
-● │ Scroll diff with arrow keys in log view
-● │ Prepend the path to the repository root when editing a diff file
-● │ Introduce the stash view
-● │ Open editor at selected line also for multi-file diffs in the stage view
-● │ Fix regression when running tig with no arguments and custom encoding
-● │ Fix unicode_width for combining characters
-● │ Enable tilde expansion in ~/.tigrc "source" commands
-● │ Fix blame and status to work from within directories starting with a dot
-● │ Reenable the log view from the command line
-● │ Do not apply diff styling to untracked files in the stage view
-● │ Fix regexec() error checking in grep_text() and grep_refs()
-● │ Pass terminal dimensions to git by setting COLUMNS and LINES
-● │ Do not expand the graph for merges already aligned to the left
-● │ Use TMPDIR for temporary files
-● │ Create temporary file with name as suffix
-● │ Improve invalidation during reload of references
-● │ Set the reference list ID during creation
-● │ Fix rendering glitch for branch names
-● │ Fix display of all branches labels in repos with short branch names
+∙─│─╯ tig-1.2
+∙ │ Remove release-docs/ during distclean
+∙ │ Only warn about missing curses configuration once
+∙ │ remove useless call to strdup() in get_temp_dir()
+∙ │ Move all checks for the log view commit context to log_select
+∙ │ Fix %(prompt) variable formatting
+∙ │ Revert "Scroll diff with arrow keys in log view"
+∙ │ Display correct diff the context in split log view
+∙ │ Add log_select function to find commit from context in log view
+∙ │ Provide proper work-around for missing setenv()
+∙ │ Provide mkstemps() work-around for platforms lacking it
+∙ │ Add example showing how to show display submodule log in diffs
+∙ │ Fix %(commit) assignment in the diff view
+∙ │ Add utility method to help copy commit ID to revision buffer
+∙ │ stash: Highlight the diffstat of combined diffs
+∙ │ stash: Ensure that the whole stash@{_} text is shown
+∙ │ stash: Refactor ID drawing method
+∙ │ stash: Use main view infrastructure for the stash view
+∙ │ iconv: Consolidate convert methods into one single backend
+∙ │ iconv: Remove unnecessary length argument to encoding_iconv
+∙ │ iconv: Convert characters before trimming text before rendering
+∙ │ iconv: Move draw_chars encoding code to IO module
+∙ │ iconv: Ignore unrepresentable characters when transliterating
+∙ │ Only set LINES and COLUMNS environment variables for external commands
+∙ │ Crop text when title-overflow is enabled
+∙ │ Scroll diff with arrow keys in log view
+∙ │ Prepend the path to the repository root when editing a diff file
+∙ │ Introduce the stash view
+∙ │ Open editor at selected line also for multi-file diffs in the stage view
+∙ │ Fix regression when running tig with no arguments and custom encoding
+∙ │ Fix unicode_width for combining characters
+∙ │ Enable tilde expansion in ~/.tigrc "source" commands
+∙ │ Fix blame and status to work from within directories starting with a dot
+∙ │ Reenable the log view from the command line
+∙ │ Do not apply diff styling to untracked files in the stage view
+∙ │ Fix regexec() error checking in grep_text() and grep_refs()
+∙ │ Pass terminal dimensions to git by setting COLUMNS and LINES
+∙ │ Do not expand the graph for merges already aligned to the left
+∙ │ Use TMPDIR for temporary files
+∙ │ Create temporary file with name as suffix
+∙ │ Improve invalidation during reload of references
+∙ │ Set the reference list ID during creation
+∙ │ Fix rendering glitch for branch names
+∙ │ Fix display of all branches labels in repos with short branch names
 ●─│─╮ Merge pull request #143 from bbolli/clang-warning
-│ │ ● Eliminate a constant expression
-● │ │ tigrc(5): document how to use Ctrl in key bindings
-●─│─╯ Show line numbers in the branch view
-● │ Fix formatting of revargs
-● │ Fix half cooked patch tweaks
-● │ Cancel quitting after answering no to a prompt
-● │ Fix regression causing incorect coloring of the commit title
-● │ Show diff stats as wide as the terminal
-● │ Introduce format_context struct to simplify argument passing
-● │ Append the argument in format_expand_arg
-● │ Rename format_arg => format_expand_arg
-● │ Format diff and blame arguments
-● │ Move argument formatting to separate function
-● │ Add a ".." entry if tig is used on an empty path in tree view.
-● │ Build with curses.h when using the default Mac OS X make configuration
-● │ Update documentation as regards color specification using bare numbers
-● │ Fix diff title overflow rendering to use view specific flag
-● │ [#102] Revert 40868f7 which breaks blame and pickaxe support for follow
-● │ Add +ESC key binding
-● │ Highlight commit title overflow in the diff view
-● │ Rename the title-overflow color to overflow
-● │ Refactor commit title drawing to expand text and make it reusable
-● │ main: add toggle for commit title overflow
-● │ Link to stackoverflow.com/questions/tagged/tig for Q and A
-● │ Catch SIGQUIT and gracefully exit tig
-● │ Restore default signal handlers
-● │ Add toggle-files to disable file filtering for the diff and main views
-● │ Add example user-defined commands to the manual
-● │ tigrc(5): document show-line-numbers
-● │ Detect errors and allow editor line number to be disabled
-● │ Stage view: open untracked file at selected line
-● │ Blob view: open editor at selected line
-● │ Add a line number argument to open_editor
-● │ [#116] Add vim mode lines and machinery for updating C file headers
-● │ test-graph: show usage string when no input is given on stdin
-● │ [#115] Add toggles for showing author email or email user names
-● │ Fix manual keybinging for stage-single-line
-● │ Update NEWS
-● │ Document the ability to bind internal commands
-● │ Key bindings which execute tig prompt commands
-● │ Return a request from open_run_request()
-● │ After setting an option, refresh the view if possible
-● │ Support refreshing the diff view by reloading the data
-● │ Refactor the prompt command handling into a separate function
-● │ Allow overwriting of a previously set "argv" option
-● │ Add a diff-options config, similar to blame-options
-● │ Main view: fix diff view display for staged/unstaged changes
-● │ Added configure
-● │ Report toggled option *after* refreshing/reloading the view
-● │ Don't clear the status/report line when finishing a piped update
-● │ Reload current branch name when reloading the stage view.
-● │ Don't call string_copy_rev() on empty string
-● │ autogen.sh: Set WARNINGS in a more portable fashion
-● │ [GH #93] Fix compile errors reported on old Solaris systems
-● │ [GH #93] Reload the current branch name when reloading the status view
-● │ Fix diff display when using --follow by marking it as a rev flag
-● │ Remove unneeded git update-index call
-│ ● Update for version tig-1.1
+│ │ ∙ Eliminate a constant expression
+∙ │ │ tigrc(5): document how to use Ctrl in key bindings
+∙─│─╯ Show line numbers in the branch view
+∙ │ Fix formatting of revargs
+∙ │ Fix half cooked patch tweaks
+∙ │ Cancel quitting after answering no to a prompt
+∙ │ Fix regression causing incorect coloring of the commit title
+∙ │ Show diff stats as wide as the terminal
+∙ │ Introduce format_context struct to simplify argument passing
+∙ │ Append the argument in format_expand_arg
+∙ │ Rename format_arg => format_expand_arg
+∙ │ Format diff and blame arguments
+∙ │ Move argument formatting to separate function
+∙ │ Add a ".." entry if tig is used on an empty path in tree view.
+∙ │ Build with curses.h when using the default Mac OS X make configuration
+∙ │ Update documentation as regards color specification using bare numbers
+∙ │ Fix diff title overflow rendering to use view specific flag
+∙ │ [#102] Revert 40868f7 which breaks blame and pickaxe support for follow
+∙ │ Add +ESC key binding
+∙ │ Highlight commit title overflow in the diff view
+∙ │ Rename the title-overflow color to overflow
+∙ │ Refactor commit title drawing to expand text and make it reusable
+∙ │ main: add toggle for commit title overflow
+∙ │ Link to stackoverflow.com/questions/tagged/tig for Q and A
+∙ │ Catch SIGQUIT and gracefully exit tig
+∙ │ Restore default signal handlers
+∙ │ Add toggle-files to disable file filtering for the diff and main views
+∙ │ Add example user-defined commands to the manual
+∙ │ tigrc(5): document show-line-numbers
+∙ │ Detect errors and allow editor line number to be disabled
+∙ │ Stage view: open untracked file at selected line
+∙ │ Blob view: open editor at selected line
+∙ │ Add a line number argument to open_editor
+∙ │ [#116] Add vim mode lines and machinery for updating C file headers
+∙ │ test-graph: show usage string when no input is given on stdin
+∙ │ [#115] Add toggles for showing author email or email user names
+∙ │ Fix manual keybinging for stage-single-line
+∙ │ Update NEWS
+∙ │ Document the ability to bind internal commands
+∙ │ Key bindings which execute tig prompt commands
+∙ │ Return a request from open_run_request()
+∙ │ After setting an option, refresh the view if possible
+∙ │ Support refreshing the diff view by reloading the data
+∙ │ Refactor the prompt command handling into a separate function
+∙ │ Allow overwriting of a previously set "argv" option
+∙ │ Add a diff-options config, similar to blame-options
+∙ │ Main view: fix diff view display for staged/unstaged changes
+∙ │ Added configure
+∙ │ Report toggled option *after* refreshing/reloading the view
+∙ │ Don't clear the status/report line when finishing a piped update
+∙ │ Reload current branch name when reloading the stage view.
+∙ │ Don't call string_copy_rev() on empty string
+∙ │ autogen.sh: Set WARNINGS in a more portable fashion
+∙ │ [GH #93] Fix compile errors reported on old Solaris systems
+∙ │ [GH #93] Reload the current branch name when reloading the status view
+∙ │ Fix diff display when using --follow by marking it as a rev flag
+∙ │ Remove unneeded git update-index call
+│ ∙ Update for version tig-1.1
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-1.1
-● │ [GH #91] Allow to open blob related with added content in a diff
-│ │ ● [GH #72] Convert output to ASCII//TRANSLIT unless using ncursesw
-●─│─╯ Fix status view to show section-level changes in non-lazy navigation mode
-● │ Fix lazy navigation mode to allow opening the parent tree
-● │ Do not show deleted branch when reloading the branch view
-● │ Enable lazy navigation mode for the status view
-● │ Refactor stage view title formatting
-● │ [GH #83] WIP: main view lazy navigation mode prototype
-● │ Read commit IDs from stdin when opened with --stdin
-● │ Try to automatically re-run configure script when appropriate
-● │ Work around a bug in autoreconf 2.61
-● │ Use the right Emacs mode for config.make.in
-● │ Add "show-deps" make target; rearrange existing dependencies to match output
-● │ When using autoconf, *all* of our .o files depend on config.h
-● │ Tweak Emacs' syntax highlighting of configure.ac
-● │ Make sure that our .m4 file gets included
-● │ Run autoupdate(1) on to get rid of autoconf warnings
-● │ Replace strndup(3) usage with malloc + strncpy
-● │ Handle wrapping of the first line of a view
-● │ Fix invalid memory access bug in pager line wrapping
-● │ Properly initialize variable in diff_get_pathname
-● │ [GH #62] Make the use of encoding arguments optional
-● │ Change diff-context setting to have a minimum value of 0
-● │ diff: get pathname of combined diff headers
-● │ [GH #65] Support binding more advanced external commands
-● │ Correctly report allocation failure in argv_append
-● │ tigrc(5): improve documentation of git configuration usage
-● │ Do not include merges in the announcement's change log
+∙─│─╯ tig-1.1
+∙ │ [GH #91] Allow to open blob related with added content in a diff
+│ │ ∙ [GH #72] Convert output to ASCII//TRANSLIT unless using ncursesw
+∙─│─╯ Fix status view to show section-level changes in non-lazy navigation mode
+∙ │ Fix lazy navigation mode to allow opening the parent tree
+∙ │ Do not show deleted branch when reloading the branch view
+∙ │ Enable lazy navigation mode for the status view
+∙ │ Refactor stage view title formatting
+∙ │ [GH #83] WIP: main view lazy navigation mode prototype
+∙ │ Read commit IDs from stdin when opened with --stdin
+∙ │ Try to automatically re-run configure script when appropriate
+∙ │ Work around a bug in autoreconf 2.61
+∙ │ Use the right Emacs mode for config.make.in
+∙ │ Add "show-deps" make target; rearrange existing dependencies to match output
+∙ │ When using autoconf, *all* of our .o files depend on config.h
+∙ │ Tweak Emacs' syntax highlighting of configure.ac
+∙ │ Make sure that our .m4 file gets included
+∙ │ Run autoupdate(1) on to get rid of autoconf warnings
+∙ │ Replace strndup(3) usage with malloc + strncpy
+∙ │ Handle wrapping of the first line of a view
+∙ │ Fix invalid memory access bug in pager line wrapping
+∙ │ Properly initialize variable in diff_get_pathname
+∙ │ [GH #62] Make the use of encoding arguments optional
+∙ │ Change diff-context setting to have a minimum value of 0
+∙ │ diff: get pathname of combined diff headers
+∙ │ [GH #65] Support binding more advanced external commands
+∙ │ Correctly report allocation failure in argv_append
+∙ │ tigrc(5): improve documentation of git configuration usage
+∙ │ Do not include merges in the announcement's change log
 ●─│─╮ Merge pull request #81 from esc/fix/reading_git_colors_256
 ●─│─│─╮ Merge pull request #80 from esc/fix/option_name_mismatch
-● │ │ │ Reenable copy/rename detection in the status view
-│ │ │ ● fix: the manpage says 'read-git-colors'
-│ │ ● │ fix: reading git colors in rang 0 255
-●─│─┴─╯ Remove enforced diff move/copy detection
-● │ Optionally show commit IDs for branches and tree entries
-● │ [GH #77] Add options for displaying commit IDs in the main view
-● │ Sanitize the width argument to draw_field to not include padding
-● │ Rename all column variables to end with _width
-● │ [GH #78] tig.spec: add man7 directory to RPM package
-● │ [GH #76] Add option to split views vertically
-● │ Move horizontal split calculation to separate function
-● │ [GH #25] Allow to build on Mac OS 10.7 without the configure script
-● │ [GH #70] Fix parent blaming when tig is launched in subdirectory
-● │ [GH #66] Allow run requests to exit tig after execution
-● │ [GH #39] Add note for packagers to avoid building ncurses --with-shared
-● │ [DEB-682766] Improve tigrc(5) documentation
-● │ Documentation typo and grammar fixes
-● │ Allow people to still build without autotools
-● │ Update AX_WITH_CURSES to build under Cygwin
-● │ diff: support editing changed files
-● │ diff: fix and improve detection of filename
-● │ Fixing documentation for maximize keybinding
-● │ Get rid of printf format warnings with size_t arguments
-● │ Reload colors when typed in prompt
-● │ Support tig config options in prompt
-● │ Extend prompt functionalities
-● │ Remove trailing whitespace
-● │ [GH #54] Reorder chdir checks for submodules
-● │ Annotate printf-like methods and fix warnings reported by GCC
-● │ [GH #2] Add basic support for wrapping pager-based views
-● │ Only show changes commits for the current branch
-● │ Rework custom line tracking to allow custom lines at any place
-● │ Refactor line allocation to avoid memory leaks
-● │ Introduce struct to store state during reading of the main view
-● │ Allow case-insensitive searches - implement ignore-case option.
-● │ Add files generated by cscope and ctags to .gitignore
-● │ [GH #53] Revert 73bee5e which breaks the graph when path spec is specified
-● │ Fix opening the pager view from the command prompt
-● │ Show formatted run request argv when prompting
-● │ Add support to confirm the execution of a binding
-● │ Change run request to use flags for passing silent and force options
-● │ Introduce argv_to_string function in the IO library
-● │ Simplify add_pager_refs interface to expect the commit ID
-● │ Use const char pointers for common pager and diff read functions
-● │ Add script to prepare documentation for http://jonas.nitro.dk/tig
-│ ● Update for version tig-1.0
+∙ │ │ │ Reenable copy/rename detection in the status view
+│ │ │ ∙ fix: the manpage says 'read-git-colors'
+│ │ ∙ │ fix: reading git colors in rang 0 255
+∙─│─┴─╯ Remove enforced diff move/copy detection
+∙ │ Optionally show commit IDs for branches and tree entries
+∙ │ [GH #77] Add options for displaying commit IDs in the main view
+∙ │ Sanitize the width argument to draw_field to not include padding
+∙ │ Rename all column variables to end with _width
+∙ │ [GH #78] tig.spec: add man7 directory to RPM package
+∙ │ [GH #76] Add option to split views vertically
+∙ │ Move horizontal split calculation to separate function
+∙ │ [GH #25] Allow to build on Mac OS 10.7 without the configure script
+∙ │ [GH #70] Fix parent blaming when tig is launched in subdirectory
+∙ │ [GH #66] Allow run requests to exit tig after execution
+∙ │ [GH #39] Add note for packagers to avoid building ncurses --with-shared
+∙ │ [DEB-682766] Improve tigrc(5) documentation
+∙ │ Documentation typo and grammar fixes
+∙ │ Allow people to still build without autotools
+∙ │ Update AX_WITH_CURSES to build under Cygwin
+∙ │ diff: support editing changed files
+∙ │ diff: fix and improve detection of filename
+∙ │ Fixing documentation for maximize keybinding
+∙ │ Get rid of printf format warnings with size_t arguments
+∙ │ Reload colors when typed in prompt
+∙ │ Support tig config options in prompt
+∙ │ Extend prompt functionalities
+∙ │ Remove trailing whitespace
+∙ │ [GH #54] Reorder chdir checks for submodules
+∙ │ Annotate printf-like methods and fix warnings reported by GCC
+∙ │ [GH #2] Add basic support for wrapping pager-based views
+∙ │ Only show changes commits for the current branch
+∙ │ Rework custom line tracking to allow custom lines at any place
+∙ │ Refactor line allocation to avoid memory leaks
+∙ │ Introduce struct to store state during reading of the main view
+∙ │ Allow case-insensitive searches - implement ignore-case option.
+∙ │ Add files generated by cscope and ctags to .gitignore
+∙ │ [GH #53] Revert 73bee5e which breaks the graph when path spec is specified
+∙ │ Fix opening the pager view from the command prompt
+∙ │ Show formatted run request argv when prompting
+∙ │ Add support to confirm the execution of a binding
+∙ │ Change run request to use flags for passing silent and force options
+∙ │ Introduce argv_to_string function in the IO library
+∙ │ Simplify add_pager_refs interface to expect the commit ID
+∙ │ Use const char pointers for common pager and diff read functions
+∙ │ Add script to prepare documentation for http://jonas.nitro.dk/tig
+│ ∙ Update for version tig-1.0
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-1.0
-│ ● Update for version tig-0.18-138-g4bfaaa2
+∙─│─╯ tig-1.0
+│ ∙ Update for version tig-0.18-138-g4bfaaa2
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Rework the VERSION mangling in the make dist rule
-● │ [GH #49] Increase the author auto-abbreviation threshold to 10
-● │ [GH #50] Make relative dates show number of years ago for old commits
-● │ Update the index before showing staged/unstaged changes in the main view
-● │ Do not count the first line and parent accessor lines in the tree view
-● │ Do not count the All branches line in the branch view
-● │ Do not count the unstaged/staged commit lines in the main view
-● │ Fix diff stat for files where the path separator is not shown
-● │ Use git log format to simplify commit title parsing
-● │ Show the file name of the current position in the diff status
-● │ Show the title of the last commit in the branch view
-● │ Fix regression to not handle non-symbolic-ref during rebase action
-● │ Enable diff stat navigation for the staged changes views
-● │ Fix jumping when the diff stat contains a file with no changes
-● │ Add macro to check if a view line is in range
-● │ Do not show empty trees for staged and unstaged commit entries
-● │ Update copyright notices to include 2012
-● │ Define manpage:[] AsciiDoc macro to fix manpage links
-● │ Move fall-back version string to Makefile
-● │ Move TODO items to the github issue tracker
-● │ Fix diff stat navigation for unmodified renamed files
+∙─│─╯ Rework the VERSION mangling in the make dist rule
+∙ │ [GH #49] Increase the author auto-abbreviation threshold to 10
+∙ │ [GH #50] Make relative dates show number of years ago for old commits
+∙ │ Update the index before showing staged/unstaged changes in the main view
+∙ │ Do not count the first line and parent accessor lines in the tree view
+∙ │ Do not count the All branches line in the branch view
+∙ │ Do not count the unstaged/staged commit lines in the main view
+∙ │ Fix diff stat for files where the path separator is not shown
+∙ │ Use git log format to simplify commit title parsing
+∙ │ Show the file name of the current position in the diff status
+∙ │ Show the title of the last commit in the branch view
+∙ │ Fix regression to not handle non-symbolic-ref during rebase action
+∙ │ Enable diff stat navigation for the staged changes views
+∙ │ Fix jumping when the diff stat contains a file with no changes
+∙ │ Add macro to check if a view line is in range
+∙ │ Do not show empty trees for staged and unstaged commit entries
+∙ │ Update copyright notices to include 2012
+∙ │ Define manpage:[] AsciiDoc macro to fix manpage links
+∙ │ Move fall-back version string to Makefile
+∙ │ Move TODO items to the github issue tracker
+∙ │ Fix diff stat navigation for unmodified renamed files
 ●─│─╮ Merge pull request #43 from Oblomov/master
-│ │ ● prompt_menu: protect against programming error
-│ │ ● Suppress clang warning
-│ │ ● read_ref: use string_ncopy_do directly
-●─│─╯ Fix compile warnings for an unused variable and return values
-● │ [GH #41] Clear newly allocated memory in allocators
-● │ Fix status view position restoration regression from recent refactorings
-● │ Move error logic to the respective view open handlers
-● │ Refactor view loading to allow open methods to abort
-● │ Move open view error reporting down into the view handlers
-● │ Simplify code in status_open
-● │ Move split_view and maximize_view to the open view section
-● │ Move refs code to separate file
-● │ Move keymap to view ops and change to use a struct
-● │ Rework the help view to not use line->other
-● │ Refactor setup of built-in run requests
-● │ Minor improvement of status view restoration
-● │ Store all restore information in view.prev_pos
-● │ Move navigation state to struct position
-● │ Fix refs reloading by not assuming that they are alphabetically sorted
-● │ Add small tracing utility for monitoring executed commands
-● │ Force load the branch view log data
-● │ Fix default commit order to be that of git-log(1)
-● │ Switch to use git-log(s) default commit ordering
-● │ [GH #23] Add %(prompt) variable
-● │ [GH #30] Enable notes by default
-● │ [GH #38] Do not pass navigation requests to the branch view when the main view is maximized
-● │ Fix build dependencies
-● │ Limit the number of allocated color pairs
-● │ Parse commit title correctly in presence of mergetag object
-● │ [GH #8] Read git's color settings
-● │ Show uncommitted changes in the main view as virtual staged and unstaged commits
-● │ Refactor main_add_commit from main_read
-● │ Add status staged and unstaged commands to git.h
-● │ Add blame diff commands to git.h
-● │ Move git diff command argv arrays to git.h
-● │ Allow the command status to be accessed after io_done
-● │ Fix diff command for staged files before initial commit
-● │ Only show the external group title once in the help view
-● │ User-defined commands prefixed with '@' are run with no console output
-● │ Fix mistake in tigrc: line-graphic expects utf8, not utf-8
+│ │ ∙ prompt_menu: protect against programming error
+│ │ ∙ Suppress clang warning
+│ │ ∙ read_ref: use string_ncopy_do directly
+∙─│─╯ Fix compile warnings for an unused variable and return values
+∙ │ [GH #41] Clear newly allocated memory in allocators
+∙ │ Fix status view position restoration regression from recent refactorings
+∙ │ Move error logic to the respective view open handlers
+∙ │ Refactor view loading to allow open methods to abort
+∙ │ Move open view error reporting down into the view handlers
+∙ │ Simplify code in status_open
+∙ │ Move split_view and maximize_view to the open view section
+∙ │ Move refs code to separate file
+∙ │ Move keymap to view ops and change to use a struct
+∙ │ Rework the help view to not use line->other
+∙ │ Refactor setup of built-in run requests
+∙ │ Minor improvement of status view restoration
+∙ │ Store all restore information in view.prev_pos
+∙ │ Move navigation state to struct position
+∙ │ Fix refs reloading by not assuming that they are alphabetically sorted
+∙ │ Add small tracing utility for monitoring executed commands
+∙ │ Force load the branch view log data
+∙ │ Fix default commit order to be that of git-log(1)
+∙ │ Switch to use git-log(s) default commit ordering
+∙ │ [GH #23] Add %(prompt) variable
+∙ │ [GH #30] Enable notes by default
+∙ │ [GH #38] Do not pass navigation requests to the branch view when the main view is maximized
+∙ │ Fix build dependencies
+∙ │ Limit the number of allocated color pairs
+∙ │ Parse commit title correctly in presence of mergetag object
+∙ │ [GH #8] Read git's color settings
+∙ │ Show uncommitted changes in the main view as virtual staged and unstaged commits
+∙ │ Refactor main_add_commit from main_read
+∙ │ Add status staged and unstaged commands to git.h
+∙ │ Add blame diff commands to git.h
+∙ │ Move git diff command argv arrays to git.h
+∙ │ Allow the command status to be accessed after io_done
+∙ │ Fix diff command for staged files before initial commit
+∙ │ Only show the external group title once in the help view
+∙ │ User-defined commands prefixed with '@' are run with no console output
+∙ │ Fix mistake in tigrc: line-graphic expects utf8, not utf-8
 ●─│─╮ Merge pull request #37 from v0n/abbrev_commit_hash
-│ │ ● string_copy_rev: chop rev on first space (if any)
+│ │ ∙ string_copy_rev: chop rev on first space (if any)
 ●─│─┤ Merge pull request #36 from tsibley/reload-diff-view-on-toggle
-│ │ ● Reload the view on a diff-like option change
-│ │ ● Doc typo
+│ │ ∙ Reload the view on a diff-like option change
+│ │ ∙ Doc typo
 ●─│─┤ Merge pull request #34 from tsibley/combined-diff-coloring
-│ │ ● [GH #32] Only color +/- in the second column when in a combined diff
-●─│─╯ Only reload the view after changing diff options for diff-like views
-● │ Document how to submit bugs
-● │ Move checking for line number display to draw_lineno
-● │ tigrc.5.txt: fix a typo ("changes are ignore")
-● │ Offload commit encoding entirely to git
-● │ Add support for using path encoding from git attributes
-● │ Extract encoding conversion to encoding_convert
-● │ Add interface for managing encodings
-● │ Refactor parsing of encoding options
-● │ Enable toggling of all diff ignore space options
-● │ Allow space to be ignored in the stage view and blame diffs
-● │ Use toggle_option infrastructure to change the ignore space option
-● │ Toggle to ignore all whitespace changes in diffs; bound to W
-● │ Add completion for the different .git/*_HEAD files
-● │ [GH #29] Change references section title to 'see also'
-● │ Minor simplification in add_keybinding
-● │ Rename get_key to get_view_key
-● │ Simplify view request declaration
-● │ Simplify view_ops pre-declaration
-● │ Simplify view declaration
-● │ Add draw_formatted
-● │ Change git_dir boolean to become a view flag
-● │ Replace view type enum with a view flag enum
-● │ Add source command for loading separate config file from ~/.tigrc
-● │ [GH #21] Bind single line staging to '1' by default
-● │ Move truncation logic to FORMAT_BUFFER
+│ │ ∙ [GH #32] Only color +/- in the second column when in a combined diff
+∙─│─╯ Only reload the view after changing diff options for diff-like views
+∙ │ Document how to submit bugs
+∙ │ Move checking for line number display to draw_lineno
+∙ │ tigrc.5.txt: fix a typo ("changes are ignore")
+∙ │ Offload commit encoding entirely to git
+∙ │ Add support for using path encoding from git attributes
+∙ │ Extract encoding conversion to encoding_convert
+∙ │ Add interface for managing encodings
+∙ │ Refactor parsing of encoding options
+∙ │ Enable toggling of all diff ignore space options
+∙ │ Allow space to be ignored in the stage view and blame diffs
+∙ │ Use toggle_option infrastructure to change the ignore space option
+∙ │ Toggle to ignore all whitespace changes in diffs; bound to W
+∙ │ Add completion for the different .git/*_HEAD files
+∙ │ [GH #29] Change references section title to 'see also'
+∙ │ Minor simplification in add_keybinding
+∙ │ Rename get_key to get_view_key
+∙ │ Simplify view request declaration
+∙ │ Simplify view_ops pre-declaration
+∙ │ Simplify view declaration
+∙ │ Add draw_formatted
+∙ │ Change git_dir boolean to become a view flag
+∙ │ Replace view type enum with a view flag enum
+∙ │ Add source command for loading separate config file from ~/.tigrc
+∙ │ [GH #21] Bind single line staging to '1' by default
+∙ │ Move truncation logic to FORMAT_BUFFER
 │ │ ◎ Created gh-pages branch via GitHub
-● │ manual: Fix the references section title
-● │ Do not allow single line staging for new files (untracked or added)
-● │ Fix setup of the iconv input filter
-● │ Do not read configuration from stdin
-● │ Correct typos in documentation
-● │ "make clean" should remove \$(TESTS) targets
-● │ Ensure \0 terminated input for iconv()
-● │ Add "//TRANSLIT" for iconv encoding
-● │ Introduce define for the UTF-8 encoding string
-● │ [GH #21] Fix single line updating to support unstaging
-● │ [GH #21] Support staging of single lines
-● │ Refactor diff chunk header parsing
-● │ Introduce io_printf function
-● │ Introduce macro for wrapping calls to vsnprintf
-● │ [GH #22] Add +<lineno> improvement to NEWS
-● │ tig.c: compare_refs: fix comparing by ref->ltag
-● │ Make git://github.com/jonas/tig.git repo the master
-● │ fixed compile issue: NCURSES_OPAQUE on OSX 10.6.8
-● │ fixed isnumber error (OSX 10.6.8)
+∙ │ manual: Fix the references section title
+∙ │ Do not allow single line staging for new files (untracked or added)
+∙ │ Fix setup of the iconv input filter
+∙ │ Do not read configuration from stdin
+∙ │ Correct typos in documentation
+∙ │ "make clean" should remove \$(TESTS) targets
+∙ │ Ensure \0 terminated input for iconv()
+∙ │ Add "//TRANSLIT" for iconv encoding
+∙ │ Introduce define for the UTF-8 encoding string
+∙ │ [GH #21] Fix single line updating to support unstaging
+∙ │ [GH #21] Support staging of single lines
+∙ │ Refactor diff chunk header parsing
+∙ │ Introduce io_printf function
+∙ │ Introduce macro for wrapping calls to vsnprintf
+∙ │ [GH #22] Add +<lineno> improvement to NEWS
+∙ │ tig.c: compare_refs: fix comparing by ref->ltag
+∙ │ Make git://github.com/jonas/tig.git repo the master
+∙ │ fixed compile issue: NCURSES_OPAQUE on OSX 10.6.8
+∙ │ fixed isnumber error (OSX 10.6.8)
 ●─│─╮ Merge pull request #22 from tsibley/open-at-line-number
-│ │ ● Support opening the initial view at an arbitrary line number
-│ │ ● Unify the parsing of blame options and other view options
-│ │ ● Simplify parse_options by offloading more to filter_options
-●─│─╯ [GH #19] Show filename column when blaming with copy detection enabled
-● │ Move stage chunk to private data
-● │ Introduce private view data and use it for all reading state
-● │ [GH #15] Fix diff-header colorization by ensuring color IDs are >= 1
-● │ Fix off-by-one error introduced in off-by-one error fix
-● │ [GH #12] Support multi-arg editor strings
-● │ [GH #16] Support custom colorization of lines matching a string prefix
-● │ [GH #17] Properly color binary diffstat lines
-● │ Show branches/refs which names are a substring of the current branch
-● │ Update NEWS
-● │ Fix off-by-one error in the diff stat jump feature
-● │ Create and use dup() of STDIN_FILENO instead of STDIN_FILENO itself
-● │ Add show-notes tigrc option
-● │ Support jumping to commit in the branch view
-● │ Add internal JUMP_COMMIT request and view specific logic to main_request
-● │ Find TOC sections based on 4 tildes or hyphens
-● │ Support jumping to specific SHAs in the main view
-● │ tree_compare: handle author == NULL gracefully when sorting
-● │ Decorate replaced commits
-● │ Display line numbers in main view
-│ ● Update for version tig-0.18
+│ │ ∙ Support opening the initial view at an arbitrary line number
+│ │ ∙ Unify the parsing of blame options and other view options
+│ │ ∙ Simplify parse_options by offloading more to filter_options
+∙─│─╯ [GH #19] Show filename column when blaming with copy detection enabled
+∙ │ Move stage chunk to private data
+∙ │ Introduce private view data and use it for all reading state
+∙ │ [GH #15] Fix diff-header colorization by ensuring color IDs are >= 1
+∙ │ Fix off-by-one error introduced in off-by-one error fix
+∙ │ [GH #12] Support multi-arg editor strings
+∙ │ [GH #16] Support custom colorization of lines matching a string prefix
+∙ │ [GH #17] Properly color binary diffstat lines
+∙ │ Show branches/refs which names are a substring of the current branch
+∙ │ Update NEWS
+∙ │ Fix off-by-one error in the diff stat jump feature
+∙ │ Create and use dup() of STDIN_FILENO instead of STDIN_FILENO itself
+∙ │ Add show-notes tigrc option
+∙ │ Support jumping to commit in the branch view
+∙ │ Add internal JUMP_COMMIT request and view specific logic to main_request
+∙ │ Find TOC sections based on 4 tildes or hyphens
+∙ │ Support jumping to specific SHAs in the main view
+∙ │ tree_compare: handle author == NULL gracefully when sorting
+∙ │ Decorate replaced commits
+∙ │ Display line numbers in main view
+│ ∙ Update for version tig-0.18
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.18
-● │ Update the view title status after jumping to file diff
-● │ [LP-694780][DEB-635546] Expand browsing state variables for prompt commands
-● │ Promote view_open to pager_open
-● │ rename graph-line to palette
-● │ Jump to a file's diff when enter is pressed on a diff stat file line
-● │ Use erasechar() to check for the correct backspace character
-● │ Minor cleanup in blame diff opening
-● │ Use view->parent to access status view from the stage view
-● │ Naïvely color blame IDs to distinguish lines
-● │ Sort references so that remotes comes last in the branch view
-● │ Restore the help view after collapsing/expanding a keybinding group
-● │ Improve the selection of the line blamed from a diff
-● │ Make it possible to change the diff context in the diff view
-● │ Add support for blaming diff lines
-● │ Move blame parsing code to backend utility area
-● │ Refactor blame output parsing
-● │ Rename stage_diff_find to find_prev_line_by_type_
-● │ Add option to control the diff context
-● │ Move stage open logic to stage_open
-● │ Regroup default keybindings
-● │ Show remotes in branch view
-● │ Split out function to get line type from ref
-● │ Sort "All branches" to the top and prevent segfault
+∙─│─╯ tig-0.18
+∙ │ Update the view title status after jumping to file diff
+∙ │ [LP-694780][DEB-635546] Expand browsing state variables for prompt commands
+∙ │ Promote view_open to pager_open
+∙ │ rename graph-line to palette
+∙ │ Jump to a file's diff when enter is pressed on a diff stat file line
+∙ │ Use erasechar() to check for the correct backspace character
+∙ │ Minor cleanup in blame diff opening
+∙ │ Use view->parent to access status view from the stage view
+∙ │ Naïvely color blame IDs to distinguish lines
+∙ │ Sort references so that remotes comes last in the branch view
+∙ │ Restore the help view after collapsing/expanding a keybinding group
+∙ │ Improve the selection of the line blamed from a diff
+∙ │ Make it possible to change the diff context in the diff view
+∙ │ Add support for blaming diff lines
+∙ │ Move blame parsing code to backend utility area
+∙ │ Refactor blame output parsing
+∙ │ Rename stage_diff_find to find_prev_line_by_type_
+∙ │ Add option to control the diff context
+∙ │ Move stage open logic to stage_open
+∙ │ Regroup default keybindings
+∙ │ Show remotes in branch view
+∙ │ Split out function to get line type from ref
+∙ │ Sort "All branches" to the top and prevent segfault
 ●─│─╮ Merge pull request #9 from tokkee/sh/next
-│ │ ● Use error codes when checking parse_int() return value
-│ │ ● Colorize merge commit diffs as well
-●─│─╯ get_author_initials: various fixes
-● │ Use locale-unaware methods for case conversion
-● │ Revert change to put %(ref):%(file) in the blame view title
-● │ Simplify blame argv formatting
-● │ Reload the blame view when changing the ref and file variables
-● │ Use mkauthor in grep functions
-● │ Fix problem with empty space when the author field is disabled
-● │ Unify enum map declarations through a common utility
-● │ Accept 'utf-8' for the line-graphics option as indicated in the docs
-● │ Fix regression where new content in the stage view does not reset the position
-● │ Refactor mkmode from draw_mode
-● │ Refactor mkauthor from draw_author
-● │ Refactor draw_refs out from main_draw
-● │ Merge prepare_update into open_argv; make open_file call open_argv
-● │ Use begin_update to load data in the tree and branch views
-● │ Fix blame view regression
-● │ io_run: make it possible to open file
-● │ Simplify format_argv to always replace
-● │ Rename prepare_io to prepare_update and make it more specialized
-● │ Move view splitting code to separate split_view
-● │ open_view: Use maximize_view to prepare non-split displays
-● │ open_view: gather split view code in the same branch
-● │ Introduce refresh_view based on load_view
-● │ Refactor view loading from open_view into load_view
-● │ Add open_argv and open_file to wrap update preparation and open_view call
-● │ Enhance prepare_update_file to add support for refreshable file IO
-● │ Simplify draw_author and draw_date logic
-● │ Make the low-level drawing functions update the view column
-● │ Add specialized open methods for each view
-● │ Convert tree_prepare to tree_open
-● │ Convert begin_update to act as a view_ops open function
-● │ Extend open() view ops to accept the open flags as an argument
-● │ Add VIEW_MAX_LEN macro to aid when drawing
-● │ Remove support for the deprecated TIG_{MAIN,DIFF,LOG,TREE,BLOB}_CMD env vars
-● │ Do not install test-graph
-● │ Improve parsing of the set command and variable arguments options
-● │ [GH-6] Make blame configurable via options from ~/.tigrc and the command line
-● │ tigrc(5): sort options alphabetically
-● │ Update and fix a few NEWS entries
-● │ [GH-3] Expand %(directory) to . for the root directory
-│ ● Update for version tig-0.17
+│ │ ∙ Use error codes when checking parse_int() return value
+│ │ ∙ Colorize merge commit diffs as well
+∙─│─╯ get_author_initials: various fixes
+∙ │ Use locale-unaware methods for case conversion
+∙ │ Revert change to put %(ref):%(file) in the blame view title
+∙ │ Simplify blame argv formatting
+∙ │ Reload the blame view when changing the ref and file variables
+∙ │ Use mkauthor in grep functions
+∙ │ Fix problem with empty space when the author field is disabled
+∙ │ Unify enum map declarations through a common utility
+∙ │ Accept 'utf-8' for the line-graphics option as indicated in the docs
+∙ │ Fix regression where new content in the stage view does not reset the position
+∙ │ Refactor mkmode from draw_mode
+∙ │ Refactor mkauthor from draw_author
+∙ │ Refactor draw_refs out from main_draw
+∙ │ Merge prepare_update into open_argv; make open_file call open_argv
+∙ │ Use begin_update to load data in the tree and branch views
+∙ │ Fix blame view regression
+∙ │ io_run: make it possible to open file
+∙ │ Simplify format_argv to always replace
+∙ │ Rename prepare_io to prepare_update and make it more specialized
+∙ │ Move view splitting code to separate split_view
+∙ │ open_view: Use maximize_view to prepare non-split displays
+∙ │ open_view: gather split view code in the same branch
+∙ │ Introduce refresh_view based on load_view
+∙ │ Refactor view loading from open_view into load_view
+∙ │ Add open_argv and open_file to wrap update preparation and open_view call
+∙ │ Enhance prepare_update_file to add support for refreshable file IO
+∙ │ Simplify draw_author and draw_date logic
+∙ │ Make the low-level drawing functions update the view column
+∙ │ Add specialized open methods for each view
+∙ │ Convert tree_prepare to tree_open
+∙ │ Convert begin_update to act as a view_ops open function
+∙ │ Extend open() view ops to accept the open flags as an argument
+∙ │ Add VIEW_MAX_LEN macro to aid when drawing
+∙ │ Remove support for the deprecated TIG_{MAIN,DIFF,LOG,TREE,BLOB}_CMD env vars
+∙ │ Do not install test-graph
+∙ │ Improve parsing of the set command and variable arguments options
+∙ │ [GH-6] Make blame configurable via options from ~/.tigrc and the command line
+∙ │ tigrc(5): sort options alphabetically
+∙ │ Update and fix a few NEWS entries
+∙ │ [GH-3] Expand %(directory) to . for the root directory
+│ ∙ Update for version tig-0.17
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.17
-● │ Rewrite the revision graph renderer
-● │ Move IO API to src/io.[ch]
-● │ Move includes, macros and core utilities to tig.h
-● │ Initialise views and screens with nonzero size.
-● │ Remove draw_text()s trim parameter
-● │ Remove unnecessary braces
-● │ Reduce the number of windows to max two by sharing them between all views
-● │ Use AX_WITH_CURSES from GNU autoconf archive to detect ncurses
-● │ configure.ac: Set value-if-not-found, don't check for program 'false'
-● │ Unify option toggling
-● │ Refactor option parsing error handling to use error codes
-● │ Add possiblity to pass data to io_load property reader
-● │ Rename opt_*_args to opt_*_argv
-● │ Improve viewing of diffs when browsing branches
-│ ● Update for version tig-0.16.2
+∙─│─╯ tig-0.17
+∙ │ Rewrite the revision graph renderer
+∙ │ Move IO API to src/io.[ch]
+∙ │ Move includes, macros and core utilities to tig.h
+∙ │ Initialise views and screens with nonzero size.
+∙ │ Remove draw_text()s trim parameter
+∙ │ Remove unnecessary braces
+∙ │ Reduce the number of windows to max two by sharing them between all views
+∙ │ Use AX_WITH_CURSES from GNU autoconf archive to detect ncurses
+∙ │ configure.ac: Set value-if-not-found, don't check for program 'false'
+∙ │ Unify option toggling
+∙ │ Refactor option parsing error handling to use error codes
+∙ │ Add possiblity to pass data to io_load property reader
+∙ │ Rename opt_*_args to opt_*_argv
+∙ │ Improve viewing of diffs when browsing branches
+│ ∙ Update for version tig-0.16.2
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.16.2
-● │ Fix 'tig show <commit>' fix which causes empty tree views
-● │ Check the ncurses version before using set_tabsize
-│ ● Update for version tig-0.16.1
+∙─│─╯ tig-0.16.2
+∙ │ Fix 'tig show <commit>' fix which causes empty tree views
+∙ │ Check the ncurses version before using set_tabsize
+│ ∙ Update for version tig-0.16.1
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.16.1
-● │ Fix tig show by replacing %(commit) with %(revargs) on first display
-● │ Use function set_tabsize()
-● │ Don't show out-of-sight tildes
-● │ Add an option to ignore unknown directories contents in the status view
-● │ Remove remains from the obsoleted toggle-date-short action
-● │ Actually add the ^D binding to move-page-down
-● │ Add a scroll-first-col command
-● │ Add vi-like ^ bindings
-● │ Allow tig to parse control-modified chars in tigrc
-● │ Fix segfault when starting tig in pager mode
-● │ Fall back to retry if no diff will be shown
-● │ Refactor argv_size out from argv_append
-│ ● Update for version tig-0.16
+∙─│─╯ tig-0.16.1
+∙ │ Fix tig show by replacing %(commit) with %(revargs) on first display
+∙ │ Use function set_tabsize()
+∙ │ Don't show out-of-sight tildes
+∙ │ Add an option to ignore unknown directories contents in the status view
+∙ │ Remove remains from the obsoleted toggle-date-short action
+∙ │ Actually add the ^D binding to move-page-down
+∙ │ Add a scroll-first-col command
+∙ │ Add vi-like ^ bindings
+∙ │ Allow tig to parse control-modified chars in tigrc
+∙ │ Fix segfault when starting tig in pager mode
+∙ │ Fall back to retry if no diff will be shown
+∙ │ Refactor argv_size out from argv_append
+│ ∙ Update for version tig-0.16
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.16
-● │ Fix missing ID reference
-● │ Rename {diff,file,rev}-args to {diff,file,rev}args
-● │ Load diff arguments from TIG_DIFF_OPTS if defined and no diff args was passed
-● │ Move application of string_expand to draw_text
-● │ Improve parent blame to handle line-jumping for renames better
-● │ Improve parent blame to detect renames by using the previous information
-● │ Free blame view data when reloading view
-● │ Fix clearing of the loading flag in the input select loop
-● │ Deprecate use of TIG_{MAIN,DIFF,LOG,TREE,BLOB}_CMD environment variables
-● │ Add support for splitting command line arguments
-● │ Make the branch view always prepare how the main view is loaded
-● │ Cleanup initialization of built-in run requests
-● │ Make view and run request argv members flexible and allocated
-● │ Further cleanup IO startup and initialization; fix io_run_append
-● │ Cleanup IO struct initialization
-● │ Make argv_copy always allocate its members
-● │ Move struct io's argv and dir members to struct view
-● │ Remove format_flags enum and its companion format_argv forward declaration
-● │ Move and rewrite io_format to become prepare_io
-● │ Make argv_copy support allocating argv members
-● │ Plug another memory leak and cleanup update start code while at it
-● │ Mark the argument array as freed in argv_free
-● │ Refactor io_complete into a single backend for {back,fore}ground and append IO
-● │ Introduce io_prepare as a fix to plug memory leaks related to argv formatting
-● │ Internalize format flags in the IO layer
-● │ Make the blame view format its own command arguments
-● │ Use view_request to unconditionally refresh views after run requests
-● │ Add view_request to call the view request method
-● │ Move and rename free_argv to argv_free
-● │ Make open_blob_editor use its own argv show and take blob ID as an argument
-● │ Use view_is_displayed when figuring setting up the open flags
-● │ Restructure option management code to separate section
-● │ Only update status view at EOF for displayed views
-● │ fix off-by-one on parent selection
-● │ Simplify handling of REQ_NEXT/REQ_PREVIOUS by using view->parent
-● │ Add view->prev to track history leaving view->parent for split views
-● │ Color 'Reviewed-by' and 'Tested-by' lines
-● │ When adding a keybinding check if the key is already bound
-● │ Allow built-in run requests to be unbound
-● │ Fix set_keymap to error when resolving an unknown keymap
-● │ Added support for displaying dates in localtime.
-● │ Fixed parse_timezone to correctly calculate the offset in seconds.
-● │ tigrc(5): fix typo
-● │ Fix unbind behavoir
-● │ Introduce view->type member
-● │ Use foreach_view for the stop loading action
-● │ Remove unused VIEW_REQ() macro
-● │ Add view flag with information about whether the view supports refreshing
-● │ argv: remove now unused FORMAT_DASH
-● │ argv: make prepare_update use FORMAT_NONE
-● │ Branch view: add %(branch) variable tracking currently selected branch
-● │ argv: move report call to format_arg method
-● │ argv: refactor argv_from_env to return an error state
-● │ utf8: move unicode related functions below the string helpers
-● │ utf8: make utf8_to_unicode return 0 when encountering invalid symbols
-● │ io: consolidate formatting into io_format
-● │ io: set io->error when syscalls fail and remove calls to report and die
-● │ io: rename IO methods to have io_ prefix
-● │ io: fix comment in io struct
-● │ Rename string_date to mkdate and add incorporate common checks
-● │ Move nodelay logic to the get_input read loop
-● │ Mark detached heads with [HEAD]; replace opt_head_rev with a struct ref
-● │ opt_codeset is only use in main, so make it local
-● │ Make utf8_length take opt_tab_size as a parameter
-● │ Remove line_graphic enum
-● │ Silence warning about unused computed value
-● │ Update copyrights
-● │ Only draw dates with non-zero seconds
-● │ Fix the display of relative date by storing the time zone information
-● │ Fix author abbreviation to handle multi-byte and multi-column characters
-● │ Use FALSE marco instead of C++ false value
-● │ prepare_update_file: assume file is relative to root directory
-● │ Status view: limit untracked file by the prefix/subdirectory
-● │ open_editor: always open path relative to the repository root directory
-● │ get_author_initials: improve and fix to not read outside of name string
-● │ Abbreviation of author names is now configurable and toggleable
-● │ Refactor format variable lookup and expansion
-● │ Oops, fix enum_equals
-● │ Make return value of string_date const
-● │ Simplify enum name comparison with enum_equals macro
-● │ Define date values in DATE_INFO macro
-● │ Refactor toggle_date_option into a generic enum_map based toggler
-● │ Introduce parse_enum and use it to parse the show-date option
-● │ Refactor help_name into enum_name
-● │ Fix parsing of boolean show-date values
-● │ toggle_date_option: use passed date argument instead of opt_date
-● │ Fix usage of the status view from a sub directory
-● │ Encode everything internally as UTF-8
-● │ Branch view: support browsing --all branches
-● │ Cleanup bluring of the previous view's title bar
-● │ foreach_ref: make ref argument const
-● │ Status view: update the file variable when a line is selected
-● │ TODO: line wrapping
-● │ Fix install-release-doc make rules to use origin/release
-● │ Add make rules to install documentation from the release branch
-│ ● Update for version tig-0.15
+∙─│─╯ tig-0.16
+∙ │ Fix missing ID reference
+∙ │ Rename {diff,file,rev}-args to {diff,file,rev}args
+∙ │ Load diff arguments from TIG_DIFF_OPTS if defined and no diff args was passed
+∙ │ Move application of string_expand to draw_text
+∙ │ Improve parent blame to handle line-jumping for renames better
+∙ │ Improve parent blame to detect renames by using the previous information
+∙ │ Free blame view data when reloading view
+∙ │ Fix clearing of the loading flag in the input select loop
+∙ │ Deprecate use of TIG_{MAIN,DIFF,LOG,TREE,BLOB}_CMD environment variables
+∙ │ Add support for splitting command line arguments
+∙ │ Make the branch view always prepare how the main view is loaded
+∙ │ Cleanup initialization of built-in run requests
+∙ │ Make view and run request argv members flexible and allocated
+∙ │ Further cleanup IO startup and initialization; fix io_run_append
+∙ │ Cleanup IO struct initialization
+∙ │ Make argv_copy always allocate its members
+∙ │ Move struct io's argv and dir members to struct view
+∙ │ Remove format_flags enum and its companion format_argv forward declaration
+∙ │ Move and rewrite io_format to become prepare_io
+∙ │ Make argv_copy support allocating argv members
+∙ │ Plug another memory leak and cleanup update start code while at it
+∙ │ Mark the argument array as freed in argv_free
+∙ │ Refactor io_complete into a single backend for {back,fore}ground and append IO
+∙ │ Introduce io_prepare as a fix to plug memory leaks related to argv formatting
+∙ │ Internalize format flags in the IO layer
+∙ │ Make the blame view format its own command arguments
+∙ │ Use view_request to unconditionally refresh views after run requests
+∙ │ Add view_request to call the view request method
+∙ │ Move and rename free_argv to argv_free
+∙ │ Make open_blob_editor use its own argv show and take blob ID as an argument
+∙ │ Use view_is_displayed when figuring setting up the open flags
+∙ │ Restructure option management code to separate section
+∙ │ Only update status view at EOF for displayed views
+∙ │ fix off-by-one on parent selection
+∙ │ Simplify handling of REQ_NEXT/REQ_PREVIOUS by using view->parent
+∙ │ Add view->prev to track history leaving view->parent for split views
+∙ │ Color 'Reviewed-by' and 'Tested-by' lines
+∙ │ When adding a keybinding check if the key is already bound
+∙ │ Allow built-in run requests to be unbound
+∙ │ Fix set_keymap to error when resolving an unknown keymap
+∙ │ Added support for displaying dates in localtime.
+∙ │ Fixed parse_timezone to correctly calculate the offset in seconds.
+∙ │ tigrc(5): fix typo
+∙ │ Fix unbind behavoir
+∙ │ Introduce view->type member
+∙ │ Use foreach_view for the stop loading action
+∙ │ Remove unused VIEW_REQ() macro
+∙ │ Add view flag with information about whether the view supports refreshing
+∙ │ argv: remove now unused FORMAT_DASH
+∙ │ argv: make prepare_update use FORMAT_NONE
+∙ │ Branch view: add %(branch) variable tracking currently selected branch
+∙ │ argv: move report call to format_arg method
+∙ │ argv: refactor argv_from_env to return an error state
+∙ │ utf8: move unicode related functions below the string helpers
+∙ │ utf8: make utf8_to_unicode return 0 when encountering invalid symbols
+∙ │ io: consolidate formatting into io_format
+∙ │ io: set io->error when syscalls fail and remove calls to report and die
+∙ │ io: rename IO methods to have io_ prefix
+∙ │ io: fix comment in io struct
+∙ │ Rename string_date to mkdate and add incorporate common checks
+∙ │ Move nodelay logic to the get_input read loop
+∙ │ Mark detached heads with [HEAD]; replace opt_head_rev with a struct ref
+∙ │ opt_codeset is only use in main, so make it local
+∙ │ Make utf8_length take opt_tab_size as a parameter
+∙ │ Remove line_graphic enum
+∙ │ Silence warning about unused computed value
+∙ │ Update copyrights
+∙ │ Only draw dates with non-zero seconds
+∙ │ Fix the display of relative date by storing the time zone information
+∙ │ Fix author abbreviation to handle multi-byte and multi-column characters
+∙ │ Use FALSE marco instead of C++ false value
+∙ │ prepare_update_file: assume file is relative to root directory
+∙ │ Status view: limit untracked file by the prefix/subdirectory
+∙ │ open_editor: always open path relative to the repository root directory
+∙ │ get_author_initials: improve and fix to not read outside of name string
+∙ │ Abbreviation of author names is now configurable and toggleable
+∙ │ Refactor format variable lookup and expansion
+∙ │ Oops, fix enum_equals
+∙ │ Make return value of string_date const
+∙ │ Simplify enum name comparison with enum_equals macro
+∙ │ Define date values in DATE_INFO macro
+∙ │ Refactor toggle_date_option into a generic enum_map based toggler
+∙ │ Introduce parse_enum and use it to parse the show-date option
+∙ │ Refactor help_name into enum_name
+∙ │ Fix parsing of boolean show-date values
+∙ │ toggle_date_option: use passed date argument instead of opt_date
+∙ │ Fix usage of the status view from a sub directory
+∙ │ Encode everything internally as UTF-8
+∙ │ Branch view: support browsing --all branches
+∙ │ Cleanup bluring of the previous view's title bar
+∙ │ foreach_ref: make ref argument const
+∙ │ Status view: update the file variable when a line is selected
+∙ │ TODO: line wrapping
+∙ │ Fix install-release-doc make rules to use origin/release
+∙ │ Add make rules to install documentation from the release branch
+│ ∙ Update for version tig-0.15
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.15
-● │ Makefile: Fix typo in 157ebf54
-● │ Status view: special case revert of unmerged entries with no physical file
-● │ io_open: take path as a vararg format
-● │ run_io_rd_dir: obsolete by switching call sites to run_io_rd_dir
-● │ run_io_dir: take dir argument
-● │ begin_update: simplify control flow
-● │ Remove build dependency on git from the configure script
-● │ tigmanual(7): provide the manual as a man page
-● │ Update asciidoc table syntax to the one supported by version 8.4.4
-● │ NEWS: Improve bug fix description
-● │ Fix loading of blame data when opened from the tree view
-● │ Fix draw_date to not format anything when time arg is NULL
-● │ Fix whitespace
-● │ Add support for displaying relative dates
-● │ NEWS: Mention date-shorten feature
+∙─│─╯ tig-0.15
+∙ │ Makefile: Fix typo in 157ebf54
+∙ │ Status view: special case revert of unmerged entries with no physical file
+∙ │ io_open: take path as a vararg format
+∙ │ run_io_rd_dir: obsolete by switching call sites to run_io_rd_dir
+∙ │ run_io_dir: take dir argument
+∙ │ begin_update: simplify control flow
+∙ │ Remove build dependency on git from the configure script
+∙ │ tigmanual(7): provide the manual as a man page
+∙ │ Update asciidoc table syntax to the one supported by version 8.4.4
+∙ │ NEWS: Improve bug fix description
+∙ │ Fix loading of blame data when opened from the tree view
+∙ │ Fix draw_date to not format anything when time arg is NULL
+∙ │ Fix whitespace
+∙ │ Add support for displaying relative dates
+∙ │ NEWS: Mention date-shorten feature
 ●─│─╮ Merge remote branch 'samb/short-dates'
-● │ │ Show the active (instead of the default) keybindings in the help view
-│ │ ● Add an option (and toggle) for shortening the date column by skipping the time.
-●─│─╯ Build with asciidoc-8.4.5
-● │ Fixed some uninitialized variable warnings
-● │ Allow multiple text attributes for color commands
-● │ Remove macros which are only used for default option values
-● │ Make height of split view configurable
-● │ Manual: document that :<number> jumps to the line number
-● │ Fix memory allocation check in open_commit_parent_menu
-● │ Use menus with the commit subject to present selectable commit parents
-● │ Add simple support for showing menues and use it for showing option menu
-● │ Restore the branch view position after refreshing
-● │ Fix reloading of references to not cause access to freed memory
-● │ Predefined external command: git commit
-● │ Fix previous/next with branch+main view
-● │ Add support for sorting branch entries by name, date and author
-● │ Add support for sorting tree entries by name, date or author
-● │ Branch view: fix loading to handle when two branches have same commit
-● │ Use temporary variable in refs loop in main_draw
-● │ Minor fix to always sort even if allocation fails in get_refs
-● │ Add primitive branch view
-● │ Add missing NULL in blame_grep
-● │ Fix a potential problem with reading tokens larger then BUFSIZ
-● │ Update the current branch information when reloading all references
-● │ Define an allocator for run requests
-● │ Remove the need for alloc variables
-● │ Make the granular allocators more customizable using macros
-● │ Define a tree_grep and fixing searching
-● │ Simplify searching in view lines by defining grep_text utility
-● │ Reduce memory and startup time by storing author times as time_t
-● │ Add small cache for author names to reduce memory foot-print
-│ ● Update for version tig-0.14.1
+∙ │ │ Show the active (instead of the default) keybindings in the help view
+│ │ ∙ Add an option (and toggle) for shortening the date column by skipping the time.
+∙─│─╯ Build with asciidoc-8.4.5
+∙ │ Fixed some uninitialized variable warnings
+∙ │ Allow multiple text attributes for color commands
+∙ │ Remove macros which are only used for default option values
+∙ │ Make height of split view configurable
+∙ │ Manual: document that :<number> jumps to the line number
+∙ │ Fix memory allocation check in open_commit_parent_menu
+∙ │ Use menus with the commit subject to present selectable commit parents
+∙ │ Add simple support for showing menues and use it for showing option menu
+∙ │ Restore the branch view position after refreshing
+∙ │ Fix reloading of references to not cause access to freed memory
+∙ │ Predefined external command: git commit
+∙ │ Fix previous/next with branch+main view
+∙ │ Add support for sorting branch entries by name, date and author
+∙ │ Add support for sorting tree entries by name, date or author
+∙ │ Branch view: fix loading to handle when two branches have same commit
+∙ │ Use temporary variable in refs loop in main_draw
+∙ │ Minor fix to always sort even if allocation fails in get_refs
+∙ │ Add primitive branch view
+∙ │ Add missing NULL in blame_grep
+∙ │ Fix a potential problem with reading tokens larger then BUFSIZ
+∙ │ Update the current branch information when reloading all references
+∙ │ Define an allocator for run requests
+∙ │ Remove the need for alloc variables
+∙ │ Make the granular allocators more customizable using macros
+∙ │ Define a tree_grep and fixing searching
+∙ │ Simplify searching in view lines by defining grep_text utility
+∙ │ Reduce memory and startup time by storing author times as time_t
+∙ │ Add small cache for author names to reduce memory foot-print
+│ ∙ Update for version tig-0.14.1
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.14.1
-● │ Remove unneeded doupdate from view_driver
-● │ Keep the cursor fixed while initial stage progress is reported
-● │ Fix draw_lineno to always set the static format buffer
-● │ Fix bug in draw_space to not access memory outside the space buffer
-● │ Refactor draw_lineno to use draw_graphic
-● │ Fix horizontal scrolling
-● │ Remove limitation of horizontal scrolling
-● │ tigrc(5): suggest git aliases for external commands requiring shell ops
-● │ Fix the view clearing to only be effective for displayed views
-● │ Make behavior of horizontal scrolling configurable
-● │ Fix handling of quoted strings in the config file
-● │ tigrc(5): fix error in examples for the set command
-● │ Tree view: draw submodule entry modes as "m---------"
-● │ Status view: report failures to update a file
-● │ Ignore broken pipe signals
-● │ Use putenv instead of setenv
-● │ manual: Correct the keys to move the cursor one line up/down
-● │ Status view: upon failure to open a file show error message
-● │ Refactor and share view maximization code from view-close handling
-● │ Fix io_strerror return type
-● │ Add support for handling core.worktree
-● │ Optimize read_repo_config_option to reduce string comparisons
-● │ Move setting of remote branch from repo config to separate function
-● │ Mark enum_maps and other data tables as const
-● │ Use check_blame_commit when handling REQ_ENTER
-● │ NEWS: Mention Jeff's uninitialized variable bug fix
-● │ Handle blaming beyond the creation of file more gracefully
-● │ Blame view: add guesstimation of line number when blaming parent commit
-● │ Use file and line number information when loading blame for commit
-● │ Make the blame view expand tabs at drawing time
-● │ Introduce common view position update helper
-● │ Improve restoring of the view position to bound the offset
-● │ Jump to line when a number is entered in the prompt
-● │ Warn users about integers in ~/.tigrc being out of bound
-● │ Fix uninitialized variable in string_expand_length
-● │ Add support for 256 colors by allowing "colorN" names similar to Mutt
-● │ Improve on branch information in the status view
-● │ Simplify setting the default for the system configuration file
-● │ Refactor and unify timezone parsing
-● │ Remove the need for the OPEN_NOMAXIMIZE flag
-● │ Remove unused OPEN_BACKGROUNDED flag
-● │ Use enum_map for handling obsolete color names
-● │ Use enum_map for handling obsolete request names
-● │ Refactor the int_map interface into new enum_map interface
-● │ Cleanup and simplify option file parsing
-│ ● Update for version tig-0.14
+∙─│─╯ tig-0.14.1
+∙ │ Remove unneeded doupdate from view_driver
+∙ │ Keep the cursor fixed while initial stage progress is reported
+∙ │ Fix draw_lineno to always set the static format buffer
+∙ │ Fix bug in draw_space to not access memory outside the space buffer
+∙ │ Refactor draw_lineno to use draw_graphic
+∙ │ Fix horizontal scrolling
+∙ │ Remove limitation of horizontal scrolling
+∙ │ tigrc(5): suggest git aliases for external commands requiring shell ops
+∙ │ Fix the view clearing to only be effective for displayed views
+∙ │ Make behavior of horizontal scrolling configurable
+∙ │ Fix handling of quoted strings in the config file
+∙ │ tigrc(5): fix error in examples for the set command
+∙ │ Tree view: draw submodule entry modes as "m---------"
+∙ │ Status view: report failures to update a file
+∙ │ Ignore broken pipe signals
+∙ │ Use putenv instead of setenv
+∙ │ manual: Correct the keys to move the cursor one line up/down
+∙ │ Status view: upon failure to open a file show error message
+∙ │ Refactor and share view maximization code from view-close handling
+∙ │ Fix io_strerror return type
+∙ │ Add support for handling core.worktree
+∙ │ Optimize read_repo_config_option to reduce string comparisons
+∙ │ Move setting of remote branch from repo config to separate function
+∙ │ Mark enum_maps and other data tables as const
+∙ │ Use check_blame_commit when handling REQ_ENTER
+∙ │ NEWS: Mention Jeff's uninitialized variable bug fix
+∙ │ Handle blaming beyond the creation of file more gracefully
+∙ │ Blame view: add guesstimation of line number when blaming parent commit
+∙ │ Use file and line number information when loading blame for commit
+∙ │ Make the blame view expand tabs at drawing time
+∙ │ Introduce common view position update helper
+∙ │ Improve restoring of the view position to bound the offset
+∙ │ Jump to line when a number is entered in the prompt
+∙ │ Warn users about integers in ~/.tigrc being out of bound
+∙ │ Fix uninitialized variable in string_expand_length
+∙ │ Add support for 256 colors by allowing "colorN" names similar to Mutt
+∙ │ Improve on branch information in the status view
+∙ │ Simplify setting the default for the system configuration file
+∙ │ Refactor and unify timezone parsing
+∙ │ Remove the need for the OPEN_NOMAXIMIZE flag
+∙ │ Remove unused OPEN_BACKGROUNDED flag
+∙ │ Use enum_map for handling obsolete color names
+∙ │ Use enum_map for handling obsolete request names
+∙ │ Refactor the int_map interface into new enum_map interface
+∙ │ Cleanup and simplify option file parsing
+│ ∙ Update for version tig-0.14
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.14
-● │ Read tigrc(5) options from git configuration files
-● │ tig(1): correct info on tree view related environment variables
-● │ Add release script documenting the release procedure
-● │ Spell check all text files and add dictionary to speed it up
-● │ tigrc(5): document the tree view colors
-● │ Refactor file mode drawing; rename tree-mode color to mode
-● │ Replace usage of the main-author color with the author color
-● │ Move usage string near parse_options
-● │ Tree view: improve handling of empty trees
-● │ Fix reverting of unmerged status entries
-● │ Add support for horizontal scrolling
-● │ Expand tabs in displayed lines to not rely on ncurses to expand them
-● │ Treat empty '/' as "find next"
-● │ TODO: elaborate and regroup into 'before tig-1.0' and 'long term goals'
-● │ Move initial view setup into parse_options
-● │ Move parse_option so it has access to view definitions
-● │ Remove parsing of deprecated option -S and subcommands log and diff
-● │ Rename & move read_properties and git_properties
-● │ Use warn() for warnings emitted during config file loading
-● │ Fix scrolling bugs in gnome-terminal and (u)xterm
-● │ BUGS: document problem with scrolling in (u)xterm
-● │ Tune the view clearing to wait until 2 seconds has passed
-● │ Handle all cursor positioning in get_input
-● │ Optimize drawing by updating the screen in one go
-● │ Abbreviate author names to initials when author-width < 6
-● │ Refactor author drawing into draw_author
-● │ Fix tokenizing when parsing ~/.tigrc
-● │ Workaround bug exposed by the redrawwin removal in do_scroll_view
-● │ Make cursor updating when resizing the display and loading a view
-● │ Change scrollok strategy to leave it off unless when calling wscrl
-● │ Initialize status_empty flag to FALSE
-● │ Eliminate unneeded calls to redrawwin
-● │ TODO: a small commit cache should be employed at some point
-● │ Help view: show the action name similar as in Mutt's help view
-● │ Remove preallocation of view lines in help_open
-● │ corrected doubly used ID view-manipulation in manual.txt
-● │ tigrc(5) & manual: move view specific actions out of the misc group
-● │ Add support for loading blame for parent commits
-● │ Refactor prompting for user input
-● │ Rename tree-parent action to parent
-● │ Minor cleanup of the tree view code; fix enter on the first line
-● │ TODO: remove resolved item
-● │ Tree view: improve to look less like plumbing
-● │ Refactor main_read to create parse_author_line
-● │ update_view: remove an unneeded goto
-● │ Fix floating point bug in the blame reporting
-● │ Also call end_update for views with custom open function
-● │ Add -O0 to the debug flags
-● │ Rectify arg indexes changes in blame --no-color fix
-● │ Fix status loading of unmerged entries to avoid access to freed memory
-● │ Fix kill_io() to only call kill(2) when pid is non-zero
-● │ Blame view: fix reloading of the diff view for changes not yet committed
-● │ Oops, always specify --no-color when using git diff
-● │ Blame view: fix diffing of lines marked as not yet committed
-● │ Add support for restoring the view position in reloadable views
-● │ Fix status_exists to be consistent with data displayed in the stage view
-● │ Make it possible to call select_view_line for non-displayed views
-● │ Refactor find_next_line into select_view_line
-● │ Refactor user input handling into separate function
-● │ Add support for opening any blob in an editor
-● │ Prefer werase to wclear when possible to reduce flickering
-● │ Cleanup and improve option toggling actions to include help message
-● │ Fix stage reloading to not close when staging chunks from group diff
-● │ Do not terminate the update when switching back to a loading view
-● │ Fix regression of main view drawing
-● │ Cleanup update_view's read loop
-● │ Fix regression in handling of data for non-UTF-8 locales
-● │ Fix another regression from the dirty flag changes causing flickering
-● │ Fix serious bug where a stack allocated variable was returned
-● │ Improve messages when preparing to load blame commits
-● │ Fix regressions introduced in the last few dirty flag changes
-● │ Tree view: make drawing more smooth by using the dirty flag
-● │ Cleanup redrawing of views when updating by using the dirty flag
-● │ Cleanup the tree_read sorting loop
-● │ Fix memory corruption bug in tree_read when sorting the entries
-● │ Cleanup and simplify the code by introducing add_line_format
-● │ Cleanup the code by calling realloc_lines in add_line_data
-│ ● Sync docs
+∙─│─╯ tig-0.14
+∙ │ Read tigrc(5) options from git configuration files
+∙ │ tig(1): correct info on tree view related environment variables
+∙ │ Add release script documenting the release procedure
+∙ │ Spell check all text files and add dictionary to speed it up
+∙ │ tigrc(5): document the tree view colors
+∙ │ Refactor file mode drawing; rename tree-mode color to mode
+∙ │ Replace usage of the main-author color with the author color
+∙ │ Move usage string near parse_options
+∙ │ Tree view: improve handling of empty trees
+∙ │ Fix reverting of unmerged status entries
+∙ │ Add support for horizontal scrolling
+∙ │ Expand tabs in displayed lines to not rely on ncurses to expand them
+∙ │ Treat empty '/' as "find next"
+∙ │ TODO: elaborate and regroup into 'before tig-1.0' and 'long term goals'
+∙ │ Move initial view setup into parse_options
+∙ │ Move parse_option so it has access to view definitions
+∙ │ Remove parsing of deprecated option -S and subcommands log and diff
+∙ │ Rename & move read_properties and git_properties
+∙ │ Use warn() for warnings emitted during config file loading
+∙ │ Fix scrolling bugs in gnome-terminal and (u)xterm
+∙ │ BUGS: document problem with scrolling in (u)xterm
+∙ │ Tune the view clearing to wait until 2 seconds has passed
+∙ │ Handle all cursor positioning in get_input
+∙ │ Optimize drawing by updating the screen in one go
+∙ │ Abbreviate author names to initials when author-width < 6
+∙ │ Refactor author drawing into draw_author
+∙ │ Fix tokenizing when parsing ~/.tigrc
+∙ │ Workaround bug exposed by the redrawwin removal in do_scroll_view
+∙ │ Make cursor updating when resizing the display and loading a view
+∙ │ Change scrollok strategy to leave it off unless when calling wscrl
+∙ │ Initialize status_empty flag to FALSE
+∙ │ Eliminate unneeded calls to redrawwin
+∙ │ TODO: a small commit cache should be employed at some point
+∙ │ Help view: show the action name similar as in Mutt's help view
+∙ │ Remove preallocation of view lines in help_open
+∙ │ corrected doubly used ID view-manipulation in manual.txt
+∙ │ tigrc(5) & manual: move view specific actions out of the misc group
+∙ │ Add support for loading blame for parent commits
+∙ │ Refactor prompting for user input
+∙ │ Rename tree-parent action to parent
+∙ │ Minor cleanup of the tree view code; fix enter on the first line
+∙ │ TODO: remove resolved item
+∙ │ Tree view: improve to look less like plumbing
+∙ │ Refactor main_read to create parse_author_line
+∙ │ update_view: remove an unneeded goto
+∙ │ Fix floating point bug in the blame reporting
+∙ │ Also call end_update for views with custom open function
+∙ │ Add -O0 to the debug flags
+∙ │ Rectify arg indexes changes in blame --no-color fix
+∙ │ Fix status loading of unmerged entries to avoid access to freed memory
+∙ │ Fix kill_io() to only call kill(2) when pid is non-zero
+∙ │ Blame view: fix reloading of the diff view for changes not yet committed
+∙ │ Oops, always specify --no-color when using git diff
+∙ │ Blame view: fix diffing of lines marked as not yet committed
+∙ │ Add support for restoring the view position in reloadable views
+∙ │ Fix status_exists to be consistent with data displayed in the stage view
+∙ │ Make it possible to call select_view_line for non-displayed views
+∙ │ Refactor find_next_line into select_view_line
+∙ │ Refactor user input handling into separate function
+∙ │ Add support for opening any blob in an editor
+∙ │ Prefer werase to wclear when possible to reduce flickering
+∙ │ Cleanup and improve option toggling actions to include help message
+∙ │ Fix stage reloading to not close when staging chunks from group diff
+∙ │ Do not terminate the update when switching back to a loading view
+∙ │ Fix regression of main view drawing
+∙ │ Cleanup update_view's read loop
+∙ │ Fix regression in handling of data for non-UTF-8 locales
+∙ │ Fix another regression from the dirty flag changes causing flickering
+∙ │ Fix serious bug where a stack allocated variable was returned
+∙ │ Improve messages when preparing to load blame commits
+∙ │ Fix regressions introduced in the last few dirty flag changes
+∙ │ Tree view: make drawing more smooth by using the dirty flag
+∙ │ Cleanup redrawing of views when updating by using the dirty flag
+∙ │ Cleanup the tree_read sorting loop
+∙ │ Fix memory corruption bug in tree_read when sorting the entries
+∙ │ Cleanup and simplify the code by introducing add_line_format
+∙ │ Cleanup the code by calling realloc_lines in add_line_data
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.13
-● │ Launch mergetool from the project root directory
-● │ Clear the view after 1 second during updates where reading takes long
-● │ IO API: use select(2) to check if pipe is readable when updating a view
-● │ IO API: reindent status_run main loop after the rewrite
-● │ IO API: replace io_gets with helper for scanning buffers
-● │ IO API: use fork+exec
-● │ IO API: use argv internally
-● │ IO API: use file descriptor internally
-● │ IO API: replace init_io_fd with io_open which calls fopen(3)
-● │ IO API: use in the status view
-● │ IO API: use when loading repository properties
-● │ IO API: use in the stage view
-● │ IO API: obsolete opt_pipe
-● │ IO API: obsolete opt_cmd by using prepare_update in status_enter
-● │ IO API: use prepare_update when parsing command line arguments
-● │ IO API: use in add_describe_ref
-● │ IO API: use in the blame view
-● │ IO API: unify tree view and the default path in begin_update
-● │ IO API: use for the main, log, diff, tree and blob views
-● │ IO API: use when preparing to run commands from the prompt
-● │ IO API: convert status checkout/revert support
-● │ IO API: use when running external commands
-● │ IO API: refactor the run request command formatter
-● │ IO API: add small library for reading files and running programs
-● │ Blame: do to not reload the diff view for same commits
-● │ Blame: update blame to selected commit when pressing 'B'
-● │ Blame: remove unused member of struct blame
-● │ Add setup_update for initialize incremental view updates
-● │ Slightly reduce memory usage for keybindings
-● │ Move formatting of blame --incremental command to blame_read_file
-● │ Minor simplification of blame_open
-● │ Don't use view->cmd to share state in the blame view
-● │ Fix drawing loading views that are not displayed.
-● │ Add support for launching the editor from the tree view
-● │ Replace opt_no_head with opt_head_rev in order to save the HEAD rev
-● │ Use switch statement in tree_request
-● │ Refuse to open blame view for all non-file entries in the tree view
-● │ Refuse to open deleted files from the status and stage views
-● │ tigrc(5): minor fixes and improvements from wip/run-command
-● │ Refuse to open a directory in the status and stage view
-● │ Fix waiting for input after executing a run request in pager mode
-● │ update_view: Check the pipes and call end_update() before redrawing
-● │ Use "--" to separate file argument to git-checkout
-● │ Cleanup and fix the main loop to make view point to the current view
-│ ● Sync docs
+∙─│─╯ tig-0.13
+∙ │ Launch mergetool from the project root directory
+∙ │ Clear the view after 1 second during updates where reading takes long
+∙ │ IO API: use select(2) to check if pipe is readable when updating a view
+∙ │ IO API: reindent status_run main loop after the rewrite
+∙ │ IO API: replace io_gets with helper for scanning buffers
+∙ │ IO API: use fork+exec
+∙ │ IO API: use argv internally
+∙ │ IO API: use file descriptor internally
+∙ │ IO API: replace init_io_fd with io_open which calls fopen(3)
+∙ │ IO API: use in the status view
+∙ │ IO API: use when loading repository properties
+∙ │ IO API: use in the stage view
+∙ │ IO API: obsolete opt_pipe
+∙ │ IO API: obsolete opt_cmd by using prepare_update in status_enter
+∙ │ IO API: use prepare_update when parsing command line arguments
+∙ │ IO API: use in add_describe_ref
+∙ │ IO API: use in the blame view
+∙ │ IO API: unify tree view and the default path in begin_update
+∙ │ IO API: use for the main, log, diff, tree and blob views
+∙ │ IO API: use when preparing to run commands from the prompt
+∙ │ IO API: convert status checkout/revert support
+∙ │ IO API: use when running external commands
+∙ │ IO API: refactor the run request command formatter
+∙ │ IO API: add small library for reading files and running programs
+∙ │ Blame: do to not reload the diff view for same commits
+∙ │ Blame: update blame to selected commit when pressing 'B'
+∙ │ Blame: remove unused member of struct blame
+∙ │ Add setup_update for initialize incremental view updates
+∙ │ Slightly reduce memory usage for keybindings
+∙ │ Move formatting of blame --incremental command to blame_read_file
+∙ │ Minor simplification of blame_open
+∙ │ Don't use view->cmd to share state in the blame view
+∙ │ Fix drawing loading views that are not displayed.
+∙ │ Add support for launching the editor from the tree view
+∙ │ Replace opt_no_head with opt_head_rev in order to save the HEAD rev
+∙ │ Use switch statement in tree_request
+∙ │ Refuse to open blame view for all non-file entries in the tree view
+∙ │ Refuse to open deleted files from the status and stage views
+∙ │ tigrc(5): minor fixes and improvements from wip/run-command
+∙ │ Refuse to open a directory in the status and stage view
+∙ │ Fix waiting for input after executing a run request in pager mode
+∙ │ update_view: Check the pipes and call end_update() before redrawing
+∙ │ Use "--" to separate file argument to git-checkout
+∙ │ Cleanup and fix the main loop to make view point to the current view
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Update and improve the manual
-● │ Remove documentation relicts from before the option parsing was changed
-● │ Introduce prefixcmp macro to reduce code verbosity
-● │ Separate blame revision and file argument by "--" to avoid problems
-● │ Add bash completion for the blame subcommand
-● │ Remove outdated comment
-● │ Make more strings const
-● │ Sort references in the order: tags, heads, tracked remotes, remotes
-│ ● Sync docs
+∙─│─╯ Update and improve the manual
+∙ │ Remove documentation relicts from before the option parsing was changed
+∙ │ Introduce prefixcmp macro to reduce code verbosity
+∙ │ Separate blame revision and file argument by "--" to avoid problems
+∙ │ Add bash completion for the blame subcommand
+∙ │ Remove outdated comment
+∙ │ Make more strings const
+∙ │ Sort references in the order: tags, heads, tracked remotes, remotes
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.12.1
-● │ Rename checkout to revert and support individual diff chunks reverts
-● │ Avoid triggering assertion failure when reloading the status view
-● │ Consolidate and share view resetting via new reset_view()
-● │ Help view: move requests from the Misc group into separate groups
-● │ Help view: use "(no key)" instead of "'?'" to not confuse unbound actions
-● │ Clear the status line when closing a view
-● │ Fix bug introduced in commit for using --exclude-standard flag
-● │ Add support for refreshing the log view
-● │ Make OPEN_REFRESH imply OPEN_NOMAXIMIZE
-● │ Simplify view refreshing by adding new OPEN_REFRESH flag for open_view
-● │ Show complete shortlog for small releases
-● │ Improve checkout error reporting
-● │ Cleanup and make option argument strings const
-● │ Improve handling of unmatched quotes in ~/.tigrc
-● │ Make GIT_CONFIG only contain the config subcommand
-● │ Reload repository references when refreshing the main view
-● │ Avoid refreshing views when checkout is canceled by user
-● │ Also allow files to be checked out from stage view
-● │ Cleanup exclude rule setup by using ls-files --exclude-standard flag
-● │ Main: use --topo-order when arguments are given on the command line
-● │ main: automatically refresh after run requests
-● │ status: add support for checking out files with unstaged changes
-● │ TODO: support for jumping to parents' blame in the blame view
-● │ Add script for preparing release announcements
-│ ● Sync docs
+∙─│─╯ tig-0.12.1
+∙ │ Rename checkout to revert and support individual diff chunks reverts
+∙ │ Avoid triggering assertion failure when reloading the status view
+∙ │ Consolidate and share view resetting via new reset_view()
+∙ │ Help view: move requests from the Misc group into separate groups
+∙ │ Help view: use "(no key)" instead of "'?'" to not confuse unbound actions
+∙ │ Clear the status line when closing a view
+∙ │ Fix bug introduced in commit for using --exclude-standard flag
+∙ │ Add support for refreshing the log view
+∙ │ Make OPEN_REFRESH imply OPEN_NOMAXIMIZE
+∙ │ Simplify view refreshing by adding new OPEN_REFRESH flag for open_view
+∙ │ Show complete shortlog for small releases
+∙ │ Improve checkout error reporting
+∙ │ Cleanup and make option argument strings const
+∙ │ Improve handling of unmatched quotes in ~/.tigrc
+∙ │ Make GIT_CONFIG only contain the config subcommand
+∙ │ Reload repository references when refreshing the main view
+∙ │ Avoid refreshing views when checkout is canceled by user
+∙ │ Also allow files to be checked out from stage view
+∙ │ Cleanup exclude rule setup by using ls-files --exclude-standard flag
+∙ │ Main: use --topo-order when arguments are given on the command line
+∙ │ main: automatically refresh after run requests
+∙ │ status: add support for checking out files with unstaged changes
+∙ │ TODO: support for jumping to parents' blame in the blame view
+∙ │ Add script for preparing release announcements
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.12
-● │ Do not show boundary commits by default
-● │ main: implement refreshing by just rerunning the original command
-● │ Continue updates when pipe read has errno "Success"
-│ ● Sync docs
+∙─│─╯ tig-0.12
+∙ │ Do not show boundary commits by default
+∙ │ main: implement refreshing by just rerunning the original command
+∙ │ Continue updates when pipe read has errno "Success"
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Clean up incomplete commits from main view listed for --no-walk
-● │ Remove the global opt_request variable
-● │ TODO: Option for abbreviating author names using just the initials
-● │ Gracefully ignore negative values given to options in ~/.tigrc
-● │ Add option 'author-width' to consumize the width of the author column
-● │ INSTALL: Mention the release notes in the NEWS file
-● │ Update NEWS
-● │ Remove useless check in blame_read_file()
-● │ Rename the gitlink:[] AsciiDoc macro to manpage:[]
-● │ Fix reopening blame view when it is already loading
-● │ Fix the view notification of end of reading
-● │ Makefile: remove bashism from distclean rule
-● │ Add stage-next action to jump to next diff chunk that can be staged
-● │ Make configure check for ncurses header files
-● │ Drop use of \$(...) for popen() and system() calls
-│ ● Sync docs
+∙─│─╯ Clean up incomplete commits from main view listed for --no-walk
+∙ │ Remove the global opt_request variable
+∙ │ TODO: Option for abbreviating author names using just the initials
+∙ │ Gracefully ignore negative values given to options in ~/.tigrc
+∙ │ Add option 'author-width' to consumize the width of the author column
+∙ │ INSTALL: Mention the release notes in the NEWS file
+∙ │ Update NEWS
+∙ │ Remove useless check in blame_read_file()
+∙ │ Rename the gitlink:[] AsciiDoc macro to manpage:[]
+∙ │ Fix reopening blame view when it is already loading
+∙ │ Fix the view notification of end of reading
+∙ │ Makefile: remove bashism from distclean rule
+∙ │ Add stage-next action to jump to next diff chunk that can be staged
+∙ │ Make configure check for ncurses header files
+∙ │ Drop use of \$(...) for popen() and system() calls
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Add NEWS file
-● │ Fix warnings emitted with -pedantic
-● │ Refactor management of the current draw column and max draw width
-● │ Use draw_field() for the author field
-● │ Introduce draw_field() helper for drawing main and blame fields
-● │ Refactor revgraph drawing into draw_graphic()
-● │ blame: simplify handling of incomplete commit information
-● │ Simplify line attribute handling
-● │ Keep line graphics characters in a table initialized on startup
-● │ Add line-graphics option to disable graphics characters for line drawing
-● │ Search checks reference names too
-● │ Document the main-commit colour option
-● │ Let ncurses take care of expanding tabs by setting its TABSIZE variable
-● │ Refreshing the current view when F5 is pressed (like gitk)
-● │ Fix regression from "Improve staging of diff chunks"
-● │ Do not reload status and stage views on errors
-● │ Fix AsciiDoc replacing -- in --with-libiconv
-● │ Squelsh output of update-index when loading the status view (part II)
-● │ Rebind the maximize action to 'O' instead of 'M'
-│ ● Sync docs
+∙─│─╯ Add NEWS file
+∙ │ Fix warnings emitted with -pedantic
+∙ │ Refactor management of the current draw column and max draw width
+∙ │ Use draw_field() for the author field
+∙ │ Introduce draw_field() helper for drawing main and blame fields
+∙ │ Refactor revgraph drawing into draw_graphic()
+∙ │ blame: simplify handling of incomplete commit information
+∙ │ Simplify line attribute handling
+∙ │ Keep line graphics characters in a table initialized on startup
+∙ │ Add line-graphics option to disable graphics characters for line drawing
+∙ │ Search checks reference names too
+∙ │ Document the main-commit colour option
+∙ │ Let ncurses take care of expanding tabs by setting its TABSIZE variable
+∙ │ Refreshing the current view when F5 is pressed (like gitk)
+∙ │ Fix regression from "Improve staging of diff chunks"
+∙ │ Do not reload status and stage views on errors
+∙ │ Fix AsciiDoc replacing -- in --with-libiconv
+∙ │ Squelsh output of update-index when loading the status view (part II)
+∙ │ Rebind the maximize action to 'O' instead of 'M'
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.11
-● │ Use sans-serif font for the README page
-● │ Update copyright notice for the manual
-● │ Remove unused blame line attributes
-● │ Use tables for listing the UI colors
-● │ Minor cleanup in blame_draw
-● │ Setup colors for the selected line in draw_view_line()
-● │ Make the main and blame view share date drawing and date colors
-● │ Squelsh output of update-index when loading the status view
-● │ Avoid splitting the view when navigating stage view in full screen
-● │ Use 3 as the minimum width of formatted line numbers
-● │ Revert "When toggling options redraw the view instead of the whole display"
-● │ Fix compatibility for git rev-parse without --symbolic-full-name
-● │ Error out when starting up in empty main or blame view
-● │ Improve staging of diff chunks
-● │ Reload the status and stage views after a run request has been handled
-● │ Add support for refreshing of the stage view
-● │ When toggling options redraw the view instead of the whole display
-● │ Use werase() instead of wclear() when reloading a view
-● │ Share the line number colors between blame view and others
-● │ Rename load_repo_config() to load_git_config()
-● │ Do not load repository references when acting as a pager
+∙─│─╯ tig-0.11
+∙ │ Use sans-serif font for the README page
+∙ │ Update copyright notice for the manual
+∙ │ Remove unused blame line attributes
+∙ │ Use tables for listing the UI colors
+∙ │ Minor cleanup in blame_draw
+∙ │ Setup colors for the selected line in draw_view_line()
+∙ │ Make the main and blame view share date drawing and date colors
+∙ │ Squelsh output of update-index when loading the status view
+∙ │ Avoid splitting the view when navigating stage view in full screen
+∙ │ Use 3 as the minimum width of formatted line numbers
+∙ │ Revert "When toggling options redraw the view instead of the whole display"
+∙ │ Fix compatibility for git rev-parse without --symbolic-full-name
+∙ │ Error out when starting up in empty main or blame view
+∙ │ Improve staging of diff chunks
+∙ │ Reload the status and stage views after a run request has been handled
+∙ │ Add support for refreshing of the stage view
+∙ │ When toggling options redraw the view instead of the whole display
+∙ │ Use werase() instead of wclear() when reloading a view
+∙ │ Share the line number colors between blame view and others
+∙ │ Rename load_repo_config() to load_git_config()
+∙ │ Do not load repository references when acting as a pager
 ●─│─╮ Merge branch 'master' of remote-server:src/tig
-│ │ ● status: use draw_text completely
-● │ │ Make local tags and normal branches use normal font-weight
-● │ │ Show the tracked remote branch with bold text
-│ │ ● Add draw_lineno() and use when drawing the blame and pager view
-│ │ ● Add action to maximize the current view; bound to M by default
-●─│─╯ Disable opening views that require a git directory when in pager mode
-● │ Fix pager mode by always doing the isatty()
-● │ stage: disable whitespace warnings from git apply when staging updates
-● │ Improve perfomance and usability when updating many files
-● │ Fix and improve status refreshing after updating
-● │ Fix uninitialized variable warning
-● │ Output extra \n on tig -h
-● │ Avoid reloading the status view when nothing was updated
-● │ Oops, fix delimiter documentation
-● │ Add support for preparing the initial commit in the status view
-● │ Rename "main-delim" color to the more generic "delimiter"
-● │ Show the current branch in the status view
-● │ Save current branch from rev-parse output and highlight it
-● │ blame: Fix opening from subdirectory and consecutive invokations
-● │ Remove deprecated options and cleanup option parsing
-● │ More blame view fixes
-● │ Various fixes and improvements of the new blame view
-● │ Add blame view
-● │ Add hack to allow view loading to have multiple phases
-● │ Simplify subcommand option parsing by moving it out of the loop
-● │ draw_text: remove unused col argument
-● │ Use rewritten parent info from --parents to simplify the revgraph
-● │ Move unrelated UTF-8 setup code out of parse_options
-● │ tigrc(5): Improve documentation of new show-* options
-● │ configure: test for git binary and improve config subcommand test
-● │ Call realloc() less often because it is potentially slow.
-● │ New config options show-author, show-date, show-refs, show-line-numbers.
-● │ Fixed displaying local tags.
-● │ New actions toggle-date, toggle-author, and toggle-refs.
-● │ Fix index refreshing into separate call so diff-files is always run
-● │ draw_text: reduce indentation level
-● │ draw_text: minor cleanup to use fewer local variables
-● │ utf8_length: add reserve flag for reserving a trailing character
-● │ TODO: --boundary flag is already used
-● │ 0.11.git
-│ ● Sync docs
+│ │ ∙ status: use draw_text completely
+∙ │ │ Make local tags and normal branches use normal font-weight
+∙ │ │ Show the tracked remote branch with bold text
+│ │ ∙ Add draw_lineno() and use when drawing the blame and pager view
+│ │ ∙ Add action to maximize the current view; bound to M by default
+∙─│─╯ Disable opening views that require a git directory when in pager mode
+∙ │ Fix pager mode by always doing the isatty()
+∙ │ stage: disable whitespace warnings from git apply when staging updates
+∙ │ Improve perfomance and usability when updating many files
+∙ │ Fix and improve status refreshing after updating
+∙ │ Fix uninitialized variable warning
+∙ │ Output extra \n on tig -h
+∙ │ Avoid reloading the status view when nothing was updated
+∙ │ Oops, fix delimiter documentation
+∙ │ Add support for preparing the initial commit in the status view
+∙ │ Rename "main-delim" color to the more generic "delimiter"
+∙ │ Show the current branch in the status view
+∙ │ Save current branch from rev-parse output and highlight it
+∙ │ blame: Fix opening from subdirectory and consecutive invokations
+∙ │ Remove deprecated options and cleanup option parsing
+∙ │ More blame view fixes
+∙ │ Various fixes and improvements of the new blame view
+∙ │ Add blame view
+∙ │ Add hack to allow view loading to have multiple phases
+∙ │ Simplify subcommand option parsing by moving it out of the loop
+∙ │ draw_text: remove unused col argument
+∙ │ Use rewritten parent info from --parents to simplify the revgraph
+∙ │ Move unrelated UTF-8 setup code out of parse_options
+∙ │ tigrc(5): Improve documentation of new show-* options
+∙ │ configure: test for git binary and improve config subcommand test
+∙ │ Call realloc() less often because it is potentially slow.
+∙ │ New config options show-author, show-date, show-refs, show-line-numbers.
+∙ │ Fixed displaying local tags.
+∙ │ New actions toggle-date, toggle-author, and toggle-refs.
+∙ │ Fix index refreshing into separate call so diff-files is always run
+∙ │ draw_text: reduce indentation level
+∙ │ draw_text: minor cleanup to use fewer local variables
+∙ │ utf8_length: add reserve flag for reserving a trailing character
+∙ │ TODO: --boundary flag is already used
+∙ │ 0.11.git
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.10.1
-● │ More verbose diff headers (including dates and committer)
-● │ Fix drawing "outside" the screen in the status and pager views
-● │ Fixed handling of UTF8 tag names and commit messages.
-● │ Make configure search for the ncursesw library first
-● │ Fix compiler warnings: pointer of type ‘void *’ used in arithmetic
-● │ Fix signed char comparison where char is unsigned by default
-● │ Fixed spurious "/bin/sh: --list: command not found" error
-│ ● Sync docs
+∙─│─╯ tig-0.10.1
+∙ │ More verbose diff headers (including dates and committer)
+∙ │ Fix drawing "outside" the screen in the status and pager views
+∙ │ Fixed handling of UTF8 tag names and commit messages.
+∙ │ Make configure search for the ncursesw library first
+∙ │ Fix compiler warnings: pointer of type ‘void *’ used in arithmetic
+∙ │ Fix signed char comparison where char is unsigned by default
+∙ │ Fixed spurious "/bin/sh: --list: command not found" error
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Refresh the index when opening the status view to avoid "empty diffs"
-● │ Add rename support to the status view
-● │ Make it more clear that use of configure (and autoreconf) is optional
-● │ Replace SYSCONFDIR value in distributed documentation distributed
-● │ tig-0.10.1.git
-│ ● Sync docs
+∙─│─╯ Refresh the index when opening the status view to avoid "empty diffs"
+∙ │ Add rename support to the status view
+∙ │ Make it more clear that use of configure (and autoreconf) is optional
+∙ │ Replace SYSCONFDIR value in distributed documentation distributed
+∙ │ tig-0.10.1.git
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-│ │ ● Replace SYSCONFDIR value in distributed documentation distributed
-│ ● │ Sync docs
+│ │ ∙ Replace SYSCONFDIR value in distributed documentation distributed
+│ ∙ │ Sync docs
 │ ●─│─╮ Merge branch 'master' into release
-●─│─┴─╯ tig-0.10
-● │ Make command line parsing more compatible with gitk
-● │ Add system-wide configuration file and new config file environment vars
-● │ Make it possible to overwrite the default (terminal) colors
-● │ Add support for showing boundary commits in the main view
-● │ Drop -B from diff options
-● │ Simplify documentation building and fix asciidoc.conf dependency
-● │ Replace the manpage XSL workarounds with AsciiDoc conf workarounds
-● │ INSTALL: Document the optional documentation tools
-● │ Update manpages to not contain contain so many formatting workarounds
-● │ Added examples to tig(1) manpage
-● │ TODO: Mention tig.c splitting and revgraph rewrite
-● │ Install manpages in \$(prefix)/share/man
-● │ Updated .gitignore
-● │ Removed trailing whitespace.
-● │ Added action tree-parent and bound it to backspace by default.
-● │ Added color option main-revgraph to color the revision graph.
-● │ Add documentation for undocumented color options.
-● │ Minor formatting and spelling fixes.
-● │ Ignore HTML files in general
-● │ manual: remove section on porcelains
-● │ Makefile: add ASCIIDOC_FLAGS
-● │ Avoid using git-diff since it might run external diff drivers
-● │ Use --no-color option when calling git-log and git-diff
-● │ Rearrange the order of option parsing
-● │ Fix crash when opening mergetool for lines that are not unmerged
-● │ Use get_key_name() in get_key()
-● │ Add missing = for comparison in obsolete actions check
-● │ Collect remaining string in last entry when parsing config file lines
-● │ Improve sanity check error messages
-● │ Obsolete the cherry-pick action and define as builtin external command
-● │ Add support binding keys to running external commands
-● │ Unify REQ_NONE and REQ_UNKNOWN by moving REQ_NONE to be the last request
-● │ tig-0.10.git
-│ ● Sync docs
-│ ● Sync docs
+∙─│─┴─╯ tig-0.10
+∙ │ Make command line parsing more compatible with gitk
+∙ │ Add system-wide configuration file and new config file environment vars
+∙ │ Make it possible to overwrite the default (terminal) colors
+∙ │ Add support for showing boundary commits in the main view
+∙ │ Drop -B from diff options
+∙ │ Simplify documentation building and fix asciidoc.conf dependency
+∙ │ Replace the manpage XSL workarounds with AsciiDoc conf workarounds
+∙ │ INSTALL: Document the optional documentation tools
+∙ │ Update manpages to not contain contain so many formatting workarounds
+∙ │ Added examples to tig(1) manpage
+∙ │ TODO: Mention tig.c splitting and revgraph rewrite
+∙ │ Install manpages in \$(prefix)/share/man
+∙ │ Updated .gitignore
+∙ │ Removed trailing whitespace.
+∙ │ Added action tree-parent and bound it to backspace by default.
+∙ │ Added color option main-revgraph to color the revision graph.
+∙ │ Add documentation for undocumented color options.
+∙ │ Minor formatting and spelling fixes.
+∙ │ Ignore HTML files in general
+∙ │ manual: remove section on porcelains
+∙ │ Makefile: add ASCIIDOC_FLAGS
+∙ │ Avoid using git-diff since it might run external diff drivers
+∙ │ Use --no-color option when calling git-log and git-diff
+∙ │ Rearrange the order of option parsing
+∙ │ Fix crash when opening mergetool for lines that are not unmerged
+∙ │ Use get_key_name() in get_key()
+∙ │ Add missing = for comparison in obsolete actions check
+∙ │ Collect remaining string in last entry when parsing config file lines
+∙ │ Improve sanity check error messages
+∙ │ Obsolete the cherry-pick action and define as builtin external command
+∙ │ Add support binding keys to running external commands
+∙ │ Unify REQ_NONE and REQ_UNKNOWN by moving REQ_NONE to be the last request
+∙ │ tig-0.10.git
+│ ∙ Sync docs
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.9.1
-● │ SITES: 'Tarballs' is a bit more telling than 'Releases'
-● │ Cleanup status_request to make it reload the status view by default
-● │ Add support for launching git-mergetool from the status view
-● │ Refactor code to open_external_viewer
-● │ Detect working trees and disable the status view when it is missing
-● │ Document the refresh request
-● │ Ignore REQ_NONE in the help view and improve unbound request handling
-● │ Never put the release number in the tarball name for tagged versions
-● │ Also ignore generated .md5 files for tarballs
-● │ Add support for refreshing/reloading the status view
-● │ Remove unused 'view' argument from open_editor
-● │ Include autoconf file for 'make dist'
-● │ Fix the clean rule to never remove generated doc files
-● │ Fix out-of-range lineno when reloading the status view
-● │ Fix open_editor to make the file path relative to the project root
-● │ Handle REQ_NONE upfront in view_driver
-● │ Support cherry-picking commits in main view to current branch
-● │ Oops, always ensure that ICONV_CONST is defined
-● │ Use the more advanced iconv.m4 script from ELinks
-● │ tig-0.9.1.git
-│ ● Sync docs
+∙─│─╯ tig-0.9.1
+∙ │ SITES: 'Tarballs' is a bit more telling than 'Releases'
+∙ │ Cleanup status_request to make it reload the status view by default
+∙ │ Add support for launching git-mergetool from the status view
+∙ │ Refactor code to open_external_viewer
+∙ │ Detect working trees and disable the status view when it is missing
+∙ │ Document the refresh request
+∙ │ Ignore REQ_NONE in the help view and improve unbound request handling
+∙ │ Never put the release number in the tarball name for tagged versions
+∙ │ Also ignore generated .md5 files for tarballs
+∙ │ Add support for refreshing/reloading the status view
+∙ │ Remove unused 'view' argument from open_editor
+∙ │ Include autoconf file for 'make dist'
+∙ │ Fix the clean rule to never remove generated doc files
+∙ │ Fix out-of-range lineno when reloading the status view
+∙ │ Fix open_editor to make the file path relative to the project root
+∙ │ Handle REQ_NONE upfront in view_driver
+∙ │ Support cherry-picking commits in main view to current branch
+∙ │ Oops, always ensure that ICONV_CONST is defined
+∙ │ Use the more advanced iconv.m4 script from ELinks
+∙ │ tig-0.9.1.git
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.9
-● │ Change the default styles for the status view
-● │ Update documentation
-│ ● Sync docs
+∙─│─╯ tig-0.9
+∙ │ Change the default styles for the status view
+∙ │ Update documentation
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Force adding of doc files in the release-doc rule
-● │ Fix INSTALL
-● │ Build intermediate tig.o file to fix tig dependency on config.h
-● │ Ensure ICONV_INBUF_TYPE is always defined; fix GIT_CONFIG define
-● │ Guard config.h include with HAVE_CONFIG_H
-● │ Define TIG_VERSION as intended when autoconf was introduced
-● │ Change last commit to make tig depend on config.h
-● │ Make tig.c depend on config.h when using configure
-● │ Add CC to the list of expanded symbols by configure
-● │ Allow LDLIBS to be overriden by configure
-● │ Fix warning from blob_read returning pointer instead of bool
-● │ stage: add request handler supporting file edits and chunk staging
-● │ Add stage view, which is used for showing status changes
-● │ autoconf: check for the AsciiDoc and XmlTo document tools
-● │ autoconf: check whether to use git-config or git-repo-config
-● │ Add autoconf-based build infrastructure for tig
-● │ tree: use simple stack to remember the previous subtree line numbers
-● │ Only show the command being loaded from for the pager view
-● │ TODO: tig now has a status view
-● │ Make it possible to browse all status changes once the diff view is open
-● │ Fix handling of REQ_NEXT/REQ_PREVIOUS
-● │ Fix updating of the view title to show the current position in the view
-● │ Warn about nothing to enter if REQ_ENTER reaches the view_driver switch
-● │ status: implement support for opening files in editor
-● │ status: cleanup status_request by resurrection status_enter
-● │ status: "wire" REQ_STATUS_UPDATE handling through status_request
-● │ Add view request operation for handling view specific requests
-● │ status: fix switching to the main view when starting in status view
-● │ status: improve title and report messages
-● │ status: make it possible to batch updates by pressing on the section line
-● │ status: assert that there are always view lines in the status view
-● │ status: make it possible to see all changes for a status section
-● │ status window: mention 'u' instead of Enter
-● │ Add support for showing staged/unstaged changes and untracked files
-● │ Introduce status-update action bound to 'u' by default
-● │ Avoid flickering when moving past the main view's first and last line
-● │ Ignore generated HTML pages
-● │ Ignore generated manpages.
-● │ Include the tig bash completion script as documentation
-● │ Rename contrib/tig-completion.sh to contrib/tig-completion.bash
-● │ Fix a few typos in the bash completion
-● │ Simplify naming (versioning) of non-release tig tarball and rpm file
-● │ Move tig.spec.in to the contrib area
-● │ Move tigrc to the contrib area
-● │ Add tig bash completion script
-● │ Delete the old VERSION file before appending the new one in make dist
-● │ Use \$(MAKE) instead of 'make' and 'git *' instead of 'git-*'
-● │ tig-0.8.git
-│ ● Sync docs
+∙─│─╯ Force adding of doc files in the release-doc rule
+∙ │ Fix INSTALL
+∙ │ Build intermediate tig.o file to fix tig dependency on config.h
+∙ │ Ensure ICONV_INBUF_TYPE is always defined; fix GIT_CONFIG define
+∙ │ Guard config.h include with HAVE_CONFIG_H
+∙ │ Define TIG_VERSION as intended when autoconf was introduced
+∙ │ Change last commit to make tig depend on config.h
+∙ │ Make tig.c depend on config.h when using configure
+∙ │ Add CC to the list of expanded symbols by configure
+∙ │ Allow LDLIBS to be overriden by configure
+∙ │ Fix warning from blob_read returning pointer instead of bool
+∙ │ stage: add request handler supporting file edits and chunk staging
+∙ │ Add stage view, which is used for showing status changes
+∙ │ autoconf: check for the AsciiDoc and XmlTo document tools
+∙ │ autoconf: check whether to use git-config or git-repo-config
+∙ │ Add autoconf-based build infrastructure for tig
+∙ │ tree: use simple stack to remember the previous subtree line numbers
+∙ │ Only show the command being loaded from for the pager view
+∙ │ TODO: tig now has a status view
+∙ │ Make it possible to browse all status changes once the diff view is open
+∙ │ Fix handling of REQ_NEXT/REQ_PREVIOUS
+∙ │ Fix updating of the view title to show the current position in the view
+∙ │ Warn about nothing to enter if REQ_ENTER reaches the view_driver switch
+∙ │ status: implement support for opening files in editor
+∙ │ status: cleanup status_request by resurrection status_enter
+∙ │ status: "wire" REQ_STATUS_UPDATE handling through status_request
+∙ │ Add view request operation for handling view specific requests
+∙ │ status: fix switching to the main view when starting in status view
+∙ │ status: improve title and report messages
+∙ │ status: make it possible to batch updates by pressing on the section line
+∙ │ status: assert that there are always view lines in the status view
+∙ │ status: make it possible to see all changes for a status section
+∙ │ status window: mention 'u' instead of Enter
+∙ │ Add support for showing staged/unstaged changes and untracked files
+∙ │ Introduce status-update action bound to 'u' by default
+∙ │ Avoid flickering when moving past the main view's first and last line
+∙ │ Ignore generated HTML pages
+∙ │ Ignore generated manpages.
+∙ │ Include the tig bash completion script as documentation
+∙ │ Rename contrib/tig-completion.sh to contrib/tig-completion.bash
+∙ │ Fix a few typos in the bash completion
+∙ │ Simplify naming (versioning) of non-release tig tarball and rpm file
+∙ │ Move tig.spec.in to the contrib area
+∙ │ Move tigrc to the contrib area
+∙ │ Add tig bash completion script
+∙ │ Delete the old VERSION file before appending the new one in make dist
+∙ │ Use \$(MAKE) instead of 'make' and 'git *' instead of 'git-*'
+∙ │ tig-0.8.git
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.8
-● │ Fix pager mode regressions
-● │ Fix (another) integer type mismatch on 64-bit systems
-● │ Fix integer type mismatch on 64-bit systems
-● │ Add TODO about using non-blocking I/O for incremental view loading
-● │ Only emit one "Not a git repository" error message
-● │ Allow CFLAGS to be overridden while preserving VERSION
-● │ Grab path to the git directory; use it when listing untracked files
-● │ read_properties: use size_t instead of int for callback
-● │ Fix wrong uses of string_copy() with pointer instead of buffer
-● │ Fix use of the status view from subdirectories
-● │ Fix string_copy macro to use sizeof(src) for the source buffer
+∙─│─╯ tig-0.8
+∙ │ Fix pager mode regressions
+∙ │ Fix (another) integer type mismatch on 64-bit systems
+∙ │ Fix integer type mismatch on 64-bit systems
+∙ │ Add TODO about using non-blocking I/O for incremental view loading
+∙ │ Only emit one "Not a git repository" error message
+∙ │ Allow CFLAGS to be overridden while preserving VERSION
+∙ │ Grab path to the git directory; use it when listing untracked files
+∙ │ read_properties: use size_t instead of int for callback
+∙ │ Fix wrong uses of string_copy() with pointer instead of buffer
+∙ │ Fix use of the status view from subdirectories
+∙ │ Fix string_copy macro to use sizeof(src) for the source buffer
 ●─│─╮ Merge branch 'jn/rpm-updates'
-│ │ ● Refresh VERSION file when building distribution tarball in "make dist"
-│ │ ● Include documentation sources for rpmbuild with '--without docs'
-│ │ ● Remove PDF version of manual from being build and installed
-● │ │ Make dist rule more robust using '&&'; create .tar.gz.md5 file
-●─│─╯ Fix typo the INSTALL file
-● │ Supply explicit permission bits to 'install'
-● │ tig-0.7.git
-│ ● Sync docs
+│ │ ∙ Refresh VERSION file when building distribution tarball in "make dist"
+│ │ ∙ Include documentation sources for rpmbuild with '--without docs'
+│ │ ∙ Remove PDF version of manual from being build and installed
+∙ │ │ Make dist rule more robust using '&&'; create .tar.gz.md5 file
+∙─│─╯ Fix typo the INSTALL file
+∙ │ Supply explicit permission bits to 'install'
+∙ │ tig-0.7.git
+│ ∙ Sync docs
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ tig-0.7
-● │ Rename sync-docs to release-doc; add release-dist rule
-● │ Various random Makefile cleanups
+∙─│─╯ tig-0.7
+∙ │ Rename sync-docs to release-doc; add release-dist rule
+∙ │ Various random Makefile cleanups
 │ ●─╮ Merge branch 'master' into release
-●─│─╯ Update sync-docs target to use git porcelain instead of cogito
-● │ Infrastructure for tig rpm builds
-● │ Move "static" version info to VERSION file
-● │ Add version information to man pages
-● │ Add manpage XSL from git and enhance with literallayout fixes
-● │ Add status view
-● │ main_read: cleanup and simplify
-● │ Refactor add_line_text parts into add_line_data; use it in main_read
-● │ Add open method to view_ops
-● │ Add notice about empty pager view
-● │ Add notice about empty pager view
-● │ Make keybinding reference more dynamic
-● │ Move space separator from get_key to formatting in open_help_view
-● │ Improve managment of view->ref and the title line
-● │ Be more paranoid about paths when updating the tree view
-● │ move_view: fix view->offset overflow bug
-● │ Introduce add_line_text to simplify pager based rendering
-● │ Fix revision graph visualization during incremental updating
-● │ Add TODO item about diff chunk staging/unstaging
-● │ Make it possible to install man pages and html files separately
-│ ● Fix synced docs ... stupid Mac OS X sed ;)
-│ ● Sync docs
+∙─│─╯ Update sync-docs target to use git porcelain instead of cogito
+∙ │ Infrastructure for tig rpm builds
+∙ │ Move "static" version info to VERSION file
+∙ │ Add version information to man pages
+∙ │ Add manpage XSL from git and enhance with literallayout fixes
+∙ │ Add status view
+∙ │ main_read: cleanup and simplify
+∙ │ Refactor add_line_text parts into add_line_data; use it in main_read
+∙ │ Add open method to view_ops
+∙ │ Add notice about empty pager view
+∙ │ Add notice about empty pager view
+∙ │ Make keybinding reference more dynamic
+∙ │ Move space separator from get_key to formatting in open_help_view
+∙ │ Improve managment of view->ref and the title line
+∙ │ Be more paranoid about paths when updating the tree view
+∙ │ move_view: fix view->offset overflow bug
+∙ │ Introduce add_line_text to simplify pager based rendering
+∙ │ Fix revision graph visualization during incremental updating
+∙ │ Add TODO item about diff chunk staging/unstaging
+∙ │ Make it possible to install man pages and html files separately
+│ ∙ Fix synced docs ... stupid Mac OS X sed ;)
+│ ∙ Sync docs
 │ ●─╮ Merge with tig-0.6
-● │ │ tig-0.6.git
-●─│─╯ Bump the version number to 0.6
-● │ Oops, remove -liconv from LDFLAGS
-● │ Disable show-rev-graph by default
+∙ │ │ tig-0.6.git
+∙─│─╯ Bump the version number to 0.6
+∙ │ Oops, remove -liconv from LDFLAGS
+∙ │ Disable show-rev-graph by default
 ●─│─╮ Merge with master
-│ │ ● Improve handling of remotes
-│ │ ● TODO: use autoconf to detect newer git and git-config availability
-│ │ ● Make tig handle GIT_DIR better
-│ │ ● Drop --stat usage from the main command assembled during option parsing
-│ │ ● Add note about using autoconf to detect iconv(3) presence in libc
-│ │ ● Fix parameter warning for iconv(3)
-│ │ ● Fix SITES URLs; promote git://repo.or.cz/tig.git mirror more
-│ │ ● Discard error messages from git-describe
-│ │ ● Fix commit author line parsing for when the name is empty
+│ │ ∙ Improve handling of remotes
+│ │ ∙ TODO: use autoconf to detect newer git and git-config availability
+│ │ ∙ Make tig handle GIT_DIR better
+│ │ ∙ Drop --stat usage from the main command assembled during option parsing
+│ │ ∙ Add note about using autoconf to detect iconv(3) presence in libc
+│ │ ∙ Fix parameter warning for iconv(3)
+│ │ ∙ Fix SITES URLs; promote git://repo.or.cz/tig.git mirror more
+│ │ ∙ Discard error messages from git-describe
+│ │ ∙ Fix commit author line parsing for when the name is empty
 ●─│─│─╮ Merge with master
-│ │ ●─╯ Never split the tree view when opening another tree view
-│ │ ● Cast second arg to iconv to remove warning
-│ │ ● main_read: handle titles that start with whitespace
-│ │ ● Increase commit.title size from 75 to 128
-│ │ ● Hardwire ERR to mean REQ_NONE in the main loop
-│ │ ● add_keybinding: always allocate the new keybinding
-│ │ ● tig-0.5.git
-│ ● │ Sync docs
+│ │ ∙─╯ Never split the tree view when opening another tree view
+│ │ ∙ Cast second arg to iconv to remove warning
+│ │ ∙ main_read: handle titles that start with whitespace
+│ │ ∙ Increase commit.title size from 75 to 128
+│ │ ∙ Hardwire ERR to mean REQ_NONE in the main loop
+│ │ ∙ add_keybinding: always allocate the new keybinding
+│ │ ∙ tig-0.5.git
+│ ∙ │ Sync docs
 │ ●─│─╮ Merge with master
-│ │ ●─╯ SITES: Point to pasky's git proxy repo.or.cz
-│ │ ● INSTALL: mention possible iconv problems and workarounds
-│ │ ● manual: document the tree/blob environment variables
-│ ● │ Sync docs
+│ │ ∙─╯ SITES: Point to pasky's git proxy repo.or.cz
+│ │ ∙ INSTALL: mention possible iconv problems and workarounds
+│ │ ∙ manual: document the tree/blob environment variables
+│ ∙ │ Sync docs
 │ ●─│─╮ Merge with master
-│ │ ●─╯ Always clear the status window after prompting
-│ │ ● Oops, check log, diff, and show before options
-│ │ ● Use wclrtoeol instead of werase
-│ │ ● Fix clearing of the status window after prompting
-│ │ ● parse_option: check for '-' first and break if it is not an option
-│ │ ● Improve the "input mode" so the cursor is correctly positioned
-│ │ ● add_keybinding: plug memory leak
-│ │ ● TODO: repository status view, better text-input support
-│ │ ● tigrc(5): mention tree/blob view actions; use dash in favour of underscore
-│ │ ● Run the documentation through aspell
-● │ │ push_rev_graph: iterate all graph revs when looking for duplicates
-│ │ ● BUGS: Merge locale support with utf8-only bug, add horizontal scrolling
+│ │ ∙─╯ Always clear the status window after prompting
+│ │ ∙ Oops, check log, diff, and show before options
+│ │ ∙ Use wclrtoeol instead of werase
+│ │ ∙ Fix clearing of the status window after prompting
+│ │ ∙ parse_option: check for '-' first and break if it is not an option
+│ │ ∙ Improve the "input mode" so the cursor is correctly positioned
+│ │ ∙ add_keybinding: plug memory leak
+│ │ ∙ TODO: repository status view, better text-input support
+│ │ ∙ tigrc(5): mention tree/blob view actions; use dash in favour of underscore
+│ │ ∙ Run the documentation through aspell
+∙ │ │ push_rev_graph: iterate all graph revs when looking for duplicates
+│ │ ∙ BUGS: Merge locale support with utf8-only bug, add horizontal scrolling
 ●─│─│─╮ Merge with master
-│ │ ●─╯ Abbreviate the view reference in the view title for small widths
-│ │ ● update_view_title: format load seconds as part of the state string
-│ │ ● update_view_title: use string_format_from instead of wprintw
-│ │ ● A simple fix of the bad wrapping bugs
-│ │ ● update_display_cursor: take view as arg
-● │ │ Make the rev graph visualization have a one rev look-ahead
-● │ │ update_rev_graph: move code to prepare_rev_graph
-● │ │ Allow view readers to 'finalize' by calling with NULL line before closing
-● │ │ append_to_rev_graph: use local variable
-● │ │ Always draw the space between end of rev graph and start of commit title
-● │ │ Refactor (separator, line) chtype management to use 'fillers'
-● │ │ More graph_parent_is_merge usage
-● │ │ draw_rev_graph: refactor stuff to get_rev_graph_symbol
-● │ │ Improve comments
-● │ │ Use 'graph' instead of 'stack' in the rev graph code
-● │ │ Move rev graph code to own section
-● │ │ Move stuff to reset_rev_graph and rename it to done_rev_graph
-● │ │ Simplify the update_rev_graph end-game
-● │ │ Add graph_parent_is_merge
-● │ │ Now it actually starts looking like something
-● │ │ Refactor graph drawing
-● │ │ Remove fprintf stuff
-● │ │ More cleanups
-● │ │ Refector stuff into draw_rev_graph
-● │ │ Some more refactoring and cleanups
-● │ │ Cracking
-● │ │ Minor cleanups
-● │ │ Version 1
-●─│─╯ SIZEOF_REV introduced: 41 bytes of pure madness!
-● │ Minor cleanups
-● │ Oops, always update the tree view ref
-● │ Fix updating of the blob ref and the blob view ref
-● │ Also color Acked-by lines
-● │ Fix redrawing of old current line
-● │ Only split the tree view when the tree view is visible
-● │ move_view: drop redraw arg and handle backgrounded moves
-● │ do_scroll_view: drop redraw arg
-● │ do_scroll_view: minor refactoring of the current line updating
-● │ search_view: use opt_search directly instead of through an argument
-● │ Remove some old cruft that was clearing hidden lines at the end
-● │ Introduce selected flag and use it for refacter wclrtoeol usage
-● │ Add selected arg to the view draw operation
-● │ Refactor current line activation to new select view operation
-● │ Fix tree viewing again; introduced by string safety patch
-● │ Make view->regex into a pointer
-● │ Fix git-describe reference adding when there are no tags and thus no output
-● │ Improve string buffer copy safety
-● │ Hrmpf, fix one more default keybinding clash, this time the blob view
-● │ Review all string_format users and use string_format instead of snprintf
-● │ Move the current line to the first entry in the tree view
-● │ Use ICONV_NONE instead of (iconv_t) -1
-● │ Remove redundant ending ';'
-● │ manual: mention the tree/blob views
-● │ Fix default keybinding clash for 'n' between find-next and toggle-lineno
-● │ Use size_t instead of int for string_* functions
-● │ Reintroduce foreach_view and use it to fix background loading
-● │ Rename foreach_view to foreach_displayed_view
-● │ Add support for tree and blob view
-● │ tig(1): Do not differentiate between git (show|log|diff) options
-● │ Reformat the state variable list (opt_*)
-● │ Add support for searching using regex
-● │ Replace screen-update action with noop action named "none"
-● │ read_prompt: return static allocated buffer; move out exec mode setup
-● │ read_prompt: take prompt 'name' as arg
-● │ SIZEOF_STR: introduced and use instead of 1024, also replaces SIZEOF_CMD
-● │ Add poor man's "show most recent tag" by using git-describe
-● │ add_pager_refs: rename local line data pointer to commit_id
-● │ Add .gitignore file
-│ ● Sync docs
+│ │ ∙─╯ Abbreviate the view reference in the view title for small widths
+│ │ ∙ update_view_title: format load seconds as part of the state string
+│ │ ∙ update_view_title: use string_format_from instead of wprintw
+│ │ ∙ A simple fix of the bad wrapping bugs
+│ │ ∙ update_display_cursor: take view as arg
+∙ │ │ Make the rev graph visualization have a one rev look-ahead
+∙ │ │ update_rev_graph: move code to prepare_rev_graph
+∙ │ │ Allow view readers to 'finalize' by calling with NULL line before closing
+∙ │ │ append_to_rev_graph: use local variable
+∙ │ │ Always draw the space between end of rev graph and start of commit title
+∙ │ │ Refactor (separator, line) chtype management to use 'fillers'
+∙ │ │ More graph_parent_is_merge usage
+∙ │ │ draw_rev_graph: refactor stuff to get_rev_graph_symbol
+∙ │ │ Improve comments
+∙ │ │ Use 'graph' instead of 'stack' in the rev graph code
+∙ │ │ Move rev graph code to own section
+∙ │ │ Move stuff to reset_rev_graph and rename it to done_rev_graph
+∙ │ │ Simplify the update_rev_graph end-game
+∙ │ │ Add graph_parent_is_merge
+∙ │ │ Now it actually starts looking like something
+∙ │ │ Refactor graph drawing
+∙ │ │ Remove fprintf stuff
+∙ │ │ More cleanups
+∙ │ │ Refector stuff into draw_rev_graph
+∙ │ │ Some more refactoring and cleanups
+∙ │ │ Cracking
+∙ │ │ Minor cleanups
+∙ │ │ Version 1
+∙─│─╯ SIZEOF_REV introduced: 41 bytes of pure madness!
+∙ │ Minor cleanups
+∙ │ Oops, always update the tree view ref
+∙ │ Fix updating of the blob ref and the blob view ref
+∙ │ Also color Acked-by lines
+∙ │ Fix redrawing of old current line
+∙ │ Only split the tree view when the tree view is visible
+∙ │ move_view: drop redraw arg and handle backgrounded moves
+∙ │ do_scroll_view: drop redraw arg
+∙ │ do_scroll_view: minor refactoring of the current line updating
+∙ │ search_view: use opt_search directly instead of through an argument
+∙ │ Remove some old cruft that was clearing hidden lines at the end
+∙ │ Introduce selected flag and use it for refacter wclrtoeol usage
+∙ │ Add selected arg to the view draw operation
+∙ │ Refactor current line activation to new select view operation
+∙ │ Fix tree viewing again; introduced by string safety patch
+∙ │ Make view->regex into a pointer
+∙ │ Fix git-describe reference adding when there are no tags and thus no output
+∙ │ Improve string buffer copy safety
+∙ │ Hrmpf, fix one more default keybinding clash, this time the blob view
+∙ │ Review all string_format users and use string_format instead of snprintf
+∙ │ Move the current line to the first entry in the tree view
+∙ │ Use ICONV_NONE instead of (iconv_t) -1
+∙ │ Remove redundant ending ';'
+∙ │ manual: mention the tree/blob views
+∙ │ Fix default keybinding clash for 'n' between find-next and toggle-lineno
+∙ │ Use size_t instead of int for string_* functions
+∙ │ Reintroduce foreach_view and use it to fix background loading
+∙ │ Rename foreach_view to foreach_displayed_view
+∙ │ Add support for tree and blob view
+∙ │ tig(1): Do not differentiate between git (show|log|diff) options
+∙ │ Reformat the state variable list (opt_*)
+∙ │ Add support for searching using regex
+∙ │ Replace screen-update action with noop action named "none"
+∙ │ read_prompt: return static allocated buffer; move out exec mode setup
+∙ │ read_prompt: take prompt 'name' as arg
+∙ │ SIZEOF_STR: introduced and use instead of 1024, also replaces SIZEOF_CMD
+∙ │ Add poor man's "show most recent tag" by using git-describe
+∙ │ add_pager_refs: rename local line data pointer to commit_id
+∙ │ Add .gitignore file
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ prompt: make ':show <id>' use the diff view
-● │ Add support for converting from git encoding to locale encoding
-● │ Pass --root to git-show so the diff command will show the initial commit
-● │ Silence stderr for all view commands
-● │ Improve handling of 'bogus' author lines
-● │ Create directories during make install
-● │ Check the value returned by fopen() during display initialization
-● │ No need to use --stat for the default TIG_MAIN_CMD
-● │ tig-0.4.git
+∙─│─╯ prompt: make ':show <id>' use the diff view
+∙ │ Add support for converting from git encoding to locale encoding
+∙ │ Pass --root to git-show so the diff command will show the initial commit
+∙ │ Silence stderr for all view commands
+∙ │ Improve handling of 'bogus' author lines
+∙ │ Create directories during make install
+∙ │ Check the value returned by fopen() during display initialization
+∙ │ No need to use --stat for the default TIG_MAIN_CMD
+∙ │ tig-0.4.git
 ●─│─╮ Merge with ssh://brok.diku.dk/~/tig
-│ │ ● tigrc(5): Fix keybinding headers
-● │ │ Use docbook to build manual.pdf; clean *.xml files
-│ ● │ Sync docs
+│ │ ∙ tigrc(5): Fix keybinding headers
+∙ │ │ Use docbook to build manual.pdf; clean *.xml files
+│ ∙ │ Sync docs
 │ ●─│─╮ Merge with master
-●─│─│─╯ Add sync-docs rule to update docs in the release branch
-● │ │ Manual: fix page up keys
-● │ │ Add manual link to SITES; improve/fix SEE ALSO sections
-│ ● │ Sync docs
+∙─│─│─╯ Add sync-docs rule to update docs in the release branch
+∙ │ │ Manual: fix page up keys
+∙ │ │ Add manual link to SITES; improve/fix SEE ALSO sections
+│ ∙ │ Sync docs
 │ ●─│─╮ Merge with master
-●─│─┴─╯ CSS fix: s/monospaced/monospace/
-● │ Use tables for the listing of default keybindings
-│ ● Sync docs
+∙─│─┴─╯ CSS fix: s/monospaced/monospace/
+∙ │ Use tables for the listing of default keybindings
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ Documentation update
-● │ Add "Hash" key name mapped to "#"; Don't use ";" as a comment character
-● │ Allow strings to be enclosed in either ' or "
-● │ Make prompt use internal user input reader
+∙─│─╯ Documentation update
+∙ │ Add "Hash" key name mapped to "#"; Don't use ";" as a comment character
+∙ │ Allow strings to be enclosed in either ' or "
+∙ │ Make prompt use internal user input reader
 ●─│─╮ Merge with ssh://diku/~/tig
-│ │ ● Config: improve error reporting and do a few cleanups and simplifications
-● │ │ Rename "encoding" option to "commit-encoding"
-● │ │ Install HTML files into \$(prefix)/share/doc/tig
-● │ │ Add ToC to the tig manual
-● │ │ Misc doc improvements
-●─│─╯ Add support for keybindings
-● │ Rename keymap to keybinding, get_request to get_keybinding
-● │ Add default configuration file
-● │ Add special string comparer for gracefully parsing ~/.tigrc identifiers
-● │ Establish "Open view" section
-● │ Rename load_help_page to open_help_view and move it up
-● │ Move keybinding stuff up after line stuff
-● │ Support set command in ~/.tigrc; allows a few options to be configured
-● │ Simplify the option value tokenization by doing it one place
-● │ Factor out set_option_color from set_option
-● │ Make declaration of die() specify the __NORETURN attribute
-│ ● Sync docs
+│ │ ∙ Config: improve error reporting and do a few cleanups and simplifications
+∙ │ │ Rename "encoding" option to "commit-encoding"
+∙ │ │ Install HTML files into \$(prefix)/share/doc/tig
+∙ │ │ Add ToC to the tig manual
+∙ │ │ Misc doc improvements
+∙─│─╯ Add support for keybindings
+∙ │ Rename keymap to keybinding, get_request to get_keybinding
+∙ │ Add default configuration file
+∙ │ Add special string comparer for gracefully parsing ~/.tigrc identifiers
+∙ │ Establish "Open view" section
+∙ │ Rename load_help_page to open_help_view and move it up
+∙ │ Move keybinding stuff up after line stuff
+∙ │ Support set command in ~/.tigrc; allows a few options to be configured
+∙ │ Simplify the option value tokenization by doing it one place
+∙ │ Factor out set_option_color from set_option
+∙ │ Make declaration of die() specify the __NORETURN attribute
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ Improve error reporting for unknown options
-● │ Add feature request for showing nearest branch heads or tags for a commit
-● │ Makefile: make customization of installation locations easier
-● │ Make the view title show percentage shown like less
-● │ Implement the basic controlling of revision graph visualization
-● │ Add strip rule
-● │ Don't begin any update for the built-in help page
-● │ More color and attribute maps closer to the users
-● │ Simplify detection of tag commits via ^{}
-● │ Minor tidyup
-● │ Generalize the option parsing
-● │ Move tig(1) material to tig.1.txt
-● │ Correct error checking
-● │ Remove prev arg to view->ops->read()
-● │ Wrap all snprintf usage to simplify error handling
-● │ Add support for showing tags and other repo refs in the diff and log view
-● │ Refactor view->line reallocation
-● │ Make 'h' and '?' show built-in key binding quick reference
-● │ Rename documentation build rules using s/docs/doc/; more like git
-● │ Add COPYING file
-● │ Fix segfault where current_view would become >= sizeof(display)
-│ ● Sync docs
+∙─│─╯ Improve error reporting for unknown options
+∙ │ Add feature request for showing nearest branch heads or tags for a commit
+∙ │ Makefile: make customization of installation locations easier
+∙ │ Make the view title show percentage shown like less
+∙ │ Implement the basic controlling of revision graph visualization
+∙ │ Add strip rule
+∙ │ Don't begin any update for the built-in help page
+∙ │ More color and attribute maps closer to the users
+∙ │ Simplify detection of tag commits via ^{}
+∙ │ Minor tidyup
+∙ │ Generalize the option parsing
+∙ │ Move tig(1) material to tig.1.txt
+∙ │ Correct error checking
+∙ │ Remove prev arg to view->ops->read()
+∙ │ Wrap all snprintf usage to simplify error handling
+∙ │ Add support for showing tags and other repo refs in the diff and log view
+∙ │ Refactor view->line reallocation
+∙ │ Make 'h' and '?' show built-in key binding quick reference
+∙ │ Rename documentation build rules using s/docs/doc/; more like git
+∙ │ Add COPYING file
+∙ │ Fix segfault where current_view would become >= sizeof(display)
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ Remove SITES title so it is more adaptive to where it is included
-● │ Split out manual material to separate file
-● │ List SITES in tig(1)
-● │ Move stuff to SITES and INSTALL files
-● │ Move stuff to BUGS and TODO files; only show BUGS in tig(1)
-● │ Move ~/.tigrc documentation into it's own man page, tigrc(5)
-● │ Use ~/.tigrc for user configuration rather than ~/.tig
-● │ Add TODO about keybinding cheat sheet
-● │ Emit more informative error messages when loading ~/.tig
-● │ Only touch the option strings if necessary
-● │ Improve color documentation
-● │ Add support for setting color options in the ~/.tig user configuration file
-● │ Make read_properties take several separator characters; chomp name & value
-● │ Oops, fix short help wrt tab size short option
-● │ Rename repo config loaders using s/config/repo_config/
-● │ Make read_properties() take FILE *pipe instead of command line
-● │ Document the loading time displayed in the title window after 3 seconds
-● │ Make the stop all loading request stop all loading
-● │ Notify that the prompt is unusable while loading
-● │ Tab size short option changes from -t to -b
-● │ Minor usability fix: when closing never switch to an already closed view
-● │ "View commands" section becomes "History commands".
-● │ License revisited: it's GPLv2 or later
-● │ Fix off by one error; makes tags visible again
-● │ When updating the title window, move the cursor to the end of line
-● │ Factor out cursor moving
-● │ Make window switching smother; fix blurring of previous view when switching
-● │ Never close backgrounded loads; only clear window when starting to update
-● │ Only pass on properies with non-zero length names
-● │ Refactor reading of properties from pipes
-● │ Load config before parsing command line options so they can override
-● │ Make UTF-8 handling optional but still default
-● │ Add support for loading repo config
-● │ Cleanup see also section
-● │ Move env handling up below option handling
-● │ Put license also in the program header
-● │ Rearrange pager_enter logic
-● │ Update README; set a less ugly font-family
-● │ Introduce struct line and use it for view->line
-● │ Improve title updating and remove flickering
-● │ Make update reporting less verbose
-● │ Fix spurious resizing of the display (take 2)
-● │ Add macro for getting number of displayed views
-● │ Only resize the display when actually required
-● │ Fix updating of the main view title when the screen isn't split
-● │ End the current update before begining a new one; fixes CPU hogging
-│ ● Sync docs
+∙─│─╯ Remove SITES title so it is more adaptive to where it is included
+∙ │ Split out manual material to separate file
+∙ │ List SITES in tig(1)
+∙ │ Move stuff to SITES and INSTALL files
+∙ │ Move stuff to BUGS and TODO files; only show BUGS in tig(1)
+∙ │ Move ~/.tigrc documentation into it's own man page, tigrc(5)
+∙ │ Use ~/.tigrc for user configuration rather than ~/.tig
+∙ │ Add TODO about keybinding cheat sheet
+∙ │ Emit more informative error messages when loading ~/.tig
+∙ │ Only touch the option strings if necessary
+∙ │ Improve color documentation
+∙ │ Add support for setting color options in the ~/.tig user configuration file
+∙ │ Make read_properties take several separator characters; chomp name & value
+∙ │ Oops, fix short help wrt tab size short option
+∙ │ Rename repo config loaders using s/config/repo_config/
+∙ │ Make read_properties() take FILE *pipe instead of command line
+∙ │ Document the loading time displayed in the title window after 3 seconds
+∙ │ Make the stop all loading request stop all loading
+∙ │ Notify that the prompt is unusable while loading
+∙ │ Tab size short option changes from -t to -b
+∙ │ Minor usability fix: when closing never switch to an already closed view
+∙ │ "View commands" section becomes "History commands".
+∙ │ License revisited: it's GPLv2 or later
+∙ │ Fix off by one error; makes tags visible again
+∙ │ When updating the title window, move the cursor to the end of line
+∙ │ Factor out cursor moving
+∙ │ Make window switching smother; fix blurring of previous view when switching
+∙ │ Never close backgrounded loads; only clear window when starting to update
+∙ │ Only pass on properies with non-zero length names
+∙ │ Refactor reading of properties from pipes
+∙ │ Load config before parsing command line options so they can override
+∙ │ Make UTF-8 handling optional but still default
+∙ │ Add support for loading repo config
+∙ │ Cleanup see also section
+∙ │ Move env handling up below option handling
+∙ │ Put license also in the program header
+∙ │ Rearrange pager_enter logic
+∙ │ Update README; set a less ugly font-family
+∙ │ Introduce struct line and use it for view->line
+∙ │ Improve title updating and remove flickering
+∙ │ Make update reporting less verbose
+∙ │ Fix spurious resizing of the display (take 2)
+∙ │ Add macro for getting number of displayed views
+∙ │ Only resize the display when actually required
+∙ │ Fix updating of the main view title when the screen isn't split
+∙ │ End the current update before begining a new one; fixes CPU hogging
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ Bind 'j'/'k' to moving up/down; add next/previous requests bound to Down/Up
-● │ Move struct commit to appear just above the main view backend
-● │ Add -O2 to CFLAGS to get more warnings
-● │ Cache all queries for refs based on ID
-● │ Move git directory assertion to main; don't require .git repo in pager mode
-● │ In pager mode, fix entering commit lines from log and pager view
-● │ Remove old window cycling code from before enter request appeared
-● │ Add simple window stack, tracking view relation ship via parent member
-● │ Remove objsize member from struct commit
-● │ Make Enter in the pager view always scroll
-● │ Record builds with dirty working tree by appending -dirty to the version
-● │ Remove trailing space; make cursed global static
-● │ Make -h and --help options ouput a help message
-● │ Bind '-' to PageUp; raises Mutt compatibility
-● │ Streamline version displaying and show built date
-● │ Make Enter in the main view switch to the split diff view
-● │ Add preliminary support for UTF-8 handling in the main view
-● │ Add close view request; bound to 'q' by default
-● │ Bind quit to 'Q'
-● │ Add -Werror to the cc debug flags
-● │ Pressing Enter in the diff view will now scroll it one line down
-● │ Rearrange things in the start of the viewer
-● │ Bind 'b' to Page Up, and Space to Page Down
-● │ Make sense of the comment about view->win height
-● │ Group display functions at the bottom
-● │ Redraw the whole display after toggling line number
-● │ Minor documentation updates
-│ ● Sync docs
+∙─│─╯ Bind 'j'/'k' to moving up/down; add next/previous requests bound to Down/Up
+∙ │ Move struct commit to appear just above the main view backend
+∙ │ Add -O2 to CFLAGS to get more warnings
+∙ │ Cache all queries for refs based on ID
+∙ │ Move git directory assertion to main; don't require .git repo in pager mode
+∙ │ In pager mode, fix entering commit lines from log and pager view
+∙ │ Remove old window cycling code from before enter request appeared
+∙ │ Add simple window stack, tracking view relation ship via parent member
+∙ │ Remove objsize member from struct commit
+∙ │ Make Enter in the pager view always scroll
+∙ │ Record builds with dirty working tree by appending -dirty to the version
+∙ │ Remove trailing space; make cursed global static
+∙ │ Make -h and --help options ouput a help message
+∙ │ Bind '-' to PageUp; raises Mutt compatibility
+∙ │ Streamline version displaying and show built date
+∙ │ Make Enter in the main view switch to the split diff view
+∙ │ Add preliminary support for UTF-8 handling in the main view
+∙ │ Add close view request; bound to 'q' by default
+∙ │ Bind quit to 'Q'
+∙ │ Add -Werror to the cc debug flags
+∙ │ Pressing Enter in the diff view will now scroll it one line down
+∙ │ Rearrange things in the start of the viewer
+∙ │ Bind 'b' to Page Up, and Space to Page Down
+∙ │ Make sense of the comment about view->win height
+∙ │ Group display functions at the bottom
+∙ │ Redraw the whole display after toggling line number
+∙ │ Minor documentation updates
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ Fix warnings
-● │ Fix linking with --as-needed ld(1) option.
-● │ Minor doc and coding style fixes
-● │ Mark quit() and die() __noreturn
-● │ Make some strings "const"
+∙─│─╯ Fix warnings
+∙ │ Fix linking with --as-needed ld(1) option.
+∙ │ Minor doc and coding style fixes
+∙ │ Mark quit() and die() __noreturn
+∙ │ Make some strings "const"
 │ ●─╮ Merge with master
-●─│─╯ tig version 0.3
-│ ● Sync docs
+∙─│─╯ tig version 0.3
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ Minor documentation fixes; nothing from git-ls-remote means no git repo
-│ ● Sync docs
+∙─│─╯ Minor documentation fixes; nothing from git-ls-remote means no git repo
+│ ∙ Sync docs
 │ ●─╮ Merge with master
-●─│─╯ After seeing Linus' mail further improve revision specification section
-● │ Make the last variables static
-│ ● Fix File history section
+∙─│─╯ After seeing Linus' mail further improve revision specification section
+∙ │ Make the last variables static
+│ ∙ Fix File history section
 │ ●─╮ Merge with master
-●─│─╯ Fix File history section number
-│ ● Update generated docs
+∙─│─╯ Fix File history section number
+│ ∙ Update generated docs
 │ ●─╮ Merge with master
-●─│─╯ Minor fixes
+∙─│─╯ Minor fixes
 │ ●─╮ Merge with master
-●─│─╯ Only tig(1) is required by the help view
+∙─│─╯ Only tig(1) is required by the help view
 │ ●─╮ Merge with master
-●─│─╯ Only set VERSION to git-describe if .git is available
-│ ● Put documentation in a branch named release
+∙─│─╯ Only set VERSION to git-describe if .git is available
+│ ∙ Put documentation in a branch named release
 │ ●─╮ Merge with master
-●─│─╯ Put documentation in a branch named release
-│ ● Add README.html
+∙─│─╯ Put documentation in a branch named release
+│ ∙ Add README.html
 │ ●─╮ Merge with master
-●─│─╯ You gotta have a README file
-│ ● Create documentation branch
-●─╯ Document file history rev limiting
-● ... and yet more doc ups
-● Check spelling
-● Further improve documentation
-● Lots of documentation improvements
-● Improve documentation; optional tab size; move up/down + enter req; fix wrapping
-● Only save commit tag refs; move line type info to view->ops; switch silently
-● Fix file mode diff header handling; fix repo refs
-● Add support for repository references
-● Oops, no need to #include <readline/readline>
-● Try to improve report("")
-● Implement support for terminal resizing
-● Take commands from the environment
-● Use --topo-order; fclose(stdin); space cleanup
-● Fix title in split view; scroll/move reporting; ...
-● Fix scrolling when current line is outside of splitted view
-● Support for show
-● Improve documentation
-● Fix ref navigation bug; make internal command line work; cleanups
-● Add support for pager view
-● Add support for git log / git diff options
-● Lots of small improvements
-● Meep
-● Lots of cleanups and improvements; speed up attr access
-● Heavy renaming and code recomposition
-● Lots of minor UI improvements
-● Lot's of cleanups and fixes
-● TODO's and TODON'T's ...
-● Primitive option parsing; rendering generalizations
-● Cleanup line matching
-● Started on the main view
-● Sync. Home/End seems to finally work.
-● Possible simplification
-● The pager is begining to work. :)
-● Exploration
-● Misc cleanups
-● Misc cleanups and improvements
-● Show root; blast raw diff lines
-● No binaries
-● Half working prototype
+∙─│─╯ You gotta have a README file
+│ ∙ Create documentation branch
+∙─╯ Document file history rev limiting
+∙ ... and yet more doc ups
+∙ Check spelling
+∙ Further improve documentation
+∙ Lots of documentation improvements
+∙ Improve documentation; optional tab size; move up/down + enter req; fix wrapping
+∙ Only save commit tag refs; move line type info to view->ops; switch silently
+∙ Fix file mode diff header handling; fix repo refs
+∙ Add support for repository references
+∙ Oops, no need to #include <readline/readline>
+∙ Try to improve report("")
+∙ Implement support for terminal resizing
+∙ Take commands from the environment
+∙ Use --topo-order; fclose(stdin); space cleanup
+∙ Fix title in split view; scroll/move reporting; ...
+∙ Fix scrolling when current line is outside of splitted view
+∙ Support for show
+∙ Improve documentation
+∙ Fix ref navigation bug; make internal command line work; cleanups
+∙ Add support for pager view
+∙ Add support for git log / git diff options
+∙ Lots of small improvements
+∙ Meep
+∙ Lots of cleanups and improvements; speed up attr access
+∙ Heavy renaming and code recomposition
+∙ Lots of minor UI improvements
+∙ Lot's of cleanups and fixes
+∙ TODO's and TODON'T's ...
+∙ Primitive option parsing; rendering generalizations
+∙ Cleanup line matching
+∙ Started on the main view
+∙ Sync. Home/End seems to finally work.
+∙ Possible simplification
+∙ The pager is begining to work. :)
+∙ Exploration
+∙ Misc cleanups
+∙ Misc cleanups and improvements
+∙ Show root; blast raw diff lines
+∙ No binaries
+∙ Half working prototype
 ◎ Initial commit
 EOF

--- a/test/graph/regression/horizontal-artifact-test
+++ b/test/graph/regression/horizontal-artifact-test
@@ -31,11 +31,11 @@ assert_equals stdout <<EOF
 ●─╮ Commit A3 - merge A1 and A2
 │ │ ●─╮ Commit B2 - merge A1 and B1
 │ │ │ │ ●─╮ Commit C2 - merge A1 and C1
-●─│─┴─│─╯ │ Commit A1 - after R
+∙─│─┴─│─╯ │ Commit A1 - after R
 │ │ ╭─╯ ╭─╯ ●─╮ Commit D2 - merge R and D1
-│ │ │ ╭─╯ ╭─╯ ● Commit D1 - after R
-│ ● │ │ ╭─╯ ╭─╯ Commit A2 - after R
-│ │ ● │ │ ╭─╯ Commit B1 - after R
-│ │ │ ● │ │ Commit C1 - after R
+│ │ │ ╭─╯ ╭─╯ ∙ Commit D1 - after R
+│ ∙ │ │ ╭─╯ ╭─╯ Commit A2 - after R
+│ │ ∙ │ │ ╭─╯ Commit B1 - after R
+│ │ │ ∙ │ │ Commit C1 - after R
 ◎─┴─┴─┴─┴─╯ Commit R
 EOF

--- a/test/graph/regression/horizontal-bar-wrong-2-test
+++ b/test/graph/regression/horizontal-bar-wrong-2-test
@@ -28,14 +28,14 @@ commit R
 EOF
 
 assert_equals stdout <<EOF
-● Commit A4 - after A3
-│ ● Commit B - after A3
-│ │ ● Commit C - after A3
-│ │ │ ● Commit D - after A2
-│ │ │ │ ● Commit E - after A2
-●─┴─╯ │ │ Commit A3 - after A2
+∙ Commit A4 - after A3
+│ ∙ Commit B - after A3
+│ │ ∙ Commit C - after A3
+│ │ │ ∙ Commit D - after A2
+│ │ │ │ ∙ Commit E - after A2
+∙─┴─╯ │ │ Commit A3 - after A2
 ●─┬───┴─╯ Commit A2 - merge A1 and F
-│ ● Commit F - after R
-● │ Commit A1 - after R
+│ ∙ Commit F - after R
+∙ │ Commit A1 - after R
 ◎─╯ Commit R
 EOF

--- a/test/main/commit-order-edge-case-test
+++ b/test/main/commit-order-edge-case-test
@@ -23,11 +23,11 @@ test_tig
 
 assert_equals 'ensure-topo-order-with-graph.screen' <<EOF
 2014-02-01 22:36 Benjamin Bergman ●─╮ Merge branch 'feature_branch'
-2014-02-01 22:35 Benjamin Bergman │ ● More featuresA
-2014-02-01 22:36 Benjamin Bergman ● │ More master
+2014-02-01 22:35 Benjamin Bergman │ ∙ More featuresA
+2014-02-01 22:36 Benjamin Bergman ∙ │ More master
 2014-02-01 22:21 Benjamin Bergman ●─│─╮ Merge branch 'feature_branch'
-2014-02-01 23:00 Benjamin Bergman │ ●─╯ Add feature
-2014-02-01 22:21 Benjamin Bergman ● │ Add to master
+2014-02-01 23:00 Benjamin Bergman │ ∙─╯ Add feature
+2014-02-01 22:21 Benjamin Bergman ∙ │ Add to master
 2014-02-01 22:18 Benjamin Bergman ◎─╯ init
 
 [main] 324309341617186ec7f9bf2f9b504a956b9c382a - commit 1 of 7             100%
@@ -35,11 +35,11 @@ EOF
 
 assert_equals 'graph-supports-date-order.screen' <<EOF
 2014-02-01 22:36 Benjamin Bergman ●─╮ Merge branch 'feature_branch'
-2014-02-01 22:36 Benjamin Bergman ● │ More master
-2014-02-01 22:35 Benjamin Bergman │ ● More featuresA
+2014-02-01 22:36 Benjamin Bergman ∙ │ More master
+2014-02-01 22:35 Benjamin Bergman │ ∙ More featuresA
 2014-02-01 22:21 Benjamin Bergman ●─│─╮ Merge branch 'feature_branch'
-2014-02-01 23:00 Benjamin Bergman │ ●─╯ Add feature
-2014-02-01 22:21 Benjamin Bergman ● │ Add to master
+2014-02-01 23:00 Benjamin Bergman │ ∙─╯ Add feature
+2014-02-01 22:21 Benjamin Bergman ∙ │ Add to master
 2014-02-01 22:18 Benjamin Bergman ◎─╯ init
 
 [main] 324309341617186ec7f9bf2f9b504a956b9c382a - commit 1 of 7             100%

--- a/test/main/graph-argument-test
+++ b/test/main/graph-argument-test
@@ -50,19 +50,19 @@ test_tig_script 'follow' --follow project/Build.scala <<EOF
 EOF
 
 test_tig_script 'first-parent' --first-parent <<EOF
-2014-03-01 17:26 JFonseca ● WIP: Upgrade to 0.4-SNAPSHOT and DCE
-2014-03-01 15:59 JFonseca ● Add type parameter for js.Dynamic
-2014-01-16 22:51 JFonseca ● Move classes under org.scalajs.benchmark package sco
-2014-01-16 17:43 JFonseca ● Bump Scala.js version to 0.3-SNAPSHOT
-2014-01-16 17:39 JFonseca ● Integrate app code into the benchmark infrastructure
-2014-01-16 07:47 JFonseca ● Merge pull request #4 from phaller/patch-1
-2013-12-17 00:02 JFonseca ● Update links to reflect project name change
-2013-12-03 23:35 JFonseca ● Use Scala.js 0.2-SNAPSHOT
-2013-11-26 23:39 JFonseca ● Extract the benchmark list variable name; fix push t
-2013-11-26 23:31 JFonseca ● Solve the easiest sudoku grid
-2013-11-26 23:22 JFonseca ● Disable phantomjs by default
-2013-11-26 22:55 JFonseca ● Exclude Sudoku when running all benchmarks
-2013-11-26 22:52 JFonseca ● Fix reference setup to work for node
-2013-11-26 22:03 JFonseca ● Move benchmark registration to Scala
+2014-03-01 17:26 JFonseca ∙ WIP: Upgrade to 0.4-SNAPSHOT and DCE
+2014-03-01 15:59 JFonseca ∙ Add type parameter for js.Dynamic
+2014-01-16 22:51 JFonseca ∙ Move classes under org.scalajs.benchmark package sco
+2014-01-16 17:43 JFonseca ∙ Bump Scala.js version to 0.3-SNAPSHOT
+2014-01-16 17:39 JFonseca ∙ Integrate app code into the benchmark infrastructure
+2014-01-16 07:47 JFonseca ∙ Merge pull request #4 from phaller/patch-1
+2013-12-17 00:02 JFonseca ∙ Update links to reflect project name change
+2013-12-03 23:35 JFonseca ∙ Use Scala.js 0.2-SNAPSHOT
+2013-11-26 23:39 JFonseca ∙ Extract the benchmark list variable name; fix push t
+2013-11-26 23:31 JFonseca ∙ Solve the easiest sudoku grid
+2013-11-26 23:22 JFonseca ∙ Disable phantomjs by default
+2013-11-26 22:55 JFonseca ∙ Exclude Sudoku when running all benchmarks
+2013-11-26 22:52 JFonseca ∙ Fix reference setup to work for node
+2013-11-26 22:03 JFonseca ∙ Move benchmark registration to Scala
 [main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 44             31%
 EOF

--- a/test/main/start-on-line-test
+++ b/test/main/start-on-line-test
@@ -16,26 +16,26 @@ EOF
 test_tig +42
 
 assert_equals 'position.screen' <<EOF
-2013-10-29 18:46 Sébastien Doeraene │ ● Update for new groupId and package struc
-2013-10-27 23:05 Jonas Fonseca      ●─╯ Add JavaScript benchmark reference code
-2013-10-27 18:12 Jonas Fonseca      ● Add check sum calculation for verifying ra
-2013-10-26 12:54 Jonas Fonseca      ● Add Scala.js LICENSE file and a cool licen
-2013-10-25 22:08 Jonas Fonseca      ● Add script to build and run all benchmarks
-2013-10-25 20:29 Jonas Fonseca      ● Support node as a JavaScript engine
-2013-10-25 00:34 Jonas Fonseca      ● Run benchmarks for a fixed number of milli
-2013-10-24 23:44 Jonas Fonseca      ● Rework the benchmark runner and add option
-2013-10-18 18:00 Jonas Fonseca      ● Add DeltaBlue benchmark
-2013-10-17 23:11 Jonas Fonseca      ● Tidyup indentation
-2013-10-17 23:09 Jonas Fonseca      ● Use case class apply constructor when addi
+2013-10-29 18:46 Sébastien Doeraene │ ∙ Update for new groupId and package struc
+2013-10-27 23:05 Jonas Fonseca      ∙─╯ Add JavaScript benchmark reference code
+2013-10-27 18:12 Jonas Fonseca      ∙ Add check sum calculation for verifying ra
+2013-10-26 12:54 Jonas Fonseca      ∙ Add Scala.js LICENSE file and a cool licen
+2013-10-25 22:08 Jonas Fonseca      ∙ Add script to build and run all benchmarks
+2013-10-25 20:29 Jonas Fonseca      ∙ Support node as a JavaScript engine
+2013-10-25 00:34 Jonas Fonseca      ∙ Run benchmarks for a fixed number of milli
+2013-10-24 23:44 Jonas Fonseca      ∙ Rework the benchmark runner and add option
+2013-10-18 18:00 Jonas Fonseca      ∙ Add DeltaBlue benchmark
+2013-10-17 23:11 Jonas Fonseca      ∙ Tidyup indentation
+2013-10-17 23:09 Jonas Fonseca      ∙ Use case class apply constructor when addi
 2013-10-18 07:00 Jonas Fonseca      ●─╮ Merge pull request #1 from sjrd/patch-1
-2013-10-18 11:39 Sébastien Doeraene │ ● Fix the "./run.sh opt" invocation.
-2013-10-17 20:34 Jonas Fonseca      ●─╯ Add Richards benchmark
-2013-10-17 20:29 Jonas Fonseca      ● Simplify render scene loop by using Range.
-2013-10-17 20:27 Jonas Fonseca      ● Make the run shell script infrastructure r
-2013-10-17 20:25 Jonas Fonseca      ● Simplify creation of new benchmark project
-2013-10-14 16:28 Jonas Fonseca      ● Add link to the github pages
-2013-10-14 16:19 Jonas Fonseca      ● Add .gitignore file
-2013-10-14 16:09 Jonas Fonseca      ● Move description of the optimizeJS warning
+2013-10-18 11:39 Sébastien Doeraene │ ∙ Fix the "./run.sh opt" invocation.
+2013-10-17 20:34 Jonas Fonseca      ∙─╯ Add Richards benchmark
+2013-10-17 20:29 Jonas Fonseca      ∙ Simplify render scene loop by using Range.
+2013-10-17 20:27 Jonas Fonseca      ∙ Make the run shell script infrastructure r
+2013-10-17 20:25 Jonas Fonseca      ∙ Simplify creation of new benchmark project
+2013-10-14 16:28 Jonas Fonseca      ∙ Add link to the github pages
+2013-10-14 16:19 Jonas Fonseca      ∙ Add .gitignore file
+2013-10-14 16:09 Jonas Fonseca      ∙ Move description of the optimizeJS warning
 2013-10-14 13:15 Jonas Fonseca      ◎ Initial import of Tracer benchmark
 
 


### PR DESCRIPTION
by returning smaller character "Bullet Operator" for ordinary commits