### PR TITLE
add a TODO test category

### DIFF
--- a/test/README.adoc
+++ b/test/README.adoc
@@ -39,6 +39,10 @@ trace::
 
 	Show trace information.
 
+todos::
+
+	Run TODO tests, which are otherwise skipped.
+
 valgrind::
 
 	Run tests and verify memory access with Valgrind.

--- a/test/tigrc/segfault-test
+++ b/test/tigrc/segfault-test
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+. libtest.sh
+
+test_todo "Segfault without 'set reference-format' in tigrc"
+
+export TIGRC_SYSTEM=/dev/null
+
+tigrc <<EOF
+bind generic : prompt
+# sufficient to rescue from crash
+# set reference-format = branch
+EOF
+
+steps ':save-options'
+
+test_tig status
+
+assert_equals stderr <<EOF
+EOF

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -310,7 +310,7 @@ show_test_results()
 
 		# Replace CR used by Git progress messages
 		tr '\r' '\n' < .test-result
-	elif [ "$verbose" ]; then
+	elif [ -n "$verbose" ]; then
 		count="$(grep -c '^ *\[OK\]' < .test-result || true)"
 		printf 'Passed %d assertions\n' "$count"
 	fi | sed "s/^/$indent| /"

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -298,7 +298,7 @@ show_test_results()
 		printf 'No test results found\n'
 	elif grep -q '^ *\[FAIL\]' < .test-result; then
 		failed="$(grep -c '^ *\[FAIL\]' < .test-result || true)"
-		count="$(grep -c '^ *\[(FAIL\|OK\)\]' < .test-result || true)"
+		count="$(grep -c '^ *\[\(FAIL\|OK\)\]' < .test-result || true)"
 
 		printf 'Failed %d out of %d test(s)\n' "$failed" "$count"
 

--- a/test/tools/show-results.sh
+++ b/test/tools/show-results.sh
@@ -25,6 +25,7 @@ tests="$(find test/ -name ".test-result" | grep -c . || true)"
 asserts="$(find test/ -name ".test-result" -exec cat -- "{}" \; | grep -c '^ *\[\(OK\|FAIL\)\]' || true)"
 failures="$(find test/ -name ".test-result" -exec cat -- "{}" \; | grep -c '^ *\[FAIL\]' || true)"
 skipped="$(find test/ -name ".test-skipped" | grep -c . || true)"
+todos="$(find test/ \( -name ".test-skipped" -or -name ".test-skipped-subtest-*" \) -exec cat -- "{}" + | grep -c '^\[TODO\]' || true)"
 
 if [ "$failures" = 0 ]; then
 	printf "Passed %d assertions in %d tests" "$asserts" "$tests"
@@ -33,7 +34,11 @@ else
 fi
 
 if [ "$skipped" != 0 ]; then
-	printf " (%d skipped)" "$skipped"
+	todo_text=""
+	if [ "$todos" != 0 ]; then
+		todo_text=", $todos as todos"
+	fi
+	printf " (%d skipped%s)" "$skipped" "$todo_text"
 fi
 
 printf '\n'


### PR DESCRIPTION
It would be more fancy to run TODOs every time, and report unexpected successes.

Instead this PR creates a `TODO` category which is a simple subset of `skipped`.  TODOs can be executed by adding the string `todos` to `$TEST_OPTS`.

Individual selections within `run_test_cases` are supported, ~~but it would be a bit more work to make the final summary statement have a correct count of skipped TODOs from `run_test_cases`.~~

Edit: updated to 
 * count `run_test_cases` TODOs correctly in `show-results.sh`
 * include an example usage: a test which currently exercises a segfault

