### PR TITLE
save and restore TTY attributes

### DIFF
--- a/include/tig/tig.h
+++ b/include/tig/tig.h
@@ -53,6 +53,7 @@
 #include <sys/file.h>
 #include <time.h>
 #include <fcntl.h>
+#include <termios.h>
 
 #include <regex.h>
 

--- a/src/display.c
+++ b/src/display.c
@@ -83,14 +83,16 @@ open_external_viewer(const char *argv[], const char *dir, bool silent, bool conf
 		clear();
 		refresh();
 		endwin();                  /* restore original tty modes */
+		tcsetattr(opt_tty.fd, TCSAFLUSH, opt_tty.attr);
 		ok = io_run_fg(argv, dir);
 		if (confirm || !ok) {
 			if (!ok && *notice)
 				fprintf(stderr, "%s", notice);
 			fprintf(stderr, "Press Enter to continue");
 			getc(opt_tty.file);
-			fseek(opt_tty.file, 0, SEEK_END);
 		}
+		fseek(opt_tty.file, 0, SEEK_END);
+		tcsetattr(opt_tty.fd, TCSAFLUSH, opt_tty.attr);
 		set_terminal_modes();
 	}
 


### PR DESCRIPTION
main program:

 * `opt_tty` becomes a struct
 * `tcgetattr()` at init time
 * `tcsetattr()` in `done_display()`
 * specify `TCSAFLUSH` action in `done_display()` so that tig can't leave keystrokes behind

`open_external_viewer()`, after running external command:

 * restore init-time tty attributes before duplicating ncurses setup steps
 * use `TCSAFLUSH` action when restoring tty attributes to block keystrokes leaking in from external command phase - probably more robust than `fseek()` on the file pointer
 * but keep `fseek … SEEK_END`, which does no harm, make it unconditional

edit: also set tty attributes and flush before running external command

