### PR TITLE
wordexp() support and compat fallback

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -114,6 +114,8 @@ can be one of the following flags:
    `setenv()`.
  - `NO_MKSTEMPS`: Define this variable to enable work-around for missing
    `mkstemps()`.
+ - `NO_WORDEXP`: Define this variable to enable work-around for missing
+   `wordexp()`.
  - `NO_BUILTIN_TIGRC`: Reduce the size of the binary by not including a
    built-in tigrc. The built-in tigrc is used as a fallback when no
    `tigrc` is found in the system configuration directory (e.g. `/etc`).

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,11 @@ COMPAT_CPPFLAGS += -DNO_STRNDUP
 COMPAT_OBJS += compat/strndup.o
 endif
 
+ifdef NO_WORDEXP
+COMPAT_CPPFLAGS += -DNO_WORDEXP
+COMPAT_OBJS += compat/wordexp.o
+endif
+
 COMPAT_OBJS += compat/hashtab.o
 
 override CPPFLAGS += $(COMPAT_CPPFLAGS)

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -24,6 +24,7 @@
 #define HAVE_STRING_H
 #define HAVE_SYS_TIME_H
 #define HAVE_UNISTD_H
+#define HAVE_WORDEXP_H
 #endif
 
 /*
@@ -44,6 +45,20 @@ int compat_setenv(const char *name, const char *value, int replace);
 #include <stddef.h>
 #define strndup compat_strndup
 char *compat_strndup(const char *s, size_t n);
+#endif
+
+#ifdef NO_WORDEXP
+#define wordexp compat_wordexp
+#define wordfree compat_wordfree
+#define WRDE_NOCMD 4
+typedef struct
+{
+	char **we_wordv;
+} wordexp_t;
+int compat_wordexp (const char *words, wordexp_t *pwordexp, int flags);
+void compat_wordfree (wordexp_t *pwordexp);
+#else
+#include <wordexp.h>
 #endif
 
 #endif

--- a/compat/wordexp.c
+++ b/compat/wordexp.c
@@ -1,0 +1,51 @@
+/* Copyright (c) 2006-2013 Jonas Fonseca <jonas.fonseca@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "compat.h"
+#include "stddef.h"
+#include <stdlib.h>
+#include <string.h>
+
+void
+compat_wordfree (wordexp_t *pwordexp)
+{
+	free(pwordexp->we_wordv[0]);
+	free(pwordexp->we_wordv);
+}
+
+int
+compat_wordexp (const char *words, wordexp_t *pwordexp, int flags)
+{
+	pwordexp->we_wordv = calloc(2, sizeof(*pwordexp->we_wordv));
+	pwordexp->we_wordv[0] = calloc(1, strlen(words) + 1);
+	strncpy(pwordexp->we_wordv[0], words, strlen(words) + 1);
+
+	if (    pwordexp->we_wordv[0][0] == '~'
+	    && (pwordexp->we_wordv[0][1] == '/' || pwordexp->we_wordv[0][1] == 0)) {
+		const char *home = getenv("HOME") ? getenv("HOME") : "~";
+		pwordexp->we_wordv[0] = realloc(pwordexp->we_wordv[0],
+						strlen(pwordexp->we_wordv[0]) + strlen(home));
+		memmove(pwordexp->we_wordv[0] + strlen(home) - 1, pwordexp->we_wordv[0],
+			strlen(pwordexp->we_wordv[0]));
+		/* intentional overwrite by one character */
+		memmove(pwordexp->we_wordv[0], home, strlen(home));
+	}
+
+	return 0;
+}
+
+/* vim: set ts=8 sw=8 noexpandtab: */

--- a/config.make.in
+++ b/config.make.in
@@ -25,6 +25,7 @@ GENHTML = @GENHTML@
 @NO_MKSTEMPS@ NO_MKSTEMPS = y
 @NO_SETENV@ NO_SETENV = y
 @NO_STRNDUP@ NO_STRNDUP = y
+@NO_WORDEXP@ NO_WORDEXP = y
 
 # Add config.h as a dependency for all object files
 CONFIG_H = config.h

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ m4_pattern_forbid([^AX_])
 
 AC_PROG_CC
 
