### PR TITLE
fully deduplicate history on save

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -527,6 +527,9 @@ prompt_histfile(void)
 static void
 prompt_teardown(void)
 {
+	if (opt_history_size <= 0)
+		return;
+
 	write_history(prompt_histfile());
 }
 


### PR DESCRIPTION
Some shells expose an option to control deduplication, but I think it is just common sense.

Incidentally fix prompt_teardown from firing when history-size is 0.