### PR TITLE
tighten up assert_vars testing

### DIFF
--- a/test/help/all-keybindings-test
+++ b/test/help/all-keybindings-test
@@ -20,6 +20,7 @@ test_tig
 
 assert_equals \
 	'help-default.screen' \
+	'ignore' \
 	"Test failures due to changes to 'tigrc' can be fixed by running:" \
 	"  > make test/help/all-keybindings-test && cp test/tmp/help/all-keybindings-test/help-default.screen test/help/all-keybindings-test.expected" \
 	< "$expected"

--- a/test/main/branch-var-test
+++ b/test/main/branch-var-test
@@ -12,7 +12,6 @@ EOF
 
 steps '
 	:/mp/feature
-	:save-display main.screen
 
 	:1
 	:exec !assert-var "%(branch)" == "mp/feature"
@@ -25,6 +24,9 @@ steps '
 
 	:15
 	:exec !assert-var "%(branch)" == "r1.0"
+
+	:1
+	:save-display main.screen
 '
 
 in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"

--- a/test/main/graph-argument-test
+++ b/test/main/graph-argument-test
@@ -27,7 +27,8 @@ test_tig_script() {
 	test_tig "$@"
 
 	assert_equals "$name.screen" < "$name.expected"
-	assert_equals "$name.stderr" ''
+	assert_equals "$name.stderr" <<-EOF
+	EOF
 }
 
 test_tig_script 'follow' --follow project/Build.scala <<EOF

--- a/test/refs/branch-var-test
+++ b/test/refs/branch-var-test
@@ -11,8 +11,6 @@ set refresh-mode = manual
 EOF
 
 steps '
-	:save-display refs.screen
-
 	:1
 	:exec !assert-var "-%(branch)" == "-"
 
@@ -30,6 +28,9 @@ steps '
 
 	:6
 	:exec !assert-var "%(branch)" == "r1.0"
+
+	:1
+	:save-display refs.screen
 '
 
 in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"

--- a/test/status/repo-var-test
+++ b/test/status/repo-var-test
@@ -3,6 +3,8 @@
 . libtest.sh
 . libgit.sh
 
+export LINES=10
+
 steps "
 	:exec !assert-var '%(repo:head)' == master
 	:exec !assert-var '%(repo:head-id)' == feeb2dfd5e09e887e4b6c901e7d91a4c85a7831d
@@ -11,11 +13,24 @@ steps "
 	:exec !assert-var '%(repo:prefix)' == repo-two-a/
 	:exec !assert-var '%(repo:git-dir)' == '$HOME/$work_dir/.git'
 	:exec !assert-var '%(repo:is-inside-work-tree)' == true
+	:save-display status.screen
 "
 
 in_work_dir create_repo_from_tgz "$base_dir/files/repo-two.tgz"
 
 work_dir="$work_dir/repo-two-a"
 test_tig status
+
+assert_equals status.screen <<EOF
+On branch master. Your branch is up-to-date with 'origin/master'.
+Changes to be committed:
+  (no files)
+Changes not staged for commit:
+  (no files)
+Untracked files:
+  (no files)
+
+[status] Nothing to update                                                  100%
+EOF
 
 assert_vars

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -269,15 +269,24 @@ executable 'assert-var' <<EOF
 #!/bin/sh
 
 mkdir -p "$(dirname -- "$expected_var_file")"
-while [ \$# -gt 0 ]; do
-	arg="\$1"; shift
+lhs="\${1:-}"
+if [ "\$#" -gt 0 ]; then
+	shift
+fi
+if [ "\${1:-}" = "==" ]; then
+	shift
+fi
+rhs="\$*"
 
-	case "\$arg" in
-		==) break ;;
-		*)  printf '%s\\n' "\$arg" >> "$HOME/$vars_file" ;;
-	esac
-done
-printf '%s\\n' "\$*" >> "$expected_var_file"
+if [ -z "\$lhs" ]; then
+	lhs='\"\"'
+fi
+if [ -z "\$rhs" ]; then
+	rhs='\"\"'
+fi
+
+printf '%s\\n' "\$lhs" >> "$HOME/$vars_file"
+printf '%s\\n' "\$rhs" >> "$expected_var_file"
 EOF
 
 assert_vars()


### PR DESCRIPTION
`assert_vars` was a bit vulnerable to false positives, and unable to test on whitespace.

 * take second arg of `assert_equals` for whitespace strict/ignore. Notes are still on trailing args.
 * rewrite the `assert-vars` inline script: less likely to trivially exit, save empty strings as literal `""`
 * run at least one test after `assert-vars` to ensure that steps-script completes

The last is a bit of a hack, though it harms nothing.  Better would be for the `assert_vars` shell function to accept an argument for the number of variables tested (number of lines in the vars file).