### PR TITLE
Fix line numbers in grep view when scrolled

### DIFF
--- a/include/tig/draw.h
+++ b/include/tig/draw.h
@@ -31,7 +31,7 @@ bool draw_text(struct view *view, enum line_type type, const char *string);
 bool PRINTF_LIKE(3, 4) draw_formatted(struct view *view, enum line_type type, const char *format, ...);
 bool draw_graphic(struct view *view, enum line_type type, const chtype graphic[], size_t size, bool separator);
 bool draw_field(struct view *view, enum line_type type, const char *text, int width, enum align align, bool trim);
-bool draw_lineno(struct view *view, struct view_column *column, unsigned int lineno);
+bool draw_lineno(struct view *view, struct view_column *column, unsigned int lineno, bool add_offset);
 bool view_column_draw(struct view *view, struct line *line, unsigned int lineno);
 
 void redraw_view(struct view *view);

--- a/src/draw.c
+++ b/src/draw.c
@@ -332,9 +332,11 @@ draw_lineno_custom(struct view *view, struct view_column *column, unsigned int l
 }
 
 bool
-draw_lineno(struct view *view, struct view_column *column, unsigned int lineno)
+draw_lineno(struct view *view, struct view_column *column, unsigned int lineno, bool add_offset)
 {
-	lineno += view->pos.offset + 1;
+	lineno += 1;
+	if (add_offset)
+		lineno += view->pos.offset;
 	return draw_lineno_custom(view, column, lineno);
 }
 
@@ -484,7 +486,11 @@ view_column_draw(struct view *view, struct line *line, unsigned int lineno)
 			continue;
 
 		case VIEW_COLUMN_LINE_NUMBER:
-			if (draw_lineno(view, column, column_data.line_number ? *column_data.line_number : lineno))
+			/* Avoid corrupting line numbers (which actually are search results)
+			 * in grep mode by special-treating that view. */
+			if (draw_lineno(view, column,
+			                column_data.line_number ? *column_data.line_number : lineno,
+			                strcmp(view->name, "grep")))
 				return true;
 			continue;
 

--- a/test/grep/default-test
+++ b/test/grep/default-test
@@ -209,10 +209,10 @@ main.c
 EOF
 
 assert_equals 'grep-i-split.screen' <<EOF
- 14| Is inserted.
- 16| The exit paragraph.
+  8| Is inserted.
+ 10| The exit paragraph.
 main.c
-  7| #include <stdin.h>
+  1| #include <stdin.h>
 [grep] main.c - line 10 of 13                                                76%
 #include <stdin.h>
 

--- a/test/grep/start-on-line-test
+++ b/test/grep/start-on-line-test
@@ -18,33 +18,33 @@ EOF
 test_tig grep class +42
 
 assert_equals 'position.screen' <<EOF
-554| class Planner {
-724| class Plan {
+527| class Planner {
+697| class Plan {
 richards/src/main/scala/org/scalajs/benchmark/richards/Richards.scala
-151| class Scheduler {
-279| class TaskControlBlock(val link: TaskControlBlock, val id: Int, val priority: Int, var queue: P
-343| sealed abstract class Task(scheduler: Scheduler) {
-354| case class IdleTask(scheduler: Scheduler, var v1: Int, var count: Int) extends Task(scheduler)
-375| case class DeviceTask(scheduler: Scheduler) extends Task(scheduler) {
-398| case class WorkerTask(scheduler: Scheduler, var v1: Int, var v2: Int) extends Task(scheduler) {
-424| case class HandlerTask(scheduler: Scheduler) extends Task(scheduler) {
-471| case class Packet(var link: Packet, var id: Int, val kind: Int) {
+124| class Scheduler {
+252| class TaskControlBlock(val link: TaskControlBlock, val id: Int, val priority: Int, var queue: P
+316| sealed abstract class Task(scheduler: Scheduler) {
+327| case class IdleTask(scheduler: Scheduler, var v1: Int, var count: Int) extends Task(scheduler)
+348| case class DeviceTask(scheduler: Scheduler) extends Task(scheduler) {
+371| case class WorkerTask(scheduler: Scheduler, var v1: Int, var v2: Int) extends Task(scheduler) {
+397| case class HandlerTask(scheduler: Scheduler) extends Task(scheduler) {
+444| case class Packet(var link: Packet, var id: Int, val kind: Int) {
 tracer/src/main/scala/org/scalajs/benchmark/tracer/Color.scala
- 46| class Color(val red: Double, val green: Double, val blue: Double) {
+ 19| class Color(val red: Double, val green: Double, val blue: Double) {
 tracer/src/main/scala/org/scalajs/benchmark/tracer/Engine.scala
- 49| case class EngineConfiguration(
- 64| class Engine(val config: EngineConfiguration) {
+ 22| case class EngineConfiguration(
+ 37| class Engine(val config: EngineConfiguration) {
 tracer/src/main/scala/org/scalajs/benchmark/tracer/Material.scala
- 49| abstract class Material(val reflection: Double, val transparency: Double, val gloss: Double) {
- 55| class Chessboard(colorEven: Color, colorOdd: Color,
- 85| class Solid(color: Color, reflection: Double, refraction: Double, transparency: Double, gloss:
+ 22| abstract class Material(val reflection: Double, val transparency: Double, val gloss: Double) {
+ 28| class Chessboard(colorEven: Color, colorOdd: Color,
+ 58| class Solid(color: Color, reflection: Double, refraction: Double, transparency: Double, gloss:
 tracer/src/main/scala/org/scalajs/benchmark/tracer/RenderScene.scala
- 49| class RenderScene extends Scene {
+ 22| class RenderScene extends Scene {
 tracer/src/main/scala/org/scalajs/benchmark/tracer/Scene.scala
- 46| class Ray(val position: Vector, val direction: Vector) {
- 50| class Camera(val position: Vector, val lookAt: Vector, val up: Vector) {
- 64| class Background(val color: Color, val ambience: Double)
- 66| class Light(val position: Vector, val color: Color, val intensity: Double = 10.0)
- 68| abstract class Scene {
+ 19| class Ray(val position: Vector, val direction: Vector) {
+ 23| class Camera(val position: Vector, val lookAt: Vector, val up: Vector) {
+ 37| class Background(val color: Color, val ambience: Double)
+ 39| class Light(val position: Vector, val color: Color, val intensity: Double = 10.0)
+ 41| abstract class Scene {
 [grep] tracer/src/main/scala/org/scalajs/benchmark/tracer/Engine.scala - line 42 of 62           88%
 EOF


### PR DESCRIPTION
Disable the addition of number of scrolled lines to the line number in
"grep" mode, as the line numbers in this case actually are search
results, and not line numbers of e.g. a viewed file.