### PR TITLE
Handle \n like \r

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -813,6 +813,9 @@ get_input(int prompt_position, struct key *key)
 			input_mode = false;
 			if (key_value == erasechar())
 				key_value = KEY_BACKSPACE;
+			/* Handle \n just like \r */
+			else if (key_value == '\n')
+				key_value = KEY_RETURN;
 
 			/*
 			 * Ctrl-<key> values are represented using a 0x1F


### PR DESCRIPTION
Currently, when \n is received, tig will report
"Unknown key, press h for help"

This is a workaround for vim/vim#1998 but nevertheless it might make
sense to handle \n synonymous to \r. So this patch makes handling \n
like \r.