### PR TITLE
suppress valgrind warning within darwin libsystem

### DIFF
--- a/test/tools/valgrind-Darwin.supp
+++ b/test/tools/valgrind-Darwin.supp
@@ -1,0 +1,9 @@
+{
+	darwin_libsystem_wordexp
+	Memcheck:Cond
+	fun:strstr
+	fun:wordexp
+	fun:expand_path
+	...
+	fun:main
+}


### PR DESCRIPTION
Initializing `we_result` doesn't affect the warning:

```
Conditional jump or move depends on uninitialised value(s)
   at 0x1003EF302: strstr (in /usr/lib/system/libsystem_c.dylib)
   by 0x1003F0987: wordexp (in /usr/lib/system/libsystem_c.dylib)
   by 0x100005FB2: expand_path (io.c:156)
```
