### PR TITLE
make $TEST_OPTS respect wordsplit under bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,11 @@ clean-test:
 test: clean-test $(TESTS)
 	$(QUIET_SUMMARY)test/tools/show-results.sh
 
-export TIG_TEST_OPTS = $(V:1=no-indent)
+ifneq (,$(strip $(V:@=)))
+export MAKE_TEST_OPTS = no-indent
+else
+export MAKE_TEST_OPTS =
+endif
 
 $(TESTS): PATH := $(CURDIR)/test/tools:$(CURDIR)/src:$(PATH)
 $(TESTS): $(EXE) test/tools/test-graph

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -60,7 +60,7 @@ export LINES=30
 export COLUMNS=80
 
 # Internal test env
-# A comma-separated list of options. See docs in test/README.
+# A space-separated list of options. See docs in test/README.
 export TEST_OPTS="${TEST_OPTS:-}"
 # Used by tig_script to set the test "scope" used by test_tig.
 export TEST_NAME=
@@ -197,20 +197,25 @@ trace=
 todos=
 valgrind=
 
-set -- ${TIG_TEST_OPTS:-} ${TEST_OPTS:-}
-
-while [ $# -gt 0 ]; do
-	arg="$1"; shift
+ORIG_IFS="$IFS"
+IFS=" 	"
+for arg in ${MAKE_TEST_OPTS:-} ${TEST_OPTS:-}; do
+	if [ -z "$arg" ]; then
+		continue;
+	fi
 	case "$arg" in
 		verbose) verbose=yes ;;
-		no-indent) indent= ;;
+		no[-_]indent|noindent) indent= ;;
 		debugger=*) debugger="$(expr "$arg" : 'debugger=\(.*\)')" ;;
 		debugger) debugger="$(auto_detect_debugger)" ;;
 		trace) trace=yes ;;
-		todos) todos=yes ;;
+		todo|todos) todos=yes ;;
 		valgrind) valgrind="$HOME/valgrind.log" ;;
+		*) die "unknown TEST_OPTS element '$arg'" ;;
 	esac
 done
+IFS="$ORIG_IFS"
+ORIG_IFS=
 
 #
 # Test runners and assertion checking.


### PR DESCRIPTION
Options were ignored when more than one was present:

```
TEST_OPTS="verbose todos" make test 
```

since IFS was set conditionally https://github.com/jonas/tig/blob/5d86622e4b9c29f6b948c4e463de7b026d4f9119/test/tools/libtest.sh#L18-L21 .

In the refactor, you might not approve renaming `$TIG_TEST_OPTS` to `$MAKE_TEST_OPTS`.  My reasoning was that I kept forgetting which one I was meant to set at CLI.

 * force wordsplit by `$IFS`
 * `for` loop is easier than `set`/`shift`
 * doc space-separation not comma
 * accept some user typos
 * die on unknown options
 * stop Makefile from setting `$TIG_TEST_OPTS` to `@` (which was default unless `make test V=1`)
 * recast `$TIG_TEST_OPTS` as `$MAKE_TEST_OPTS`
 * always set `$MAKE_TEST_OPTS` in Makefile; user interface is `TEST_OPTS`
