### PR TITLE
single-line output of external command to status bar

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -640,6 +640,8 @@ the command that should be executed.
 |=============================================================================
 |!			|Run the command in the foreground with output shown.
 |@			|Run the command in the background with no output.
+|+			|Run the command synchronously, and echo the first line
+			 of output to the status bar.
 |?			|Prompt the user before executing the command.
 |<			|Exit Tig after executing the command.
 |=============================================================================
@@ -704,6 +706,9 @@ bind main S !git format-patch -1 %(commit)
 
 # Create and checkout a new branch; specify custom prompt
 bind main B ?git checkout -b "%(prompt Enter new branch name: )"
+
+# Show commit statistics for the author under the cursor
+bind main U +sh -c 'git --no-pager shortlog -s --author="$(git show -s --format=%aE %(commit))" </dev/tty'
 --------------------------------------------------------------------------
 
 Advanced shell-like commands

--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -52,7 +52,7 @@ bool save_view(struct view *view, const char *path);
 bool vertical_split_is_enabled(enum vertical_split vsplit, int height, int width);
 int apply_vertical_split(int base_width);
 
-bool open_external_viewer(const char *argv[], const char *dir, bool silent, bool confirm, bool refresh, const char *notice);
+bool open_external_viewer(const char *argv[], const char *dir, bool silent, bool confirm, bool echo, bool refresh, const char *notice);
 void open_editor(const char *file, unsigned int lineno);
 void enable_mouse(bool enable);
 

--- a/include/tig/io.h
+++ b/include/tig/io.h
@@ -93,7 +93,7 @@ bool io_get(struct io *io, struct buffer *buf, int c, bool can_read);
 bool io_write(struct io *io, const void *buf, size_t bufsize);
 bool io_printf(struct io *io, const char *fmt, ...) PRINTF_LIKE(2, 3);
 bool io_read_buf(struct io *io, char buf[], size_t bufsize, bool allow_empty);
-bool io_run_buf(const char **argv, char buf[], size_t bufsize, bool allow_empty);
+bool io_run_buf(const char **argv, char buf[], size_t bufsize, const char *dir, bool allow_empty);
 enum status_code io_load(struct io *io, const char *separators,
 	    io_read_fn read_property, void *data);
 enum status_code io_load_span(struct io *io, const char *separators,

--- a/include/tig/keys.h
+++ b/include/tig/keys.h
@@ -82,6 +82,7 @@ struct run_request_flags {
 	bool confirm;
 	bool exit;
 	bool internal;
+	bool echo;
 };
 
 struct run_request {

--- a/src/blob.c
+++ b/src/blob.c
@@ -71,7 +71,7 @@ blob_open(struct view *view, enum open_flags flags)
 		};
 
 		if (!string_format(blob_spec, "%s:%s", commit, view->env->file) ||
-		    !io_run_buf(rev_parse_argv, view->env->blob, sizeof(view->env->blob), false))
+		    !io_run_buf(rev_parse_argv, view->env->blob, sizeof(view->env->blob), NULL, false))
 			return error("Failed to resolve blob from file name");
 
 		string_ncopy(state->commit, commit, strlen(commit));

--- a/src/display.c
+++ b/src/display.c
@@ -56,11 +56,22 @@ open_script(const char *path)
 }
 
 bool
-open_external_viewer(const char *argv[], const char *dir, bool silent, bool confirm, bool refresh, const char *notice)
+open_external_viewer(const char *argv[], const char *dir, bool silent, bool confirm, bool echo, bool refresh, const char *notice)
 {
 	bool ok;
 
-	if (silent || is_script_executing()) {
+	if (echo) {
+		char buf[SIZEOF_STR] = "";
+
+		io_run_buf(argv, buf, sizeof(buf), dir, false);
+		if (*buf) {
+			report("%s", buf);
+			return true;
+		} else {
+			report("No output");
+			return false;
+		}
+	} else if (silent || is_script_executing()) {
 		ok = io_run_bg(argv, dir);
 
 	} else {
@@ -127,7 +138,7 @@ open_editor(const char *file, unsigned int lineno)
 	if (lineno && opt_editor_line_number && string_format(lineno_cmd, "+%u", lineno))
 		editor_argv[argc++] = lineno_cmd;
 	editor_argv[argc] = file;
-	if (!open_external_viewer(editor_argv, repo.cdup, false, false, true, EDITOR_LINENO_MSG))
+	if (!open_external_viewer(editor_argv, repo.cdup, false, false, false, true, EDITOR_LINENO_MSG))
 		opt_editor_line_number = false;
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -109,7 +109,7 @@ get_path_encoding(const char *path, struct encoding *default_encoding)
 
 	/* <path>: encoding: <encoding> */
 
-	if (!*path || !io_run_buf(check_attr_argv, buf, sizeof(buf), false)
+	if (!*path || !io_run_buf(check_attr_argv, buf, sizeof(buf), NULL, false)
 	    || !(encoding = strstr(buf, ENCODING_SEP)))
 		return default_encoding;
 
@@ -121,7 +121,7 @@ get_path_encoding(const char *path, struct encoding *default_encoding)
 			"file", "-I", "--", path, NULL
 		};
 
-		if (!*path || !io_run_buf(file_argv, buf, sizeof(buf), false)
+		if (!*path || !io_run_buf(file_argv, buf, sizeof(buf), NULL, false)
 		    || !(encoding = strstr(buf, CHARSET_SEP)))
 			return default_encoding;
 
@@ -582,11 +582,11 @@ io_read_buf(struct io *io, char buf[], size_t bufsize, bool allow_empty)
 }
 
 bool
-io_run_buf(const char **argv, char buf[], size_t bufsize, bool allow_empty)
+io_run_buf(const char **argv, char buf[], size_t bufsize, const char *dir, bool allow_empty)
 {
 	struct io io;
 
-	return io_run(&io, IO_RD, NULL, NULL, argv) && io_read_buf(&io, buf, bufsize, allow_empty);
+	return io_run(&io, IO_RD, dir, NULL, argv) && io_read_buf(&io, buf, bufsize, allow_empty);
 }
 
 bool

--- a/src/keys.c
+++ b/src/keys.c
@@ -450,7 +450,7 @@ static size_t run_requests;
 
 DEFINE_ALLOCATOR(realloc_run_requests, struct run_request, 8)
 
-#define COMMAND_FLAGS ":!?@<"
+#define COMMAND_FLAGS ":!?@<+"
 
 enum status_code
 parse_run_request_flags(struct run_request_flags *flags, const char **argv)
@@ -469,6 +469,8 @@ parse_run_request_flags(struct run_request_flags *flags, const char **argv)
 			flags->confirm = 1;
 		} else if (*argv[0] == '<') {
 			flags->exit = 1;
+		} else if (*argv[0] == '+') {
+			flags->echo = 1;
 		} else if (*argv[0] != '!') {
 			break;
 		}
@@ -529,6 +531,8 @@ format_run_request_flags(const struct run_request *req)
 	    flags[flagspos++] = '?';
 	if (req->flags.exit)
 		flags[flagspos++] = '<';
+	if (req->flags.echo)
+		flags[flagspos++] = '+';
 	if (flagspos > 1)
 		flags[flagspos++] = 0;
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -1043,7 +1043,7 @@ exec_run_request(struct view *view, struct run_request *req)
 
 		if (confirmed)
 			open_external_viewer(argv, repo.cdup, req->flags.silent,
-					     !req->flags.exit, false, "");
+					     !req->flags.exit, req->flags.echo, false, "");
 	}
 
 	if (argv)

