### PR TITLE
Add support of toggling commit and author (name and date)

### DIFF
--- a/include/tig/argv.h
+++ b/include/tig/argv.h
@@ -35,6 +35,7 @@ bool argv_appendn(const char ***argv, const char *arg, size_t arglen);
 bool argv_append_array(const char ***dst_argv, const char *src_argv[]);
 bool argv_copy(const char ***dst, const char *src[]);
 bool argv_contains(const char **argv, const char *arg);
+bool argv_containsn(const char **argv, const char *arg, size_t arglen);
 
 typedef char argv_string[SIZEOF_STR];
 typedef unsigned long argv_number;

--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -43,6 +43,11 @@ struct ref;
 	_(PP_REFS,		"Refs: "), \
 	_(PP_REFLOG,		"Reflog: "), \
 	_(PP_REFLOGMSG,		"Reflog message: "), \
+	_(PP_AUTHOR,		"Author: "	), \
+	_(PP_AUTHORDATE,		"Date: "), \
+	_(PP_AUTHORDATE2,		"AuthorDate: "), \
+	_(PP_COMMITTER,		"Commit: "	), \
+	_(PP_COMMITDATE,		"CommitDate: "), \
 	_(COMMIT,		"commit "), \
 	_(PARENT,		"parent "), \
 	_(TREE,			"tree "), \

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -87,6 +87,8 @@ typedef struct view_column *view_settings;
 	_(vertical_split,		enum vertical_split,	VIEW_RESET_DISPLAY | VIEW_DIFF_LIKE) \
 	_(wrap_lines,			bool,			VIEW_NO_FLAGS) \
 	_(wrap_search,			bool,			VIEW_NO_FLAGS) \
+	_(committer,			bool,			VIEW_LOG_LIKE | VIEW_BLAME_LIKE) \
+	_(commit_date,			bool,			VIEW_LOG_LIKE | VIEW_BLAME_LIKE) \
 
 #define DEFINE_OPTION_EXTERNS(name, type, flags) extern type opt_##name;
 OPTION_INFO(DEFINE_OPTION_EXTERNS)

--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -72,6 +72,7 @@ enum view_flag {
 	VIEW_SORTABLE		= 1 << 15,
 	VIEW_FLEX_WIDTH		= 1 << 16,
 	VIEW_RESET_DISPLAY	= 1 << 17,
+	VIEW_COMMIT_NAMEDATE	= 1 << 18,
 };
 
 #define view_has_flags(view, flag)	((view)->ops->flags & (flag))

--- a/src/argv.c
+++ b/src/argv.c
@@ -206,6 +206,18 @@ argv_contains(const char **argv, const char *arg)
 	return false;
 }
 
+bool
+argv_containsn(const char **argv, const char *arg, size_t arglen)
+{
+	int i;
+
+	if (arglen == 0) arglen = strlen(arg);
+	for (i = 0; argv && argv[i]; i++)
+		if (!strncmp(argv[i], arg, arglen))
+			return true;
+	return false;
+}
+
 DEFINE_ALLOCATOR(argv_realloc, const char *, SIZEOF_ARG)
 
 bool

--- a/src/blame.c
+++ b/src/blame.c
@@ -539,7 +539,7 @@ blame_select(struct view *view, struct line *line)
 static struct view_ops blame_ops = {
 	"line",
 	argv_env.commit,
-	VIEW_SEND_CHILD_ENTER | VIEW_BLAME_LIKE,
+	VIEW_SEND_CHILD_ENTER | VIEW_BLAME_LIKE | VIEW_REFRESH | VIEW_COMMIT_NAMEDATE,
 	sizeof(struct blame_state),
 	blame_open,
 	blame_read,

--- a/src/options.c
+++ b/src/options.c
@@ -156,9 +156,14 @@ use_mailmap_arg()
 const char *
 log_custom_pretty_arg(void)
 {
-	return opt_mailmap
-		? "--pretty=format:commit %m %H %P%x00%aN <%aE> %ad%x00%s%x00%N"
-		: "--pretty=format:commit %m %H %P%x00%an <%ae> %ad%x00%s%x00%N";
+	static char pretty_arg[64];
+	char name_c = opt_committer ? 'c' : 'a';
+	snprintf(pretty_arg, sizeof(pretty_arg)-1,
+		"--pretty=format:commit %%m %%H %%P%%x00%%%c%c <%%%c%c> %s%%x00%%s%%x00%%N",
+		name_c, opt_mailmap ? 'N' : 'n',
+		name_c, opt_mailmap ? 'E' : 'e',
+		opt_commit_date ? "%cd" : "%ad");
+	return pretty_arg;
 }
 
 #define ENUM_ARG(enum_name, arg_string) ENUM_MAP_ENTRY(arg_string, enum_name)
@@ -887,6 +892,8 @@ option_bind_command(int argc, const char *argv[])
 			{ "toggle-title-overflow",	"commit-title-overflow" },
 			{ "toggle-untracked-dirs",	"status-show-untracked-dirs" },
 			{ "toggle-vertical-split",	"show-vertical-split" },
+			{ "toggle-committer",		"committer" },
+			{ "toggle-commit-date",		"commit-date" },
 		};
 		int alias;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -14,6 +14,7 @@
 #include "tig/tig.h"
 #include "tig/parse.h"
 #include "tig/map.h"
