### PR TITLE
require expected-asserts count argument to assert_vars

### DIFF
--- a/test/main/all-arg-test
+++ b/test/main/all-arg-test
@@ -21,7 +21,7 @@ in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"
 
 test_tig --all
 
-assert_vars
+assert_vars 1
 
 assert_equals stderr <<EOF
 EOF

--- a/test/main/branch-var-test
+++ b/test/main/branch-var-test
@@ -33,7 +33,7 @@ in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"
 
 test_tig --all
 
-assert_vars
+assert_vars 4
 
 assert_equals 'main.screen' <<EOF
 2009-02-13 23:31 Max Power             * [mp/feature] {max-power/mp/feature} WIP

--- a/test/refs/branch-var-test
+++ b/test/refs/branch-var-test
@@ -37,7 +37,7 @@ in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"
 
 test_tig refs
 
-assert_vars
+assert_vars 6
 
 assert_equals 'refs.screen' <<EOF
                                All references

--- a/test/status/repo-var-test
+++ b/test/status/repo-var-test
@@ -33,4 +33,4 @@ Untracked files:
 [status] Nothing to update                                                  100%
 EOF
 
-assert_vars
+assert_vars 7

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -232,7 +232,7 @@ ORIG_IFS=
 assert_equals()
 {
 	file="$1"; shift
-	whitespace_arg="ignore";
+	whitespace_arg='-w';
 
 	if [ "$#" -ge 1 ]; then
 		whitespace_arg="${1:-}"

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -306,7 +306,7 @@ EOF
 assert_vars()
 {
 	if [ -e "$expected_var_file" ]; then
-		assert_equals "$vars_file" strict "message" < "$expected_var_file"
+		assert_equals "$vars_file" strict "$*" < "$expected_var_file"
 	else
 		printf '[FAIL] %s not found\n' "$expected_var_file" >> .test-result
 	fi


### PR DESCRIPTION
This defends against silent failures, since both `vars` and `expected/vars` have been filled by the same action.

Other followups to #707 
 * `-w` is a clearer default value for `$whitespace_arg`
 * fix stub `"message"` param left from dev
