### PR TITLE
Use initscr to ensure proper TTY setup for the prompt

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -4,11 +4,17 @@ Release notes
 master
 ------
 
+Improvements:
+
+ - Restore TTY attributes. (GH #725)
+
 Bug fixes:
 
  - Add workaround that detects busy loops when Tig loses the TTY. This may
    happen if Tig does not receive the HUP signal (e.g. when started with
    `nohup`). (GH #164)
+ - Fix compatibility with ncurses-5.4 which caused copy-pasting to not work
+   in the prompt. (GH #767)
 
 tig-2.3.0
 ---------

--- a/src/display.c
+++ b/src/display.c
@@ -609,7 +609,10 @@ init_display(void)
 		die("Failed to register done_display");
 
 	/* Initialize the curses library */
-	{
+	if (!no_display && isatty(STDIN_FILENO)) {
+		/* Needed for ncurses 5.4 compatibility. */
+		cursed = !!initscr();
+	} else {
 		/* Leave stdin and stdout alone when acting as a pager. */
 		FILE *out_tty;
 


### PR DESCRIPTION
Reverts part of c883298355e02fc2c431cb68fe5edc212ec62fea to ensure
pasting into the prompt works for ncurses 5.4.

Fixes #767