### PR TITLE
history-size tigrc option

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -323,6 +323,11 @@ The following variables can be set:
 	line number is passed as `+<line-number>` in front of the file name.
 	Example: `vim +10 tig.c`
 
+'history-size' (int)::
+
+	Size of the persistent `~/.tig_history` file when compiled with readline
+	support. Default is 500. Set to 0 to disable.
+
 'mouse' (bool)::
 
 	Whether to enable mouse support. Off by default since it makes selecting

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -46,6 +46,7 @@ typedef struct view_column *view_settings;
 	_(focus_child,			bool,			VIEW_NO_FLAGS) \
 	_(git_colors,			const char **,		VIEW_NO_FLAGS) \
 	_(grep_view,			view_settings,		VIEW_NO_FLAGS) \
+	_(history_size,			int,			VIEW_NO_FLAGS) \
 	_(horizontal_scroll,		double,			VIEW_NO_FLAGS) \
 	_(id_width,			int,			VIEW_NO_FLAGS) \
 	_(ignore_case,			enum ignore_case,	VIEW_NO_FLAGS) \

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -24,7 +24,6 @@
 #ifdef HAVE_READLINE
 #include <readline/readline.h>
 #include <readline/history.h>
-#define HISTORY_SIZE 500
 #endif /* HAVE_READLINE */
 
 static char *
@@ -534,8 +533,12 @@ prompt_init(void)
 	HIST_ENTRY *last_entry;
 
 	readline_init();
+
+	if (opt_history_size <= 0)
+		return;
+
 	using_history();
-	stifle_history(HISTORY_SIZE);
+	stifle_history(opt_history_size);
 	read_history(prompt_histfile());
 	if (atexit(prompt_teardown))
 		die("Failed to register prompt_teardown");

--- a/src/tig.c
+++ b/src/tig.c
@@ -722,8 +722,6 @@ main(int argc, const char *argv[])
 	enum request request = parse_options(argc, argv, pager_mode);
 	struct view *view;
 
-	prompt_init();
-
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
 		die("Failed to setup signal handler");
 
@@ -739,6 +737,8 @@ main(int argc, const char *argv[])
 	die_if_failed(load_repo_info(), "Failed to load repo info.");
 	die_if_failed(load_options(), "Failed to load user config.");
 	die_if_failed(load_git_config(), "Failed to load repo config.");
+
+	prompt_init();
 
 	/* Require a git repository unless when running in pager mode. */
 	if (!repo.git_dir[0] && request != REQ_VIEW_PAGER)

--- a/tigrc
+++ b/tigrc
@@ -118,6 +118,7 @@ set vertical-split		= auto		# Enum: horizontal, vertical, auto; Use auto to
 set split-view-width		= 50%		# Width of right-most view for vertical splits
 set editor-line-number		= yes		# Automatically pass line number to editor? Used
 						# for opening file at specific line e.g. from a diff
+set history-size		= 500		# Size of persistent history, 0 to disable
 set mouse			= no		# Enable mouse support?
 set mouse-scroll		= 3		# Number of lines to scroll via the mouse
 set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?


### PR DESCRIPTION
0 to disable the feature.

This could be tested decently once libtest.sh supports stuffing keystrokes.
