### PR TITLE
 Add the packaging metadata to build the tig snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: tig
+version: git
+summary: Text-mode interface for git
+description: |
+  Tig is an ncurses-based text-mode interface for git. It functions mainly as a
+  Git repository browser, but can also assist in staging changes for commit at
+  chunk level and act as a pager for output from various Git commands.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+
+apps:
+  tig:
+    command: tig
+
+parts:
+  tig:
+    source: .
+    plugin: autotools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: classic
 
 apps:
   tig:
-    command: tig
+    command: bin/tig
 
 parts:
   tig:


### PR DESCRIPTION
This package will let you publish the latest tig in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.