### PR TITLE
Revert "Handle \n like \r (#758)"

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -831,9 +831,6 @@ get_input(int prompt_position, struct key *key)
 			input_mode = false;
 			if (key_value == erasechar())
 				key_value = KEY_BACKSPACE;
-			/* Handle \n just like \r */
-			else if (key_value == '\n')
-				key_value = KEY_RETURN;
 
 			/*
 			 * Ctrl-<key> values are represented using a 0x1F


### PR DESCRIPTION
This reverts commit e22d8060baebc61a7cc20642f6e6c9c304f2b9a5 in order to restore the distinction between `<enter>` and `<c-j>`. 
See https://github.com/jonas/tig/pull/758.