### PR TITLE
New boolean option "send-child-enter"

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -317,6 +317,13 @@ The following variables can be set:
 	focus will remain in the parent view, avoiding reloads of the child
 	view when navigating the parent view. True by default.
 
+'send-child-enter' (bool)::
+
+	Whether to send "enter" key presses to the child view, even if parent
+	view is active. When disabled the child view has to be explicitly
+	focused to receive the "enter" key presses. In practice only relevant
+	when `set focus-child = no`. True by default.
+
 'editor-line-number' (bool)::
 
 	Whether to pass the selected line number to the editor command. The

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -66,6 +66,7 @@ typedef struct view_column *view_settings;
 	_(refresh_mode,			enum refresh_mode,	VIEW_NO_FLAGS) \
 	_(refs_view,			view_settings,		VIEW_NO_FLAGS) \
 	_(rev_args,			const char **,		VIEW_NO_FLAGS) \
+	_(send_child_enter,		bool,			VIEW_NO_FLAGS) \
 	_(show_changes,			bool,			VIEW_NO_FLAGS) \
 	_(show_notes,			bool,			VIEW_NO_FLAGS) \
 	_(split_view_height,		double,			VIEW_RESET_DISPLAY) \

--- a/src/tig.c
+++ b/src/tig.c
@@ -62,7 +62,7 @@ view_request(struct view *view, enum request request)
 	if (!view || !view->lines)
 		return request;
 
-	if (request == REQ_ENTER && !opt_focus_child &&
+	if (request == REQ_ENTER && !opt_focus_child && opt_send_child_enter &&
 	    view_has_flags(view, VIEW_SEND_CHILD_ENTER)) {
 		struct view *child = display[1];
 

--- a/tigrc
+++ b/tigrc
@@ -111,6 +111,7 @@ set ignore-case			= no		# Enum: no, yes, smart-case
 						# Ignore case when searching? Smart-case option will
 set wrap-search			= yes		# Wrap around to top/bottom of view when searching
 set focus-child			= yes		# Move focus to child view when opened?
+set send-child-enter		= yes		# Propagate "enter" keypresses to child views?
 set horizontal-scroll		= 50%		# Number of columns to scroll as % of width
 set split-view-height		= 67%		# Height of the bottom view for horizontal splits
 set vertical-split		= auto		# Enum: horizontal, vertical, auto; Use auto to


### PR DESCRIPTION
Can be set to "no" to disable sending enter key presses to child view.
In practice only relevant if "focus-child" is false.

Default is "yes", which is identical to previous behavior.