### PR TITLE
sidestep readline when executing a script

### DIFF
--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -57,6 +57,7 @@ void open_editor(const char *file, unsigned int lineno);
 void enable_mouse(bool enable);
 
 enum status_code open_script(const char *path);
+bool is_script_executing(void);
 
 #define get_cursor_pos(cursor_y, cursor_x) getyx(newscr, cursor_y, cursor_x)
 #define set_cursor_pos(cursor_y, cursor_x) wmove(newscr, cursor_y, cursor_x)

--- a/src/display.c
+++ b/src/display.c
@@ -34,7 +34,7 @@ static FILE *opt_tty;
 
 static struct io script_io = { -1 };
 
-static bool
+bool
 is_script_executing(void)
 {
 	return script_io.pipe != -1;

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -127,6 +127,20 @@ prompt_default_handler(struct input *input, struct key *key)
 }
 
 static enum input_status
+prompt_script_handler(struct input *input, struct key *key)
+{
+	switch (key_to_value(key)) {
+	case KEY_RETURN:
+	case KEY_ENTER:
+	case '\n':
+		return INPUT_STOP;
+
+	default:
+		return INPUT_OK;
+	}
+}
+
+static enum input_status
 prompt_yesno_handler(struct input *input, struct key *key)
 {
 	unsigned long c = key_to_unicode(key);
@@ -1120,9 +1134,14 @@ exec_run_request(struct view *view, struct run_request *req)
 enum request
 open_prompt(struct view *view)
 {
-	char *cmd = read_prompt(":");
+	char *cmd;
 	const char *argv[SIZEOF_ARG] = { NULL };
 	int argc = 0;
+
+	if (is_script_executing())
+		cmd = read_prompt_incremental(" ", false, true, prompt_script_handler, NULL);
+	else
+		cmd = read_prompt(":");
 
 	if (cmd && *cmd && !argv_from_string(argv, &argc, cmd)) {
 		report("Too many arguments");


### PR DESCRIPTION
Readline was causing major perf issues when interpreting a script, and inappropriately storing each script line in `~/.tig_history`.