--- a/src/status.c
+++ b/src/status.c
@@ -676,7 +676,7 @@ open_mergetool(const char *file)
 {
 	const char *mergetool_argv[] = { "git", "mergetool", file, NULL };
 
-	open_external_viewer(mergetool_argv, repo.cdup, false, true, true, "");
+	open_external_viewer(mergetool_argv, repo.cdup, false, true, false, true, "");
 }
 
 static enum request

--- a/src/view.c
+++ b/src/view.c
@@ -312,7 +312,7 @@ goto_id(struct view *view, const char *expr, bool from_start, bool save_search)
 		const char *rev_parse_argv[] = {
 			"git", "rev-parse", "--revs-only", rev, NULL
 		};
-		bool ok = rev && io_run_buf(rev_parse_argv, id, sizeof(id), true);
+		bool ok = rev && io_run_buf(rev_parse_argv, id, sizeof(id), NULL, true);
 
 		free(rev);
 		if (!ok) {

--- a/test/tigrc/parse-test
+++ b/test/tigrc/parse-test
@@ -52,7 +52,8 @@ bind main 1 !external command
 bind main 2 @silent command
 bind main 3 ?prompted command
 bind main 4 <quitting command
-bind main 0 !@?<all modifiers
+bind main 5 +echoed command
+bind main 0 !@?<+all modifiers
 
 # Non-ending multi-line command
 c\\
@@ -98,9 +99,9 @@ tig warning: ~/.tigrc:25: Unknown color attribute: normally
 tig warning: ~/.tigrc:34: Unknown option \`visibility' for column line-number
 tig warning: ~/.tigrc:36: Invalid key binding: bind keymap key action
 tig warning: ~/.tigrc:37: Invalid key binding: bind keymap key action
-tig warning: ~/.tigrc:38: Unknown command flag '%'; expected one of :!?@<
-tig warning: ~/.tigrc:39: Unknown command flag '|'; expected one of :!?@<
-tig warning: ~/.tigrc:56: Unknown option command: c
+tig warning: ~/.tigrc:38: Unknown command flag '%'; expected one of :!?@<+
+tig warning: ~/.tigrc:39: Unknown command flag '|'; expected one of :!?@<+
+tig warning: ~/.tigrc:57: Unknown option command: c
 tig warning: Errors while loading HOME/.tigrc.
 EOF
 
@@ -120,7 +121,8 @@ External commands:
    2 @silent command
    3 ?prompted command
    4 <quitting command
-   0 @?<all modifiers
+   5 +echoed command
+   0 @?<+all modifiers
 
 
 
@@ -132,6 +134,5 @@ External commands:
 
 
 
-
-[help] - line 1 of 16                                                       100%
+[help] - line 1 of 17                                                       100%
 EOF


### PR DESCRIPTION
Adds new external command option flag `+`, meaning "echo first line of the output to the status bar".  Unlike `!`, output is integrated into the regular TUI and need not be manually dismissed.

Example usage:

```ini
# Show commit statistics for the author under the cursor
bind main U +sh -c 'git --no-pager shortlog -s --author="$(git show -s --format=%aE %(commit))" </dev/tty'
```

I think this is a good feature, but recognize that `open_external_viewer()` is taking too many params.

It might be better if the feature was "collapse whitespace and display as much output as fits in one screen width", though the user can get that by appending `| xargs` to a command.

(Odd little bug in `git-shortlog`: no output from the above command without `</dev/tty`.)

Edit: flagname `+`