### PR TITLE
don't segfault on :exec irregular arguments

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -455,6 +455,9 @@ DEFINE_ALLOCATOR(realloc_run_requests, struct run_request, 8)
 enum status_code
 parse_run_request_flags(struct run_request_flags *flags, const char **argv)
 {
+	if (!argv[0])
+		return error("No arguments");
+
 	if (!strchr(COMMAND_FLAGS, *argv[0]))
 		return error("Unknown command flag '%c'; expected one of %s", argv[0][0], COMMAND_FLAGS);
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -1019,7 +1019,8 @@ exec_run_request(struct view *view, struct run_request *req)
 
 	if (!argv_to_string(req->argv, cmd, sizeof(cmd), " ")
 	    || !argv_from_string_no_quotes(req_argv, &req_argc, cmd)
-	    || !argv_format(view->env, &argv, req_argv, false, true)) {
+	    || !argv_format(view->env, &argv, req_argv, false, true)
+	    || !argv) {
 		report("Failed to format arguments");
 		return REQ_NONE;
 	}

--- a/test/prompt/exec-test
+++ b/test/prompt/exec-test
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+LINES=10
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+test_case exec-without-arg-doesnt-crash \
+	--args='status' \
+	--script='
+	:exec
+	' <<EOF
+On branch master
+Changes to be committed:
+  (no files)
+Changes not staged for commit:
+  (no files)
+Untracked files:
+  (no files)
+
+[status] Nothing to update                                                  100%
+EOF
+
+test_case exec-only-flags-doesnt-crash \
+	--args='status' \
+	--script='
+	:exec !
+	' <<EOF
+On branch master
+Changes to be committed:
+  (no files)
+Changes not staged for commit:
+  (no files)
+Untracked files:
+  (no files)
+
+[status] Nothing to update                                                  100%
+EOF
+
+run_test_cases


### PR DESCRIPTION
Bug: segfaults on `:exec` (no args) and `:exec !` (flags but no actual command args).

Created a directory `test/prompt/` here, which is debatable, since the included tests don't work by stuffing keystrokes.  But it would be a good thing for the test suite to learn how to stuff keystokes, and populate a proper `test/prompt/`.

