### PR TITLE
save-options able to write empty reference_format

### DIFF
--- a/src/refdb.c
+++ b/src/refdb.c
@@ -489,6 +489,9 @@ format_ref_formats(struct ref_format **formats, char buf[], size_t bufsize)
 	size_t bufpos = 0;
 	const char *sep = "";
 
+	if (!formats)
+		return SUCCESS;
+
 	for (type = 0; type < map->size; type++) {
 		struct ref_format *format = formats[type];
 

--- a/test/tigrc/builtin-save-test
+++ b/test/tigrc/builtin-save-test
@@ -2,14 +2,10 @@
 
 . libtest.sh
 
-test_todo "Segfault without 'set reference-format' in tigrc"
-
 export TIGRC_SYSTEM=/dev/null
 
 tigrc <<EOF
 bind generic : prompt
-# sufficient to rescue from crash
-# set reference-format = branch
 EOF
 
 steps ':save-options'


### PR DESCRIPTION
which happens if attempting to write out the builtin config.  Fixes segfault todo from #664.