### PR TITLE
Fix env var checked

### DIFF
--- a/doc/tig.1.adoc
+++ b/doc/tig.1.adoc
@@ -249,7 +249,7 @@ FILES
 	search history. The location of the history file is determined in the
 	following way. If `$XDG_DATA_HOME` is set and `$XDG_DATA_HOME/tig/`
 	exists, store history to `$XDG_DATA_HOME/tig/history`. If
-	`$XDG_CONFIG_HOME` is empty or undefined, store history to
+	`$XDG_DATA_HOME` is empty or undefined, store history to
 	`~/.local/share/tig/history` if the directory `~/.local/share/tig/`
 	exists, and fall back to `~/.tig_history` if it does not exist.
 


### PR DESCRIPTION
It looks at XDG_DATA_HOME for tig history, not XDG_CONFIG_HOME