### PR TITLE
bug: branch on content in expected file

### DIFF
--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -662,7 +662,7 @@ run_test_cases()
 		fi
 
 		assert_equals "$name.screen" < "$name.expected"
-		if [ -s "$name.stderr" ]; then
+		if [ -s "$name-assert-stderr" ]; then
 			assert_equals "$name.stderr" < "$name-assert-stderr"
 		else
 			assert_equals "$name.stderr" < /dev/null


### PR DESCRIPTION
If the user didn't specify content for STDERR, that is the same as specifying it must be empty