-AC_CHECK_HEADERS([stdint.h stdlib.h string.h sys/time.h unistd.h])
+AC_CHECK_HEADERS([stdint.h stdlib.h string.h sys/time.h unistd.h wordexp.h])
 AC_CHECK_FUNCS([gettimeofday])
 AC_CHECK_DECLS([environ])
 AC_CHECK_DECLS([errno], [], [], [#include <errno.h>])
@@ -20,6 +20,7 @@ dnl Checks for compatibility flags
 AC_CHECK_FUNCS([mkstemps], [AC_SUBST([NO_MKSTEMPS], ["#"])])
 AC_CHECK_FUNCS([setenv], [AC_SUBST([NO_SETENV], ["#"])])
 AC_CHECK_FUNCS([strndup], [AC_SUBST([NO_STRNDUP], ["#"])])
+AC_CHECK_FUNCS([wordexp], [AC_SUBST([NO_WORDEXP], ["#"])])
 
 AX_WITH_CURSES
 case "$ax_cv_ncurses" in "no")

--- a/contrib/config.make
+++ b/contrib/config.make
@@ -17,6 +17,9 @@ CPPFLAGS = -DHAVE_NCURSESW_CURSES_H
 # Uncomment to enable work-around for missing mkstemps().
 #NO_MKSTEMPS=y
 
+# Uncomment to enable work-around for missing wordexp().
+#NO_WORDEXP=y
+
 # Uncomment to not include built-in tigrc inside the binary.
 #NO_BUILTIN_TIGRC=y
 

--- a/include/tig/io.h
+++ b/include/tig/io.h
@@ -38,6 +38,12 @@ extern char encoding_arg[];
 extern struct encoding *default_encoding;
 
 /*
+ * Path manipulation.
+ */
+
+bool expand_path(char *dst, size_t dstlen, const char *src);
+
+/*
  * Executing external commands.
  */
 

--- a/src/display.c
+++ b/src/display.c
@@ -46,8 +46,13 @@ open_script(const char *path)
 	if (is_script_executing())
 		return error("Scripts cannot be run from scripts");
 
-	return io_open(&script_io, "%s", path)
-		? SUCCESS : error("Failed to open %s", path);
+	char buf[SIZEOF_STR];
+
+	if (!expand_path(buf, sizeof(buf), path))
+		return error("Failed to expand path: %s", path);
+
+	return io_open(&script_io, "%s", buf)
+		? SUCCESS : error("Failed to open %s", buf);
 }
 
 bool

--- a/test/tigrc/source-test
+++ b/test/tigrc/source-test
@@ -93,4 +93,24 @@ Misc
 [help] - line 1 of 5                                                        100%
 EOF
 
+test_case source-tilde-path \
+	--args='status' \
+	--tigrc="
+		bind generic : prompt
+		source ~/.tigrc.bind.q.for.help.screen
+		" \
+	--script="
+		:view-help
+		" \
+	<<EOF
+Quick reference for tig keybindings:
+
+[-] generic bindings
+View manipulation
+  q quit   Close all views and quit
+Misc
+  : prompt Open the prompt
+[help] - line 1 of 7                                                        100%
+EOF
+
 run_test_cases


### PR DESCRIPTION
In #168 you expressed concern about platforms without `wordexp()`.  Without being sure what those platforms would be, I included a `compat_wordexp()` that can only expand `~/`.

I think the `compat_wordexp()` here is OK so far as it goes, but `expand_path()` is clunky at best.

`wordexp()` is a standard, but it's a lousy standard.  It does several types of transformation, such as arithmetic expansion, and exposes an off switch for only one type (`WRDE_NOCMD` for command expansion).  So `expand_path()` constrains `wordexp()` by constraining its inputs and rebuilding the result.

All that's gained is the rarely-used `~username` expansion, and the ability to use the word "standard".  Though it would be nice to have expansion in more places, like `bind generic * :script ~/.tig/scripts/star.command`.

~Note: this PR makes no functional change, and merely exposes `expand_path()`.  I was doubtful that `io_open()` should always expand its arguments.~

Edit: routed existing `:source` expansion through `expand_path`, with test.  Added `:script` path expansion, which doesn't seem testable since tests are already driven by script.
