### PR TITLE
Warning fixes

### DIFF
--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -790,7 +790,7 @@ graph_add_commit(struct graph *graph_ref, struct graph_canvas *canvas,
 	return true;
 }
 
-static const bool
+static bool
 graph_symbol_forks(const struct graph_symbol *symbol)
 {
 	if (!symbol->continued_down)
@@ -805,7 +805,7 @@ graph_symbol_forks(const struct graph_symbol *symbol)
 	return true;
 }
 
-static const bool
+static bool
 graph_symbol_cross_merge(const struct graph_symbol *symbol)
 {
 	if (symbol->empty)
@@ -826,7 +826,7 @@ graph_symbol_cross_merge(const struct graph_symbol *symbol)
 	return false;
 }
 
-static const bool
+static bool
 graph_symbol_vertical_merge(const struct graph_symbol *symbol)
 {
 	if (symbol->empty)
@@ -850,7 +850,7 @@ graph_symbol_vertical_merge(const struct graph_symbol *symbol)
 	return false;
 }
 
-static const bool
+static bool
 graph_symbol_cross_over(const struct graph_symbol *symbol)
 {
 	if (symbol->empty)
@@ -874,7 +874,7 @@ graph_symbol_cross_over(const struct graph_symbol *symbol)
 	return false;
 }
 
-static const bool
+static bool
 graph_symbol_turn_left(const struct graph_symbol *symbol)
 {
 	if (symbol->matches_commit && symbol->continued_right && !symbol->continued_down)
@@ -894,7 +894,7 @@ graph_symbol_turn_left(const struct graph_symbol *symbol)
 	return false;
 }
 
-static const bool
+static bool
 graph_symbol_turn_down_cross_over(const struct graph_symbol *symbol)
 {
 	if (!symbol->continued_down)
@@ -915,7 +915,7 @@ graph_symbol_turn_down_cross_over(const struct graph_symbol *symbol)
 	return false;
 }
 
-static const bool
+static bool
 graph_symbol_turn_down(const struct graph_symbol *symbol)
 {
 	if (!symbol->continued_down)
@@ -927,7 +927,7 @@ graph_symbol_turn_down(const struct graph_symbol *symbol)
 	return true;
 }
 
-static const bool
+static bool
 graph_symbol_merge(const struct graph_symbol *symbol)
 {
 	if (symbol->continued_down)
@@ -945,7 +945,7 @@ graph_symbol_merge(const struct graph_symbol *symbol)
 	return true;
 }
 
-static const bool
+static bool
 graph_symbol_multi_merge(const struct graph_symbol *symbol)
 {
 	if (!symbol->parent_down)
@@ -957,7 +957,7 @@ graph_symbol_multi_merge(const struct graph_symbol *symbol)
 	return true;
 }
 
-static const bool
+static bool
 graph_symbol_vertical_bar(const struct graph_symbol *symbol)
 {
 	if (symbol->empty)
@@ -984,7 +984,7 @@ graph_symbol_vertical_bar(const struct graph_symbol *symbol)
 	return true;
 }
 
-static const bool
+static bool
 graph_symbol_horizontal_bar(const struct graph_symbol *symbol)
 {
 	if (!symbol->next_right)
@@ -1008,7 +1008,7 @@ graph_symbol_horizontal_bar(const struct graph_symbol *symbol)
 	return false;
 }
 
-static const bool
+static bool
 graph_symbol_multi_branch(const struct graph_symbol *symbol)
 {
 	if (symbol->continued_down)

--- a/src/grep.c
+++ b/src/grep.c
@@ -249,8 +249,7 @@ grep_read(struct view *view, struct buffer *buf, bool force_stop)
 	grep->lineno = atoi(lineno);
 	if (grep->lineno > 0)
 		grep->lineno -= 1;
-	strncpy(grep->text, text, textlen);
-	grep->text[textlen] = 0;
+	strncpy(grep->text, text, textlen + 1);
 	view_column_info_update(view, line);
 
 	state->last_file = file;

--- a/src/options.c
+++ b/src/options.c
@@ -522,6 +522,7 @@ parse_string(char *opt, const char *arg, size_t optsize)
 		if (arglen == 1 || arg[arglen - 1] != arg[0])
 			return ERROR_UNMATCHED_QUOTATION;
 		arg += 1; arglen -= 2;
+		/* Fall-through */
 	default:
 		string_ncopy_do(opt, optsize, arg, arglen);
 		return SUCCESS;

--- a/src/view.c
+++ b/src/view.c
@@ -132,6 +132,7 @@ scroll_view(struct view *view, enum request request)
 		return;
 	case REQ_SCROLL_PAGE_DOWN:
 		lines = view->height;
+		/* Fall-through */
 	case REQ_SCROLL_WHEEL_DOWN:
 	case REQ_SCROLL_LINE_DOWN:
 		if (view->pos.offset + lines > view->lines)
@@ -145,6 +146,7 @@ scroll_view(struct view *view, enum request request)
 
 	case REQ_SCROLL_PAGE_UP:
 		lines = view->height;
+		/* Fall-through */
 	case REQ_SCROLL_LINE_UP:
 	case REQ_SCROLL_WHEEL_UP:
 		if (lines > view->pos.offset)


### PR DESCRIPTION
I tried compiling tig with most warnings enabled using the current gcc snapshot that would become gcc 8. I started with `-Wall -Wextra` and disabled warnings that cannot be easily fixed (`-Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers`)

I was able to fix all warnings, but some fixes need more work, so I'm only submitting the simple and good-looking fixes.