### PR TITLE
untruncate preloaded search string

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -590,7 +590,7 @@ prompt_init(void)
 
 	last_entry = history_get(history_length);
 	if (last_entry)
-		string_copy(argv_env.search, last_entry->line);
+		string_ncopy(argv_env.search, last_entry->line, strlen(last_entry->line));
 }
 #else
 char *

--- a/test/README.adoc
+++ b/test/README.adoc
@@ -52,3 +52,8 @@ timeout=<int>::
 	Set the default timeout for each invocation of tig under the
 	test harness. The default is 10 if unset. 0 means "no
 	timeout". Individual tests may override the value.
+
+Testing API
+-----------
+
+test_require(git-worktree, address-sanitizer, diff-highlight, readline)::

--- a/test/main/search-preload-test
+++ b/test/main/search-preload-test
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export LINES=3
+export COLUMNS=80
+
+test_require readline
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+tigrc <<EOF
+set line-graphics = ascii
+EOF
+
+# Force .tig_history since the final entry isn't guaranteed under the test harness.
+file .tig_history <<EOF
+Merge pull request #1 from sjrd/patch-1
+EOF
+
+steps '
+	:find-next
+	:save-display main.screen
+'
+
+test_tig
+
+assert_equals main.screen <<EOF
+2013-10-18 07:00 Jonas Fonseca      M-. Merge pull request #1 from sjrd/patch-1
+[main] 0b89f7997f696a7f6ae4c10e3b29817862e751d6 - commit 39 of 48            81%
+EOF
+
+assert_equals stderr <<EOF
+EOF

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -413,6 +413,21 @@ require_git_version()
 	fi
 }
 
+has_readline()
+{
+	# Test functionality, since there isn't a good way to inspect the binary.
+	readline_exit_status=1
+	file readline_guard.script <<-EOF
+	:quit
+	EOF
+
+	TIG_NO_DISPLAY=1 TIG_SCRIPT=readline_guard.script tig status </dev/null >/dev/null 2>/dev/null || true
+	test -e .tig_history && readline_exit_status=0
+	rm -f -- readline_guard.script .tig_history
+
+	return "$readline_exit_status"
+}
+
 test_require()
 {
 	while [ $# -gt 0 ]; do
@@ -438,6 +453,12 @@ test_require()
 				test_skip "The test requires diff-highlight, usually found in share/git-core-contrib"
 			fi
 			;;
+		readline)
+			if ! has_readline; then
+				test_skip "The test requires a tig compiled with readline"
+			fi
+			;;
+
 		*)
 			test_skip "Unknown feature requirement: $feature"
 		esac


### PR DESCRIPTION
`string_copy()` respects `sizeof()` on its source rather than `strlen()`, truncating the preloaded search string to the sizeof a pointer.

This fixes it, though I actually don't understand why `string_copy()` wouldn't consult `strlen()`.
