### PR TITLE
whitespace linting

### DIFF
--- a/compat/hashtab.h
+++ b/compat/hashtab.h
@@ -1,4 +1,4 @@
-/* An expandable hash tables datatype.  
+/* An expandable hash tables datatype.
    Copyright (C) 1999, 2000, 2002, 2003, 2004, 2005, 2009, 2010
    Free Software Foundation, Inc.
    Contributed by Vladimir Makarov (vmakarov@cygnus.com).
@@ -61,7 +61,7 @@ typedef int (*htab_eq) (const void *, const void *);
 /* Cleanup function called whenever a live element is removed from
    the hash table.  */
 typedef void (*htab_del) (void *);
-  
+
 /* Function called by htab_traverse for each live element.  The first
    arg is the slot of the element (which can be passed to htab_clear_slot
    if desired), the second arg is the auxiliary pointer handed to

--- a/contrib/config.make-CYGWIN_NT-6.1
+++ b/contrib/config.make-CYGWIN_NT-6.1
@@ -2,7 +2,7 @@
 #
 # Use ncursesw.
 
-NCURSESW_LIBS = $(shell ncursesw5-config --libs 2>/dev/null) 
+NCURSESW_LIBS = $(shell ncursesw5-config --libs 2>/dev/null)
 HAS_ICONV = $(shell test -e "/usr/include/iconv.h" && echo true)
 
 ifeq ($(NCURSESW_LIBS),)

--- a/contrib/tig-completion.bash
+++ b/contrib/tig-completion.bash
@@ -115,8 +115,8 @@ __tig_complete_file ()
 			-W "$(git --git-dir="$(__tigdir)" ls-tree "$ls" \
 				| sed '/^100... blob /s,^.*	,,
 				       /^040000 tree /{
-				           s,^.*	,,
-				           s,$,/,
+					   s,^.*	,,
+					   s,$,/,
 				       }
 				       s/^.*	//')" \
 			-- "$cur"))
@@ -287,5 +287,5 @@ complete -o default -o nospace -F _tig tig
 # when the user has tab-completed the executable name and consequently
 # included the '.exe' suffix.
 if [ Cygwin = "$(uname -o 2>/dev/null)" ]; then
-complete -o default -o nospace -F _tig tig.exe
+	complete -o default -o nospace -F _tig tig.exe
 fi

--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -22,11 +22,11 @@ struct ref;
  */
 
 #define LINE_INFO(_) \
-	_(DIFF_HEADER,  	"diff --"), \
-	_(DIFF_DEL_FILE,  	"--- "), \
-	_(DIFF_ADD_FILE,  	"+++ "), \
-	_(DIFF_START,   	"---"), \
-	_(DIFF_CHUNK,   	"@@"), \
+	_(DIFF_HEADER,		"diff --"), \
+	_(DIFF_DEL_FILE,	"--- "), \
+	_(DIFF_ADD_FILE,	"+++ "), \
+	_(DIFF_START,		"---"), \
+	_(DIFF_CHUNK,		"@@"), \
 	_(DIFF_ADD,		"+"), \
 	_(DIFF_ADD2,		" +"), \
 	_(DIFF_DEL,		"-"), \
@@ -50,13 +50,13 @@ struct ref;
 	_(CURSOR,		""), \
 	_(STATUS,		""), \
 	_(DELIMITER,		""), \
-	_(DATE,      		""), \
-	_(MODE,      		""), \
+	_(DATE,			""), \
+	_(MODE,			""), \
 	_(ID,			""), \
 	_(OVERFLOW,		""), \
-	_(DIRECTORY,	 	""), \
-	_(FILE,  		""), \
-	_(FILE_SIZE, 		""), \
+	_(DIRECTORY,		""), \
+	_(FILE,			""), \
+	_(FILE_SIZE,		""), \
 	_(LINE_NUMBER,		""), \
 	_(TITLE_BLUR,		""), \
 	_(TITLE_FOCUS,		""), \

