### PR TITLE
tolerate empty lines in scripts

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -649,7 +649,7 @@ read_script(struct key *key)
 	static const char *line = "";
 	enum status_code code;
 
-	if (!line || !*line) {
+	while (!line || !*line) {
 		if (input_buffer.data && *input_buffer.data == ':') {
 			line = "<Enter>";
 			memset(&input_buffer, 0, sizeof(input_buffer));

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -146,7 +146,7 @@ tig_script() {
 
 	# Ensure that the steps finish by quitting
 	printf '%s\n:quit\n' "$*" \
-		| sed -e 's/^[ 	]*//' -e '/^$/d' \
+		| sed -e 's/^[ 	]*//' \
 		| sed "s|:save-display[ 	]\{1,\}\([^ 	]\{1,\}\)|:save-display $HOME/\1|" \
 		| sed "s|:save-view[ 	]\{1,\}\([^ 	]\{1,\}\)|:save-view $HOME/\1|" \
 		> "$TIG_SCRIPT"


### PR DESCRIPTION
The entire test suite provides coverage after removing a sed directive.