### PR TITLE
WIP improved context-sensitive view-blob

### DIFF
--- a/include/tig/diff.h
+++ b/include/tig/diff.h
@@ -40,7 +40,7 @@ enum status_code diff_init_highlight(struct view *view, struct diff_state *state
 bool diff_done_highlight(struct diff_state *state);
 
 unsigned int diff_get_lineno(struct view *view, struct line *line);
-const char *diff_get_pathname(struct view *view, struct line *line);
+const char *diff_get_pathname(struct view *view, struct line *line, bool strict);
 
 extern struct view diff_view;
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -438,7 +438,7 @@ stage_request(struct view *view, enum request request, struct line *line)
 		if (stage_status.new.name[0]) {
 			string_copy(view->env->file, stage_status.new.name);
 		} else {
-			const char *file = diff_get_pathname(view, line);
+			const char *file = diff_get_pathname(view, line, true);
 
 			if (file)
 				string_ncopy(view->env->file, file, strlen(file));

--- a/test/diff/diff-view-blob-test
+++ b/test/diff/diff-view-blob-test
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export LINES=10
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+# content window scrolled to avoid trailing backslash and single quote
+first_file_blob='
+# Run a benchmark against a JavaScript VM.
+
+# set -x
+
+RUN_DIR="$(dirname "$0")"
+ROOT_DIR="./$(git rev-parse --show-cdup)"
+ENGINES="d8 node"
+[blob] common/benchmark-runner.sh - line 9 of 143                            11%'
+
+last_file_blob='// The ray tracer code in this file is written by Adam Burmister. It
+// is available in its original form from:
+//
+//   http://labs.flog.co.nz/raytracer/
+//
+// Ported from the v8 benchmark suite by Google 2012.
+// Ported from the Dart benchmark_harness to Scala.js by Jonas Fonseca 2013
+
+[blob] tracer/src/main/scala/org/scalajs/benchmark/tracer/Tracer.scala - line38%'
+
+test_case view-blob-goto-line-1 \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:1
+		:view-blob
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-goto-first-stat-entry \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:10
+		:view-blob
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-goto-last-stat-entry \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:26
+		:view-blob
+		:scroll-page-down
+	' \
+	<<EOF
+$last_file_blob
+EOF
+
+test_case view-blob-motion-past-stat-entries \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:26
+		:move-down
+		:view-blob
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-goto-past-stat-entries \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:27
+		:view-blob
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-goto-first-file-header \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:29
+		:view-blob
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-motion-first-content \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:29
+		:move-down
+		:move-down
+		:move-down
+		:move-down
+		:move-down
+		:view-blob
+		:move-first-line
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-goto-first-content \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:35
+		:view-blob
+		:move-first-line
+		:scroll-page-down
+	' \
+	<<EOF
+$first_file_blob
+EOF
+
+test_case view-blob-goto-last-line \
+	--args='show ee912870202200a0b9cf4fd86ba57243212d341e' \
+	--script='
+		:367
+		:view-blob
+		:move-first-line
+		:scroll-page-down
+	' \
+	<<EOF
+$last_file_blob
+EOF
+
+run_test_cases


### PR DESCRIPTION
I would like to improve the sensitivity of some tig actions to their context.

This is expressed here as three TODO tests which call `view-blob` from the diff view.

Tig already adopts the model of context-sensitive action here, but it depends on the cursor directly touching a line which it can associate to a blob.  When that is not true, tig opens the last blob it can remember, or opens the file finder.

Neither of those is likely to match user expectations.  But when viewing a diff, the cursor is always either **on** a blob-associated line, or **before** some blob-associated line.  So I propose that the simplest intuitive context-sensitive `view-blob` is
 * view this line's blob, or failing that
 * scan forward by lines and view the next associated blob
