### PR TITLE
display.h: fix build against netbsd-curses

### DIFF
--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -58,8 +58,8 @@ void enable_mouse(bool enable);
 
 enum status_code open_script(const char *path);
 
-#define get_cursor_pos(cursor_y, cursor_x) getyx(newscr, cursor_y, cursor_x)
-#define set_cursor_pos(cursor_y, cursor_x) wmove(newscr, cursor_y, cursor_x)
+#define get_cursor_pos(cursor_y, cursor_x) getyx(curscr, cursor_y, cursor_x)
+#define set_cursor_pos(cursor_y, cursor_x) wmove(curscr, cursor_y, cursor_x)
 
 #endif
 /* vim: set ts=8 sw=8 noexpandtab: */


### PR DESCRIPTION
`newscr` is a ncurses-ism, and doesn't exist in netbsd-curses.

according to `man 3x curs_variables`:

> The New Screen
> This implementation of curses uses a special window newscr to hold  up-
> dates to the terminal screen before applying them to curscr.

so it seems using curscr instead should be fine.