### PR TITLE
Update make config for cygwin/ncurses

### DIFF
--- a/contrib/config.make-CYGWIN_NT-6.1
+++ b/contrib/config.make-CYGWIN_NT-6.1
@@ -2,7 +2,7 @@
 #
 # Use ncursesw.
 
-NCURSESW_LIBS = $(shell ncursesw5-config --libs 2>/dev/null)
+NCURSESW_LIBS = $(shell ncursesw6-config --libs 2>/dev/null)
 HAS_ICONV = $(shell test -e "/usr/include/iconv.h" && echo true)
 
 ifeq ($(NCURSESW_LIBS),)


### PR DESCRIPTION
Cygwin has apparently updated the `ncursesw` package to version 6.
Update make config to reflect that.