### PR TITLE
Fix file argument

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -118,7 +118,7 @@ get_path_encoding(const char *path, struct encoding *default_encoding)
 	    || !strcmp(encoding, "unspecified")
 	    || !strcmp(encoding, "set")) {
 		const char *file_argv[] = {
-			"file", "-I", "--", path, NULL
+			"file", "--mime", "--", path, NULL
 		};
 
 		if (!*path || !io_run_buf(file_argv, buf, sizeof(buf), NULL, false)


### PR DESCRIPTION
file -I works with macOS but not with Linux (should be file -i). Rather use the long option --mime which is valid for both.