### PR TITLE
ignore script lines starting with # (comment)

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -657,6 +657,8 @@ read_script(struct key *key)
 		} else if (!io_get(&script_io, &input_buffer, '\n', true)) {
 			io_done(&script_io);
 			return false;
+		} else if (input_buffer.data[strspn(input_buffer.data, " \t")] == '#') {
+			continue;
 		} else {
 			line = input_buffer.data;
 		}

--- a/test/script/comment-test
+++ b/test/script/comment-test
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export LINES=5
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+steps '
+	:set line-graphics = ascii
+	# comment
+	:save-display main.screen
+'
+
+test_tig
+
+assert_equals main.screen <<EOF
+2014-03-01 17:26 Jonas Fonseca      * [master] WIP: Upgrade to 0.4-SNAPSHOT and
+2014-03-01 15:59 Jonas Fonseca      * Add type parameter for js.Dynamic
+2014-01-16 22:51 Jonas Fonseca      * Move classes under org.scalajs.benchmark p
+[main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 48              6%
+EOF


### PR DESCRIPTION
Did not change doc.  In the absence of a Scripts section, the user's assumption is likely that scripts are similar to `~/.tigrc` files.
