### PR TITLE
flush buffered keystrokes after external viewer

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -64,6 +64,7 @@ open_external_viewer(const char *argv[], const char *dir, bool silent, bool conf
 				fprintf(stderr, "%s", notice);
 			fprintf(stderr, "Press Enter to continue");
 			getc(opt_tty);
+			fseek(opt_tty, 0, SEEK_END);
 		}
 	}
 


### PR DESCRIPTION
by ~~reopening the TTY~~ seeking to `SEEK_END`.  Otherwise keystrokes pressed prior to <kbd>Enter</kbd> hang around and can get read later.

To reproduce:
 * `:bind generic o !ls`
 * <kbd>o</kbd> # *shows listing*
 * <kbd>q</kbd><kbd>Enter</kbd> # *leaves `q` unflushed*
 * <kbd>o</kbd> # *does not show listing; returns immediately due to unflushed character*

