### PR TITLE
Don't allow pos->lineno to underflow in file search (#800)

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -103,8 +103,12 @@ file_finder_move(struct file_finder *finder, int direction)
 	else
 		finder->pos.lineno += direction;
 
-	if (finder->pos.lineno >= finder->lines)
-		finder->pos.lineno = finder->lines - 1;
+	if (finder->pos.lineno >= finder->lines) {
+		if (finder->lines > 0)
+			finder->pos.lineno = finder->lines - 1;
+		else
+			finder->pos.lineno = 0;
+        }
 
 	if (finder->pos.offset + finder->height <= finder->pos.lineno)
 		finder->pos.offset = finder->pos.lineno - (finder->height / 2);


### PR DESCRIPTION
If no text is found in the file search, pos->lineno would become `(unsigned long)-1` which would lead to invalid memory access in `file_finder_draw()`