+#include "tig/options.h"
 
 size_t
 parse_size(const char *text)
@@ -73,7 +74,8 @@ parse_author_line(char *ident, const struct ident **author, struct time *time)
 	if (!*email)
 		email = *name ? name : unknown_ident.email;
 
-	*author = get_author(name, email);
+	if (author)
+		*author = get_author(name, email);
 
 	/* Parse epoch and timezone */
 	if (time && emailend && emailend[1] == ' ') {
@@ -141,10 +143,10 @@ match_blame_header(const char *name, char **line)
 bool
 parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *line)
 {
-	if (match_blame_header("author ", &line)) {
+	if (match_blame_header(opt_committer ? "committer " : "author ", &line)) {
 		string_ncopy_do(author, SIZEOF_STR, line, strlen(line));
 
-	} else if (match_blame_header("author-mail ", &line)) {
+	} else if (match_blame_header(opt_committer ? "committer-mail " : "author-mail ", &line)) {
 		char *end = strchr(line, '>');
 
 		if (end)
@@ -154,10 +156,10 @@ parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *lin
 		commit->author = get_author(author, line);
 		author[0] = 0;
 
-	} else if (match_blame_header("author-time ", &line)) {
+	} else if (match_blame_header(opt_commit_date ? "committer-time " : "author-time ", &line)) {
 		parse_timesec(&commit->time, line);
 
-	} else if (match_blame_header("author-tz ", &line)) {
+	} else if (match_blame_header(opt_commit_date ? "committer-tz " : "author-tz ", &line)) {
 		parse_timezone(&commit->time, line);
 
 	} else if (match_blame_header("summary ", &line)) {

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -862,6 +862,13 @@ prompt_toggle(struct view *view, const char *argv[], enum view_flag *flags)
 		}
 	}
 
+	if (enum_equals_static("committer", option, optionlen) ||
+	    enum_equals_static("commit-date", option, optionlen)) {
+		if (!view_has_flags(view, VIEW_COMMIT_NAMEDATE)) {
+			return error("`:toggle %s` is not supported for the %s view", option, view->name);
+		}
+	}
+
 	toggle = find_option_info(option_toggles, ARRAY_SIZE(option_toggles), "", option);
 	if (toggle)
 		return prompt_toggle_option(view, argv, "", toggle, flags);

--- a/src/refs.c
+++ b/src/refs.c
@@ -139,7 +139,7 @@ refs_open_visitor(void *data, const struct ref *ref)
 	bool is_all = ref == refs_all;
 	struct line *line;
 
-        if (!is_all)
+	if (!is_all)
 		switch (refs_filter) {
 		case REFS_FILTER_TAGS:
 			if (ref->type != REFERENCE_TAG && ref->type != REFERENCE_LOCAL_TAG)
@@ -173,11 +173,11 @@ static const char **refs_argv;
 static enum status_code
 refs_open(struct view *view, enum open_flags flags)
 {
+	char pretty_arg[50] = {0};
+	char name_c = opt_committer ? 'c' : 'a';
 	const char *refs_log[] = {
 		"git", "log", encoding_arg, "--no-color", "--date=raw",
-			opt_mailmap ? "--pretty=format:%H%x00%aN <%aE> %ad%x00%s"
-				    : "--pretty=format:%H%x00%an <%ae> %ad%x00%s",
-			"--all", "--simplify-by-decoration", NULL
+		pretty_arg, "--all", "--simplify-by-decoration", NULL
 	};
 	enum status_code code;
 	const char *name = REFS_ALL_NAME;
@@ -201,6 +201,11 @@ refs_open(struct view *view, enum open_flags flags)
 		}
 	}
 
+	snprintf(pretty_arg, sizeof(pretty_arg)-1,
+		"--pretty=format:%%H%%x00%%%c%c <%%%c%c> %s%%x00%%s",
+		name_c, opt_mailmap ? 'N' : 'n',
+		name_c, opt_mailmap ? 'E' : 'e',
+		opt_commit_date ? "%cd" : "%ad");
 	if (!refs_all) {
 		int name_length = strlen(name);
 		struct ref *ref = calloc(1, sizeof(*refs_all) + name_length);
@@ -246,7 +251,7 @@ refs_select(struct view *view, struct line *line)
 static struct view_ops refs_ops = {
 	"reference",
 	argv_env.head,
-	VIEW_REFRESH | VIEW_SORTABLE,
+	VIEW_SORTABLE | VIEW_BLAME_LIKE | VIEW_REFRESH | VIEW_COMMIT_NAMEDATE,
 	0,
 	refs_open,
 	refs_read,

--- a/src/tig.c
+++ b/src/tig.c
@@ -107,6 +107,10 @@ view_request(struct view *view, enum request request)
 	_('$', "commit title overflow display",	"commit-title-overflow"), \
 	_('d', "untracked directory info",	"status-show-untracked-dirs"), \
 	_('|', "view split",			"vertical-split"), \
+	_('E', "mail map",          "mailmap"), \
+	_('L', "local date",            "date-local"), \
+	_('M', "committer",         "committer"), \
+	_('m', "commit date",           "commit-date"), \
 
 static void
 toggle_option(struct view *view)

--- a/src/tree.c
+++ b/src/tree.c
@@ -80,8 +80,8 @@ struct tree_entry {
 
 struct tree_state {
 	char commit[SIZEOF_REV];
-	const struct ident *author;
-	struct time author_time;
+	const struct ident *author; /* Author/Committer */
+	struct time author_time; /* Author data/Commit date */
 	bool read_date;
 };
 
@@ -171,13 +171,26 @@ tree_read_date(struct view *view, struct buffer *buf, struct tree_state *state)
 		state->read_date = true;
 		return false;
 
-	} else if (*text == 'c' && get_line_type(text) == LINE_COMMIT) {
-		string_copy_rev_from_commit_line(state->commit, text);
-
-	} else if (*text == 'a' && get_line_type(text) == LINE_AUTHOR) {
-		parse_author_line(text + STRING_SIZE("author "),
-				  &state->author, &state->author_time);
-
+	} else if (*text == 'c' || *text == 'a') {
+		enum line_type type = get_line_type(text);
+		switch (type)
+		{
+		case LINE_COMMIT:
+			string_copy_rev_from_commit_line(state->commit, text);
+			break;
+		case LINE_AUTHOR:
+		case LINE_COMMITTER:
+		{
+			bool committer_line = (type == LINE_COMMITTER);
+			parse_author_line(text +
+				(committer_line ? STRING_SIZE("committer ") : STRING_SIZE("author ")),
+				(opt_committer ^ committer_line) ? NULL : &state->author,
+				(opt_commit_date ^ committer_line) ? NULL : &state->author_time);
+			break;
+		}
+		default:
+			break;
+		}
 	} else if (*text == ':') {
 		char *pos;
 		size_t annotated = 1;
@@ -464,7 +477,7 @@ tree_open(struct view *view, enum open_flags flags)
 static struct view_ops tree_ops = {
 	"file",
 	argv_env.commit,
-	VIEW_SEND_CHILD_ENTER | VIEW_SORTABLE,
+	VIEW_SEND_CHILD_ENTER | VIEW_SORTABLE | VIEW_LOG_LIKE | VIEW_REFRESH | VIEW_COMMIT_NAMEDATE,
 	sizeof(struct tree_state),
 	tree_open,
 	tree_read,

--- a/test/diff/diff-stat-test
+++ b/test/diff/diff-stat-test
@@ -46,9 +46,9 @@ Dimensions: height=28 width=181
 Position: offset=0 column=0 lineno=0
 line[  0] type=commit selected=1
 line[  0] cells=1 text=[commit 1b4c64b595aeb4de1d317d669faacd3c1d82f0b0]
-line[  1] type= selected=0
+line[  1] type=pp-author selected=0
 line[  1] cells=1 text=[Author: A. U. Thor <author@example.com>]
-line[  2] type= selected=0
+line[  2] type=pp-authordate selected=0
 line[  2] cells=1 text=[Date:   Sun Jul 2 15:01:24 2017 +0200]
 line[  3] type=default selected=0
 line[  3] cells=1 text=[]

--- a/test/log/diff-stat-test
+++ b/test/log/diff-stat-test
@@ -25,7 +25,7 @@ assert_equals 'diff-stat.screen' <<EOF
 commit ee912870202200a0b9cf4fd86ba57243212d341e                                            |commit ee912870202200a0b9cf4fd86ba57243212d341e
 Refs: [master]                                                                             |Refs: [master]
 Author: Jonas Fonseca <jonas.fonseca@gmail.com>                                            |Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
-Date:   Sat Mar 1 17:26:01 2014 -0500                                                      |AuthorDate: Sat Mar 1 17:26:01 2014 -0500
+AuthorDate: Sat Mar 1 17:26:01 2014 -0500                                                  |AuthorDate: Sat Mar 1 17:26:01 2014 -0500
                                                                                            |Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
     WIP: Upgrade to 0.4-SNAPSHOT and DCE                                                   |CommitDate: Sat Mar 1 17:26:01 2014 -0500
                                                                                            |
@@ -57,7 +57,7 @@ assert_equals 'diff-stat-after-refresh.screen' <<EOF
 commit ee912870202200a0b9cf4fd86ba57243212d341e                                            |commit ee912870202200a0b9cf4fd86ba57243212d341e
 Refs: [master]                                                                             |Refs: [master]
 Author: Jonas Fonseca <jonas.fonseca@gmail.com>                                            |Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
-Date:   Sat Mar 1 17:26:01 2014 -0500                                                      |AuthorDate: Sat Mar 1 17:26:01 2014 -0500
+AuthorDate: Sat Mar 1 17:26:01 2014 -0500                                                  |AuthorDate: Sat Mar 1 17:26:01 2014 -0500
                                                                                            |Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
     WIP: Upgrade to 0.4-SNAPSHOT and DCE                                                   |CommitDate: Sat Mar 1 17:26:01 2014 -0500
                                                                                            |

--- a/test/log/log-graph-test
+++ b/test/log/log-graph-test
@@ -15,7 +15,7 @@ assert_equals 'log-graph.screen' <<EOF
 *   commit e59a941c4e7d51cd172ee2767a031f5f3fd25d05
 |\  Merge: 110e090 940efaf
 | | Author: Jonas Fonseca <jonas.fonseca@gmail.com>
-| | Date:   Thu Jan 16 07:47:58 2014 -0800
+| | AuthorDate:   Thu Jan 16 07:47:58 2014 -0800
 | |
 | |     Merge pull request #4 from phaller/patch-1
 | |
@@ -26,7 +26,7 @@ assert_equals 'log-graph.screen' <<EOF
 | |
 | * commit 940efafc379db7c6df99449d6c4da98c6a2b3d07
 |/  Author: Philipp Haller <hallerp@gmail.com>
-|   Date:   Thu Jan 16 15:32:52 2014 +0100
+|   AuthorDate:   Thu Jan 16 15:32:52 2014 +0100
 |
 |       Fix link to Dart benchmark harness
 |
@@ -35,7 +35,7 @@ assert_equals 'log-graph.screen' <<EOF
 |
 * commit 110e090f815f40d649f5432172584057b550a160
 | Author: Jonas Fonseca <jonas.fonseca@gmail.com>
-| Date:   Tue Dec 17 00:02:15 2013 +0100
+| AuthorDate:   Tue Dec 17 00:02:15 2013 +0100
 |
 |     Update links to reflect project name change
 |

--- a/test/log/start-on-line-test
+++ b/test/log/start-on-line-test
@@ -13,7 +13,7 @@ test_tig log +42
 
 assert_equals 'position.screen' <<EOF
 Author: Jonas Fonseca <jonas.fonseca@gmail.com>
-Date:   Sat Mar 1 15:59:02 2014 -0500
+AuthorDate: Sat Mar 1 15:59:02 2014 -0500
 
     Add type parameter for js.Dynamic
 
@@ -22,7 +22,7 @@ Date:   Sat Mar 1 15:59:02 2014 -0500
 
 commit 296fc90ba2c47ba3d2b6ab8e984ea3a82bb4cd6e
 Author: Jonas Fonseca <jonas.fonseca@gmail.com>
-Date:   Thu Jan 16 22:51:27 2014 -0500
+AuthorDate: Thu Jan 16 22:51:27 2014 -0500
 
     Move classes under org.scalajs.benchmark package scope
 

--- a/test/log/submodule-test
+++ b/test/log/submodule-test
@@ -29,7 +29,7 @@ assert_equals 'log-submodule.screen' <<EOF
 commit feeb2dfd5e09e887e4b6c901e7d91a4c85a7831d
 Refs: [master], {origin/master}, {origin/HEAD}
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Sun Sep 6 08:23:30 2009 +0000
+AuthorDate: Sun Sep 6 08:23:30 2009 +0000
 
     [repo-two] Integrate feature from repo-two-a, repo-two-b, repo-two-c
 
@@ -40,7 +40,7 @@ Date:   Sun Sep 6 08:23:30 2009 +0000
 
 commit 7f9d74d1b554e99059334799f56b1307f9c324d4
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Mon Aug 3 06:54:50 2009 +0000
+AuthorDate: Mon Aug 3 06:54:50 2009 +0000
 
     [repo-two] Integrate feature from repo-two-b
 
@@ -49,7 +49,7 @@ Date:   Mon Aug 3 06:54:50 2009 +0000
 
 commit 2bbde7f66edbac9b45b86ad75e6b1e8e02970a67
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Wed Jul 8 17:48:20 2009 +0000
+AuthorDate: Wed Jul 8 17:48:20 2009 +0000
 
     [repo-two] Integrate feature from repo-two-a, repo-two-c
 
@@ -59,7 +59,7 @@ Date:   Wed Jul 8 17:48:20 2009 +0000
 
 commit 3a2603a2ea55ef06860f8d8ec33ee10d95d08117
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Wed May 27 03:57:30 2009 +0000
+AuthorDate: Wed May 27 03:57:30 2009 +0000
 
     [repo-two] Creating repository
 
@@ -78,7 +78,7 @@ assert_equals 'log-submodule-diff.screen' <<EOF
 commit feeb2dfd5e09e887e4b6c901e7d91a4c85a7831d
 Refs: [master], {origin/master}, {origin/HEAD}
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Sun Sep 6 08:23:30 2009 +0000
+AuthorDate: Sun Sep 6 08:23:30 2009 +0000
 
     [repo-two] Integrate feature from repo-two-a, repo-two-b, repo-two-c
 ---
@@ -96,7 +96,7 @@ Submodule repo-two-c cd41885..e4b7821:
 
 commit 7f9d74d1b554e99059334799f56b1307f9c324d4
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Mon Aug 3 06:54:50 2009 +0000
+AuthorDate: Mon Aug 3 06:54:50 2009 +0000
 
     [repo-two] Integrate feature from repo-two-b
 ---
@@ -109,7 +109,7 @@ Submodule repo-two-b e795b27..f3866fb:
 
 commit 2bbde7f66edbac9b45b86ad75e6b1e8e02970a67
 Author: A. U. Thor <a.u.thor@example.com>
-Date:   Wed Jul 8 17:48:20 2009 +0000
+AuthorDate: Wed Jul 8 17:48:20 2009 +0000
 
     [repo-two] Integrate feature from repo-two-a, repo-two-c
 ---

--- a/tigrc
+++ b/tigrc
@@ -119,6 +119,8 @@ set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 #set log-options		= --pretty=raw	# User-defined options for `tig log` (git-log)
 #set main-options		= -n 1000	# User-defined options for `tig` (git-log)
 set mailmap			= yes		# Use .mailmap to show canonical name and email address
+#set commit-date		= no		# Show commit date instead of author date
+#set committer			= no		# Show committer name instead of author name
 
 # Misc
 set start-on-head		= no		# Start with cursor on HEAD commit


### PR DESCRIPTION
Add support of toggling commit and author (name and date)

i.e. toggling of:
1. author and committer (toggle option=m)
2. author-date and commit-date (toggle option=M)

Currently, applicable to view: main, log, refs, blame and tree.