### PR TITLE
ensure ordered writes to trace file

### DIFF
--- a/include/tig/tig.h
+++ b/include/tig/tig.h
@@ -50,6 +50,7 @@
 #include <sys/select.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/file.h>
 #include <time.h>
 #include <fcntl.h>
 

--- a/src/io.c
+++ b/src/io.c
@@ -249,16 +249,19 @@ open_trace(int devnull, const char *argv[])
 		int fd = open(trace_file, O_RDWR | O_CREAT | O_APPEND, 0666);
 		int i;
 
+		flock(fd, LOCK_EX);
 		for (i = 0; argv[i]; i++) {
 			if (write(fd, argv[i], strlen(argv[i])) == -1
 			    || write(fd, " ", 1) == -1)
 				break;
 		}
 		if (argv[i] || write(fd, "\n", 1) == -1) {
+			flock(fd, LOCK_UN);
 			close(fd);
 			return devnull;
 		}
 
+		flock(fd, LOCK_UN);
 		return fd;
 	}
 


### PR DESCRIPTION
This fixes a race condition which can be exercised readily on OS X by

``` bash
for i in $(seq 1 100); do make test/main/filter-args-test; done
```

It's of little importance to users but probably manifested as an occasional mystery glitch in Travis.
