### PR TITLE
Fix #232: Do not generate any input when handling Ctrl-Z

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -43,6 +43,7 @@ Bug fixes:
  - Set cursor position when not updating prompt contents. (GH #647)
  - Erase status line at exit time for users without altscreen-capable terminals.
    (GH #589)
+ - Fix unexpected keys when restoring from suspend (`Ctrl-Z`). (GH #232)
  - contrib/vim.tigrc: Also bind G in the main as a workaround for limitations of
    the `none` action. (GH #594, #599)
  - Only override `blame-options` when commands are given and fix parsing of

--- a/src/display.c
+++ b/src/display.c
@@ -748,6 +748,9 @@ get_input(int prompt_position, struct key *key)
 			resize_display();
 			redraw_display(true);
 
+		} else if (key_value == KEY_CTL('z')) {
+			raise(SIGTSTP);
+
 		} else {
 			int pos, key_length;
 
@@ -772,9 +775,6 @@ get_input(int prompt_position, struct key *key)
 				key->modifiers.control = 1;
 				key_value = key_value | 0x40;
 			}
-
-			if (key_value == KEY_CTL('z'))
-				raise(SIGTSTP);
 
 			if ((key_value >= KEY_MIN && key_value < KEY_MAX) || key_value < 0x1F) {
 				key->data.value = key_value;


### PR DESCRIPTION
Move the special case of Ctrl-Z introduced in
167d59ed1474e10ec3310fe7aa77314247332954 so no input is generated by
get_input.

---

@rolandwalker does this seem reasonable to you?