--- a/src/diff.c
+++ b/src/diff.c
@@ -205,7 +205,7 @@ diff_common_highlight(struct view *view, const char *text, enum line_type type)
 {
 	struct diff_stat_context context = { text, type, true };
 	enum line_type hi_type = type == LINE_DIFF_ADD
-		               ? LINE_DIFF_ADD_HIGHLIGHT : LINE_DIFF_DEL_HIGHLIGHT;
+				 ? LINE_DIFF_ADD_HIGHLIGHT : LINE_DIFF_DEL_HIGHLIGHT;
 	const char *codes[] = { "\x1b[7m", "\x1b[27m" };
 	const enum line_type types[] = { hi_type, type };
 	int i;

--- a/src/draw.c
+++ b/src/draw.c
@@ -213,7 +213,7 @@ draw_field(struct view *view, enum line_type type, const char *text, int width, 
 		int leftpad = max - textlen - 1;
 
 		if (leftpad > 0) {
-	    		if (draw_space(view, type, leftpad, leftpad))
+			if (draw_space(view, type, leftpad, leftpad))
 				return true;
 			max -= leftpad;
 			col += leftpad;;

--- a/src/main.c
+++ b/src/main.c
@@ -527,7 +527,7 @@ main_request(struct view *view, enum request request, struct line *line)
 
 		if (line->type == LINE_STAT_UNSTAGED
 		    || line->type == LINE_STAT_STAGED)
-			open_stage_view(view, NULL, line->type, flags); 
+			open_stage_view(view, NULL, line->type, flags);
 		else
 			open_diff_view(view, flags);
 		break;

--- a/src/status.c
+++ b/src/status.c
@@ -461,7 +461,7 @@ status_enter(struct view *view, struct line *line)
 			return REQ_NONE;
 		}
 
-	    	if (!suffixcmp(status->new.name, -1, "/")) {
+		if (!suffixcmp(status->new.name, -1, "/")) {
 			report("Cannot display a directory");
 			return REQ_NONE;
 		}

--- a/src/string.c
+++ b/src/string.c
@@ -223,7 +223,7 @@ unicode_width(unsigned long c, int tab_size)
 	    || (c >= 0x20000 && c <= 0x2fffd)
 	    || (c >= 0x30000 && c <= 0x3fffd)))
 		return 2;
-	
+
 	if ((c >= 0x0300 && c <= 0x036f)	/* combining diacretical marks */
 	    || (c >= 0x1dc0 && c <= 0x1dff)	/* combining diacretical marks supplement */
 	    || (c >= 0x20d0 && c <= 0x20ff)	/* combining diacretical marks for symbols */

--- a/src/tig.c
+++ b/src/tig.c
@@ -66,7 +66,7 @@ view_request(struct view *view, enum request request)
 	    view_has_flags(view, VIEW_SEND_CHILD_ENTER)) {
 		struct view *child = display[1];
 
-	    	if (forward_request_to_child(child, request)) {
+		if (forward_request_to_child(child, request)) {
 			view_request(child, request);
 			return REQ_NONE;
 		}
@@ -549,7 +549,7 @@ open_pager_mode(enum request request)
 	} else if (request == REQ_VIEW_DIFF) {
 		if (argv_contains(opt_rev_args, "--stdin"))
 			open_diff_view(NULL, OPEN_FORWARD_STDIN);
-		else              
+		else
 			open_diff_view(NULL, OPEN_STDIN);
 
 	} else {

--- a/test/help/all-keybindings-test.expected
+++ b/test/help/all-keybindings-test.expected
@@ -1,119 +1,119 @@
-Quick reference for tig keybindings:                                                      
-                                                                                          
-[-] generic bindings                                                                      
-View switching                                                                            
-                           m view-main           Show main view                           
-                           d view-diff           Show diff view                           
-                           l view-log            Show log view                            
-                           t view-tree           Show tree view                           
-                           f view-blob           Show blob view                           
-                           b view-blame          Show blame view                          
-                           r view-refs           Show refs view                           
-                        s, S view-status         Show status view                         
-                           c view-stage          Show stage view                          
-                           y view-stash          Show stash view                          
-                           g view-grep           Show grep view                           
-                           p view-pager          Show pager view                          
-                           h view-help           Show help view                           
-View manipulation                                                                         
-                     <Enter> enter               Enter and open selected line             
-                           < back                Go back to the previous view state       
-         <Down>, <Ctrl-N>, J next                Move to next                             
-           <Up>, <Ctrl-P>, K previous            Move to previous                         
-                         ',' parent              Move to parent                           
-                       <Tab> view-next           Move focus to the next view              
-                     R, <F5> refresh             Reload and refresh view                  
-                           O maximize            Maximize the current view                
-                           q view-close          Close the current view                   
-                 Q, <Ctrl-C> quit                Close all views and quit                 
-Cursor navigation                                                                         
-                           k move-up             Move cursor one line up                  
-                           j move-down           Move cursor one line down                
-         <PageDown>, <Space> move-page-down      Move cursor one page down                
-                 <PageUp>, - move-page-up        Move cursor half a page up               
-                    <Ctrl-D> move-half-page-down Move cursor half a page down             
-                    <Ctrl-U> move-half-page-up   Move cursor one page up                  
-                      <Home> move-first-line     Move cursor to first line                
-                       <End> move-last-line      Move cursor to last line                 
-Scrolling                                                                                 
-          <Insert>, <Ctrl-Y> scroll-line-up      Scroll one line up                       
-          <Delete>, <Ctrl-E> scroll-line-down    Scroll one line down                     
-                <ScrollBack> scroll-page-up      Scroll one page up                       
-                 <ScrollFwd> scroll-page-down    Scroll one page down                     
-                           | scroll-first-col    Scroll to the first line columns         
-                      <Left> scroll-left         Scroll two columns left                  
-                     <Right> scroll-right        Scroll two columns right                 
-Searching                                                                                 
-                           / search              Search the view                          
-                           ? search-back         Search backwards in the view             
-                           n find-next           Find next search match                   
-                           N find-prev           Find previous search match               
-Misc                                                                                      
-                           e edit                Open in editor                           
-                           : prompt              Open the prompt                          
-                           o options             Open the options menu                    
-                    <Ctrl-L> screen-redraw       Redraw the screen                        
-                           z stop-loading        Stop all loading views                   
-                           v show-version        Show version information                 
-Option toggling:                                                                          
-                           I :toggle sort-order                                           
-                           i :toggle sort-field                                           
-                           # :toggle line-number                                          
-                           D :toggle date                                                 
-                           A :toggle author                                               
-                           ~ :toggle line-graphics                                        
-                           F :toggle file-name                                            
-                           W :toggle ignore-space                                         
-                           X :toggle id                                                   
-                           $ :toggle commit-title-overflow                                
-                           % :toggle file-filter                                          
-[-] search bindings                                                                       
+Quick reference for tig keybindings:
+
+[-] generic bindings
+View switching
+                           m view-main           Show main view
+                           d view-diff           Show diff view
+                           l view-log            Show log view
+                           t view-tree           Show tree view
+                           f view-blob           Show blob view
+                           b view-blame          Show blame view
+                           r view-refs           Show refs view
+                        s, S view-status         Show status view
+                           c view-stage          Show stage view
+                           y view-stash          Show stash view
+                           g view-grep           Show grep view
+                           p view-pager          Show pager view
+                           h view-help           Show help view
+View manipulation
+                     <Enter> enter               Enter and open selected line
+                           < back                Go back to the previous view state
+         <Down>, <Ctrl-N>, J next                Move to next
+           <Up>, <Ctrl-P>, K previous            Move to previous
+                         ',' parent              Move to parent
+                       <Tab> view-next           Move focus to the next view
+                     R, <F5> refresh             Reload and refresh view
+                           O maximize            Maximize the current view
+                           q view-close          Close the current view
+                 Q, <Ctrl-C> quit                Close all views and quit
+Cursor navigation
+                           k move-up             Move cursor one line up
+                           j move-down           Move cursor one line down
+         <PageDown>, <Space> move-page-down      Move cursor one page down
+                 <PageUp>, - move-page-up        Move cursor half a page up
+                    <Ctrl-D> move-half-page-down Move cursor half a page down
+                    <Ctrl-U> move-half-page-up   Move cursor one page up
+                      <Home> move-first-line     Move cursor to first line
+                       <End> move-last-line      Move cursor to last line
+Scrolling
+          <Insert>, <Ctrl-Y> scroll-line-up      Scroll one line up
+          <Delete>, <Ctrl-E> scroll-line-down    Scroll one line down
+                <ScrollBack> scroll-page-up      Scroll one page up
+                 <ScrollFwd> scroll-page-down    Scroll one page down
+                           | scroll-first-col    Scroll to the first line columns
+                      <Left> scroll-left         Scroll two columns left
+                     <Right> scroll-right        Scroll two columns right
+Searching
+                           / search              Search the view
+                           ? search-back         Search backwards in the view
+                           n find-next           Find next search match
+                           N find-prev           Find previous search match
+Misc
+                           e edit                Open in editor
+                           : prompt              Open the prompt
+                           o options             Open the options menu
+                    <Ctrl-L> screen-redraw       Redraw the screen
+                           z stop-loading        Stop all loading views
+                           v show-version        Show version information
+Option toggling:
+                           I :toggle sort-order
+                           i :toggle sort-field
+                           # :toggle line-number
+                           D :toggle date
+                           A :toggle author
+                           ~ :toggle line-graphics
+                           F :toggle file-name
+                           W :toggle ignore-space
+                           X :toggle id
+                           $ :toggle commit-title-overflow
+                           % :toggle file-filter
+[-] search bindings
 View manipulation
                     <Ctrl-C> view-close          Close the current view
-Searching                                                                                 
-  <Down>, <Ctrl-N>, <Ctrl-J> find-next           Find next search match                   
-    <Up>, <Ctrl-P>, <Ctrl-K> find-prev           Find previous search match               
-[-] main bindings                                                                         
-Option toggling:                                                                          
-                           G :toggle commit-title-graph                                   
-                           F :toggle commit-title-refs                                    
-External commands:                                                                        
-                           C ?git cherry-pick %(commit)                                   
-[-] diff bindings                                                                         
-Option toggling:                                                                          
-                           [ :toggle diff-context -1                                      
-                           ] :toggle diff-context +1                                      
-Internal commands:                                                                        
-                           @ :/^@@                                                        
-[-] refs bindings                                                                         
-External commands:                                                                        
-                           C ?git checkout %(branch)                                      
-                           ! ?git branch -D %(branch)                                     
-[-] status bindings                                                                       
-View-specific actions                                                                     
-                           u status-update       Stage/unstage chunk or file changes      
-                           ! status-revert       Revert chunk or file changes             
-                           M status-merge        Merge file using external tool           
-External commands:                                                                        
-                           C !git commit                                                  
-[-] stage bindings                                                                        
-View-specific actions                                                                     
-                           u status-update       Stage/unstage chunk or file changes      
-                           ! status-revert       Revert chunk or file changes             
-                           1 stage-update-line   Stage/unstage single line                
-                           \ stage-split-chunk   Split current diff chunk                 
-Option toggling:                                                                          
-                           [ :toggle diff-context -1                                      
-                           ] :toggle diff-context +1                                      
-Internal commands:                                                                        
-                           @ :/^@@                                                        
-[-] stash bindings                                                                        
-External commands:                                                                        
-                           A ?git stash apply %(stash)                                    
-                           P ?git stash pop %(stash)                                      
-                           ! ?git stash drop %(stash)                                     
-                                                                                          
-                                                                                          
-                                                                                          
-                                                                                          
+Searching
+  <Down>, <Ctrl-N>, <Ctrl-J> find-next           Find next search match
+    <Up>, <Ctrl-P>, <Ctrl-K> find-prev           Find previous search match
+[-] main bindings
+Option toggling:
+                           G :toggle commit-title-graph
+                           F :toggle commit-title-refs
+External commands:
+                           C ?git cherry-pick %(commit)
+[-] diff bindings
+Option toggling:
+                           [ :toggle diff-context -1
+                           ] :toggle diff-context +1
+Internal commands:
+                           @ :/^@@
+[-] refs bindings
+External commands:
+                           C ?git checkout %(branch)
+                           ! ?git branch -D %(branch)
+[-] status bindings
+View-specific actions
+                           u status-update       Stage/unstage chunk or file changes
+                           ! status-revert       Revert chunk or file changes
+                           M status-merge        Merge file using external tool
+External commands:
+                           C !git commit
+[-] stage bindings
+View-specific actions
+                           u status-update       Stage/unstage chunk or file changes
+                           ! status-revert       Revert chunk or file changes
+                           1 stage-update-line   Stage/unstage single line
+                           \ stage-split-chunk   Split current diff chunk
+Option toggling:
+                           [ :toggle diff-context -1
+                           ] :toggle diff-context +1
+Internal commands:
+                           @ :/^@@
+[-] stash bindings
+External commands:
+                           A ?git stash apply %(stash)
+                           P ?git stash pop %(stash)
+                           ! ?git stash drop %(stash)
+
+
+
+
 [help] - line 1 of 114                                                                100%

--- a/test/main/filter-args-test
+++ b/test/main/filter-args-test
@@ -31,10 +31,10 @@ grep 'git rev-parse' < "$TIG_TRACE" > rev-parse.trace
 grep 'git log' < "$TIG_TRACE" > log.trace
 
 assert_equals 'rev-parse.trace' <<EOF
-git rev-parse --no-revs --no-flags common tracer 
-git rev-parse --flags --no-revs common tracer 
-git rev-parse --symbolic --revs-only common tracer 
-git rev-parse --git-dir --is-inside-work-tree --show-cdup --show-prefix HEAD --symbolic-full-name HEAD 
+git rev-parse --no-revs --no-flags common tracer
+git rev-parse --flags --no-revs common tracer
+git rev-parse --symbolic --revs-only common tracer
+git rev-parse --git-dir --is-inside-work-tree --show-cdup --show-prefix HEAD --symbolic-full-name HEAD
 EOF
 
 assert_equals 'log.trace' <<EOF

--- a/test/tigrc/width-test
+++ b/test/tigrc/width-test
@@ -15,11 +15,11 @@ in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
 ### main-view
 
 test_case main-widths-default \
-        --script='
-        :set main-view = id:yes line-number:yes,interval=5 date:default author:full commit-title:yes,graph,refs,overflow=no
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set main-view = id:yes line-number:yes,interval=5 date:default author:full commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
 ee91287   1| 2014-03-01 17:26 Jonas Fonseca      * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
 a1dcf1a    | 2014-03-01 15:59 Jonas Fonseca      * Add type parameter for js.Dynamic
 296fc90    | 2014-01-16 22:51 Jonas Fonseca      * Move classes under org.scalajs.benchmark package scope
@@ -38,11 +38,11 @@ c819b08  10| 2013-11-26 23:39 Jonas Fonseca      * Extract the benchmark list va
 EOF
 
 test_case main-widths-1 \
-        --script='
-        :set main-view = id:yes,width=1 line-number:yes,interval=5,width=1 date:default,width=1 author:full,width=1 commit-title:yes,graph,refs,overflow=no
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set main-view = id:yes,width=1 line-number:yes,interval=5,width=1 date:default,width=1 author:full,width=1 commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
 e   1| 2 J * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
 a    | 2 J * Add type parameter for js.Dynamic
 2    | 2 J * Move classes under org.scalajs.benchmark package scope
@@ -61,11 +61,11 @@ c  10| 2 J * Extract the benchmark list variable name; fix push to use scoped va
 EOF
 
 test_case main-widths-2 \
-        --script='
-        :set main-view = id:yes,width=2 line-number:yes,interval=5,width=2 date:default,width=2 author:full,width=2 commit-title:yes,graph,refs,overflow=no
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set main-view = id:yes,width=2 line-number:yes,interval=5,width=2 date:default,width=2 author:full,width=2 commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
 ee   1| 20 JF * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
 a1    | 20 JF * Add type parameter for js.Dynamic
 29    | 20 JF * Move classes under org.scalajs.benchmark package scope
@@ -84,11 +84,11 @@ c8  10| 20 JF * Extract the benchmark list variable name; fix push to use scoped
 EOF
 
 test_case main-widths-5 \
-        --script='
-        :set main-view = id:yes,width=5 line-number:yes,interval=5,width=5 date:default,width=5 author:full,width=5 commit-title:yes,graph,refs,overflow=no
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set main-view = id:yes,width=5 line-number:yes,interval=5,width=5 date:default,width=5 author:full,width=5 commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
 ee912     1| 2014- JFons * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
 a1dcf      | 2014- JFons * Add type parameter for js.Dynamic
 296fc      | 2014- JFons * Move classes under org.scalajs.benchmark package scope
@@ -107,11 +107,11 @@ c819b    10| 2013- JFons * Extract the benchmark list variable name; fix push to
 EOF
 
 test_case main-widths-20 \
-        --script='
-        :set main-view = id:yes,width=20 line-number:yes,interval=5,width=20 date:default,width=20 author:full,width=20 commit-title:yes,graph,refs,overflow=no
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set main-view = id:yes,width=20 line-number:yes,interval=5,width=20 date:default,width=20 author:full,width=20 commit-title:yes,graph,refs,overflow=no
+	:refresh
+	' \
+	<<EOF
 ee912870202200a0b9cf         1| 2014-03-01 17:26     Jonas Fonseca        * [master] WIP: Upgrade to 0.4-SNAPSHOT and DCE
 a1dcf1aaa11470978db1          | 2014-03-01 15:59     Jonas Fonseca        * Add type parameter for js.Dynamic
 296fc90ba2c47ba3d2b6          | 2014-01-16 22:51     Jonas Fonseca        * Move classes under org.scalajs.benchmark package scope
@@ -132,12 +132,12 @@ EOF
 ### tree-view
 
 test_case tree-widths-default \
-        --script='
-        :set tree-view = id:yes line-number:yes,interval=5 mode:yes file-size:yes file-name:yes
-        :view-tree
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set tree-view = id:yes line-number:yes,interval=5 mode:yes file-size:yes file-name:yes
+	:view-tree
+	:refresh
+	' \
+	<<EOF
 Directory path /
 ee91287    | drwxr-xr-x      common
 ee91287    | drwxr-xr-x      deltablue
@@ -156,12 +156,12 @@ ee91287    | -rwxr-xr-x  493 run.sh
 EOF
 
 test_case tree-widths-1 \
-        --script='
-        :set tree-view = id:yes,width=1 line-number:yes,interval=5,width=1 mode:yes,width=1 file-size:yes,width=1 file-name:yes,width=1
-        :view-tree
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set tree-view = id:yes,width=1 line-number:yes,interval=5,width=1 mode:yes,width=1 file-size:yes,width=1 file-name:yes,width=1
+	:view-tree
+	:refresh
+	' \
+	<<EOF
 Directory path /
 e    | d   ~
 e    | d   ~
@@ -180,12 +180,12 @@ e    | - 4 ~
 EOF
 
 test_case tree-widths-2 \
-        --script='
-        :set tree-view = id:yes,width=2 line-number:yes,interval=5,width=2 mode:yes,width=2 file-size:yes,width=2 file-name:yes,width=2
-        :view-tree
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set tree-view = id:yes,width=2 line-number:yes,interval=5,width=2 mode:yes,width=2 file-size:yes,width=2 file-name:yes,width=2
+	:view-tree
+	:refresh
+	' \
+	<<EOF
 Directory path /
 ee    | dr    c~
 ee    | dr    d~
@@ -204,12 +204,12 @@ ee    | -r 49 r~
 EOF
 
 test_case tree-widths-5 \
-        --script='
-        :set tree-view = id:yes,width=5 line-number:yes,interval=5,width=5 mode:yes,width=5 file-size:yes,width=5 file-name:yes,width=5
-        :view-tree
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set tree-view = id:yes,width=5 line-number:yes,interval=5,width=5 mode:yes,width=5 file-size:yes,width=5 file-name:yes,width=5
+	:view-tree
+	:refresh
+	' \
+	<<EOF
 Directory path /
 ee912      | drwxr       comm~
 ee912      | drwxr       delt~
@@ -228,12 +228,12 @@ ee912      | -rwxr   493 run.~
 EOF
 
 test_case tree-widths-20 \
-        --script='
-        :set tree-view = id:yes,width=20 line-number:yes,interval=5,width=20 mode:yes,width=20 file-size:yes,width=20 file-name:yes,width=20
-        :view-tree
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set tree-view = id:yes,width=20 line-number:yes,interval=5,width=20 mode:yes,width=20 file-size:yes,width=20 file-name:yes,width=20
+	:view-tree
+	:refresh
+	' \
+	<<EOF
 Directory path /
 ee912870202200a0b9cf          | drwxr-xr-x                                common
 ee912870202200a0b9cf          | drwxr-xr-x                                deltablue
@@ -254,12 +254,12 @@ EOF
 ### refs-vew
 
 test_case refs-widths-default \
-        --script='
-        :set refs-view = id:yes ref:yes author:yes commit-title
-        :view-refs
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set refs-view = id:yes ref:yes author:yes commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
         All references
 ee91287 master         Jonas Fonseca WIP: Upgrade to 0.4-SNAPSHOT and DCE
 
@@ -278,12 +278,12 @@ ee91287 master         Jonas Fonseca WIP: Upgrade to 0.4-SNAPSHOT and DCE
 EOF
 
 test_case refs-widths-1 \
-        --script='
-        :set refs-view = id:yes,width=1 ref:yes,width=1 author:yes,width=1 commit-title
-        :view-refs
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set refs-view = id:yes,width=1 ref:yes,width=1 author:yes,width=1 commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
   A
 e m J WIP: Upgrade to 0.4-SNAPSHOT and DCE
 
@@ -302,12 +302,12 @@ e m J WIP: Upgrade to 0.4-SNAPSHOT and DCE
 EOF
 
 test_case refs-widths-2 \
-        --script='
-        :set refs-view = id:yes,width=2 ref:yes,width=2 author:yes,width=2 commit-title
-        :view-refs
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set refs-view = id:yes,width=2 ref:yes,width=2 author:yes,width=2 commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
    Al
 ee ma JF WIP: Upgrade to 0.4-SNAPSHOT and DCE
 
@@ -326,12 +326,12 @@ ee ma JF WIP: Upgrade to 0.4-SNAPSHOT and DCE
 EOF
 
 test_case refs-widths-5 \
-        --script='
-        :set refs-view = id:yes,width=5 ref:yes,width=5 author:yes,width=5 commit-title
-        :view-refs
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set refs-view = id:yes,width=5 ref:yes,width=5 author:yes,width=5 commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
       All r
 ee912 maste JFons WIP: Upgrade to 0.4-SNAPSHOT and DCE
 
@@ -350,12 +350,12 @@ ee912 maste JFons WIP: Upgrade to 0.4-SNAPSHOT and DCE
 EOF
 
 test_case refs-widths-20 \
-        --script='
-        :set refs-view = id:yes,width=20 ref:yes,width=20 author:yes,width=20 commit-title
-        :view-refs
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set refs-view = id:yes,width=20 ref:yes,width=20 author:yes,width=20 commit-title
+	:view-refs
+	:refresh
+	' \
+	<<EOF
                      All references
 ee912870202200a0b9cf master               Jonas Fonseca        WIP: Upgrade to 0.4-SNAPSHOT and DCE
 
@@ -376,13 +376,13 @@ EOF
 ### grep-view
 
 test_case grep-widths-default \
-        --script='
-        :set grep-view = file-name:yes,width=20 line-number:yes,interval=1 text
-        :g
-        source<Enter>
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set grep-view = file-name:yes,width=20 line-number:yes,interval=1 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
 LICENSE                5| Redistribution and use in source and binary forms, with or without modification,
 LICENSE                8|     * Redistributions of source code must retain the above copyright notice,
 README.md             27| time you save a source file, a compilation of the project is triggered.
@@ -401,13 +401,13 @@ common/reference/tr~  46|   for (var property in source) {
 EOF
 
 test_case grep-widths-1 \
-        --script='
-        :set grep-view = file-name:yes,width=1 line-number:yes,interval=1,width=1 text
-        :g
-        source<Enter>
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set grep-view = file-name:yes,width=1 line-number:yes,interval=1,width=1 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
 ~    5| Redistribution and use in source and binary forms, with or without modification,
 ~    8|     * Redistributions of source code must retain the above copyright notice,
 ~   27| time you save a source file, a compilation of the project is triggered.
@@ -426,13 +426,13 @@ test_case grep-widths-1 \
 EOF
 
 test_case grep-widths-2 \
-        --script='
-        :set grep-view = file-name:yes,width=2 line-number:yes,interval=1,width=2 text
-        :g
-        source<Enter>
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set grep-view = file-name:yes,width=2 line-number:yes,interval=1,width=2 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
 L~     5| Redistribution and use in source and binary forms, with or without modification,
 L~     8|     * Redistributions of source code must retain the above copyright notice,
 R~    27| time you save a source file, a compilation of the project is triggered.
@@ -451,13 +451,13 @@ c~    46|   for (var property in source) {
 EOF
 
 test_case grep-widths-5 \
-        --script='
-        :set grep-view = file-name:yes,width=5 line-number:yes,interval=1,width=5 text
-        :g
-        source<Enter>
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set grep-view = file-name:yes,width=5 line-number:yes,interval=1,width=5 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
 LICE~     5| Redistribution and use in source and binary forms, with or without modification,
 LICE~     8|     * Redistributions of source code must retain the above copyright notice,
 READ~    27| time you save a source file, a compilation of the project is triggered.
@@ -476,13 +476,13 @@ comm~    46|   for (var property in source) {
 EOF
 
 test_case grep-widths-20 \
-        --script='
-        :set grep-view = file-name:yes,width=20 line-number:yes,interval=1,width=20 text
-        :g
-        source<Enter>
-        :refresh
-        ' \
-        <<EOF
+	--script='
+	:set grep-view = file-name:yes,width=20 line-number:yes,interval=1,width=20 text
+	:g
+	source<Enter>
+	:refresh
+	' \
+	<<EOF
 LICENSE                      5| Redistribution and use in source and binary forms, with or without modification,
 LICENSE                      8|     * Redistributions of source code must retain the above copyright notice,
 README.md                   27| time you save a source file, a compilation of the project is triggered.

--- a/tigrc
+++ b/tigrc
@@ -92,7 +92,7 @@ set reference-format		= [branch] <tag> {remote} ~replace~
 # Settings controlling how content is read from Git
 set commit-order		= auto		# Enum: auto, default, topo, date, reverse (main)
 set status-show-untracked-dirs	= yes		# Show files in untracked directories? (status)
-set status-show-untracked-files = yes		# Show untracked files?
+set status-show-untracked-files	= yes		# Show untracked files?
 set ignore-space		= no		# Enum: no, all, some, at-eol (diff)
 set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 #set diff-context		= 3		# Number of lines to show around diff changes (diff)
@@ -108,7 +108,7 @@ set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 set refresh-mode		= auto		# Enum: manual, auto, after-command, periodic
 set refresh-interval		= 10		# Interval in seconds between refreshes
 set ignore-case			= no		# Enum: no, yes, smart-case
-                                                # Ignore case when searching? Smart-case option will
+						# Ignore case when searching? Smart-case option will
 set wrap-search			= yes		# Wrap around to top/bottom of view when searching
 set focus-child			= yes		# Move focus to child view when opened?
 set horizontal-scroll		= 50%		# Number of columns to scroll as % of width
@@ -147,7 +147,7 @@ set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?
 #   %(remote)		The current remote name.
 #   %(tag)		The current tag name.
 #   %(stash)		The current stash name.
-#   %(directory)	The current directory path in the tree view; 
+#   %(directory)	The current directory path in the tree view;
 #			empty for the root directory.
 #   %(file)		The currently selected file.
 #   %(ref)		The reference given to blame or HEAD if undefined.
@@ -212,7 +212,7 @@ bind stage	1	stage-update-line	# Stage/unstage current line
 bind stage	!	status-revert		# Revert current diff (c)hunk
 bind stage	\	stage-split-chunk	# Split current diff (c)hunk
 bind stage	@	:/^@@			# Jump to next (c)hunk
-bind stage	[	:toggle diff-context -1 # Decrease the diff context
+bind stage	[	:toggle diff-context -1	# Decrease the diff context
 bind stage	]	:toggle diff-context +1	# Increase the diff context
 bind diff	@	:/^@@			# Jump to next (c)hunk
 bind diff	[	:toggle diff-context -1
@@ -379,8 +379,8 @@ color stat-untracked		magenta	default
 color help-group		blue	default
 color help-action		yellow	default
 color diff-stat			blue	default
-color diff-add-highlight	green	default standout
-color diff-del-highlight	red	default standout
+color diff-add-highlight	green	default	standout
+color diff-del-highlight	red	default	standout
 color palette-0			magenta	default
 color palette-1			yellow	default
 color palette-2			cyan	default
@@ -388,13 +388,13 @@ color palette-3			green	default
 color palette-4			default	default
 color palette-5			white	default
 color palette-6			red	default
-color palette-7			magenta	default bold
-color palette-8			yellow	default bold
-color palette-9			cyan	default bold
-color palette-10		green	default bold
-color palette-11		default	default bold
-color palette-12		white	default bold
-color palette-13		red	default bold
+color palette-7			magenta	default	bold
+color palette-8			yellow	default	bold
+color palette-9			cyan	default	bold
+color palette-10		green	default	bold
+color palette-11		default	default	bold
+color palette-12		white	default	bold
+color palette-13		red	default	bold
 color graph-commit		blue	default
 color search-result		black	yellow
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -34,7 +34,7 @@ if test -n "$VERSION"; then
 		git checkout master
 
 	# Update files which should reference the version.
-	sed -i "s/VERSION\s*=\s*[0-9.]\+/VERSION	= $VERSION/" Makefile	
+	sed -i "s/VERSION\s*=\s*[0-9.]\+/VERSION	= $VERSION/" Makefile
 	sed -i "s#tig-[0-9.]\+[0-9]\+#tig-$VERSION#g" INSTALL.adoc
 	perl -pi -e 's/^master$/RELEASE_TITLE/ms' "$NEWS"
 	perl -pi -e 's/^RELEASE_TITLE.*/RELEASE_TITLE/ms' "$NEWS"


### PR DESCRIPTION
A general whitespace cleanup offered as an apology for bungling the indents in `test/tigrc/width-test`.  Cleanup tends to reduce merge conflicts over the long term though it usually creates some in the short term.

 * tabs instead of spaces to indent
 * tabs instead of spaces to delimit columns
 * rm spaces interior to tabs
 * rm trailing space
 * rm stray linefeeds
 * add missing indents