### PR TITLE
Test timeout followups

### DIFF
--- a/test/status/on-branch-test
+++ b/test/status/on-branch-test
@@ -169,15 +169,15 @@ add_exec_prefix()
 }
 
 tig_script "all" "
-	$(cat < test-cases | while read -r name; do
+	$(while read -r name; do
 		add_exec_prefix "$name-before"
 		printf ':save-display all-%s.screen\n' "$name"
 		add_exec_prefix "$name-after"
-	done)
+	done < test-cases)
 "
 
 test_tig status
 
-cat < test-cases | while read -r name; do
+while read -r name; do
 	assert_equals "all-$name.screen" < "$name.expected"
-done
+done < test-cases

--- a/test/status/on-branch-test
+++ b/test/status/on-branch-test
@@ -176,6 +176,8 @@ tig_script "all" "
 	done < test-cases)
 "
 
+test_timeout 60
+
 test_tig status
 
 while read -r name; do

--- a/test/status/on-branch-tracking-info-test
+++ b/test/status/on-branch-tracking-info-test
@@ -91,15 +91,15 @@ add_exec_prefix()
 }
 
 tig_script "all" "
-	$(cat < test-cases | while read -r name; do
+	$(while read -r name; do
 		add_exec_prefix "$name-before"
 		printf ':save-display all-%s.screen\n' "$name"
 		add_exec_prefix "$name-after"
-	done)
+	done < test-cases)
 "
 
 test_tig status
 
-cat < test-cases | while read -r name; do
+while read -r name; do
 	assert_equals "all-$name.screen" < "$name.expected"
-done
+done < test-cases

--- a/test/status/on-branch-tracking-info-test
+++ b/test/status/on-branch-tracking-info-test
@@ -98,6 +98,8 @@ tig_script "all" "
 	done < test-cases)
 "
 
+test_timeout 60
+
 test_tig status
 
 while read -r name; do

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -389,6 +389,15 @@ test_todo()
 	test_todo_message "$*" >> .test-skipped
 }
 
+test_timeout()
+{
+	if [ -z "${1:-}" ]; then
+		die 'test_timeout requires an argument'
+	fi
+
+	timeout="${1:-}"
+}
+
 require_git_version()
 {
 	git_version="$(git version | sed 's/git version \([0-9\.]*\).*/\1/')"

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -205,6 +205,7 @@ trace=
 todos=
 valgrind=
 timeout=10
+vlg_timeout_bonus=60
 
 ORIG_IFS="$IFS"
 IFS=" 	"
@@ -540,6 +541,9 @@ test_tig()
 			runner=exec
 			if [ "$expected_status_code" = 0 ] && [ -n "$valgrind" ]; then
 				runner=valgrind_exec
+				if [ "$timeout" -gt 0 ]; then
+					timeout="$((timeout + vlg_timeout_bonus))"
+				fi
 			fi
 			if [ -s "$HOME/${prefix}stdin" ]; then
 				exec 4<"$HOME/${prefix}stdin"

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -315,7 +315,7 @@ assert_vars()
 		die "Test must supply the expected count of assertions to assert_vars()"
 	fi
 
-	grep -c . "$vars_file" | assert_equals "$vars_count_file" strict "$*"
+	grep -c . < "$vars_file" | assert_equals "$vars_count_file" strict "$*"
 
 	if [ -e "$expected_vars_file" ]; then
 		assert_equals "$vars_file" strict "$*" < "$expected_vars_file"


### PR DESCRIPTION
After #688 there are a few glitches in Travis

 * https://travis-ci.org/jonas/tig/jobs/263825104
 * https://travis-ci.org/jonas/tig/jobs/263825140
 * https://travis-ci.org/jonas/tig/jobs/263825141

`on-branch-test` is failing each time with a timeout, under valgrind.  The failure happens in a fairly long synthesized tig script.

This PR

 * adds a timeout bonus to all tests under valgrind
 * adds a `test_timeout()` function which should have been in #688
 * raises the timeout on the relevant sections of `on-branch-test` and the related `on-branch-tracking-info-test`
