### PR TITLE
Make tig the process group leader and automatically clean child processes

### DIFF
--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -43,6 +43,7 @@ extern unsigned int current_view;
 #define view_is_displayed(view) \
 	(view == display[0] || view == display[1])
 
+void init_tty(void);
 void init_display(void);
 void resize_display(void);
 void redraw_display(bool clear);

--- a/src/display.c
+++ b/src/display.c
@@ -584,7 +584,7 @@ set_terminal_modes(void)
 	leaveok(stdscr, false);
 }
 
-static void
+void
 init_tty(void)
 {
 	/* open */
@@ -598,6 +598,12 @@ init_tty(void)
 	if (!opt_tty.attr)
 		die("Failed allocation for tty attributes");
 	tcgetattr(opt_tty.fd, opt_tty.attr);
+
+	/* process-group leader */
+	signal(SIGTTOU, SIG_IGN);
+	setpgid(getpid(), getpid());
+	tcsetpgrp(opt_tty.fd, getpid());
+	signal(SIGTTOU, SIG_DFL);
 }
 
 void
@@ -607,7 +613,8 @@ init_display(void)
 	const char *term;
 	int x, y;
 
-	init_tty();
+	if (!opt_tty.file)
+		die("Can't initialize display without tty");
 
 	die_callback = done_display;
 	if (atexit(done_display))

--- a/src/tig.c
+++ b/src/tig.c
@@ -772,6 +772,8 @@ main(int argc, const char *argv[])
 	enum request request = parse_options(argc, argv, pager_mode);
 	struct view *view;
 
+	init_tty();
+
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
 		die("Failed to setup signal handler");
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -738,6 +738,14 @@ die_if_failed(enum status_code code, const char *msg)
 		die("%s: %s", msg, get_status_message(code));
 }
 
+void
+hangup_children(void)
+{
+	if (signal(SIGHUP, SIG_IGN) == SIG_ERR)
+		return;
+	killpg(getpid(), SIGHUP);
+}
+
 static inline enum status_code
 handle_git_prefix(void)
 {
@@ -773,6 +781,8 @@ main(int argc, const char *argv[])
 	struct view *view;
 
 	init_tty();
+
+	atexit(hangup_children);
 
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
 		die("Failed to setup signal handler");

--- a/test/README.adoc
+++ b/test/README.adoc
@@ -11,6 +11,9 @@ test scripts as long as `PATH` is set to include the directories `src/`
 and `test/tools`. The latter directory is where the test helper
 libraries are located, the most important of which is `libtest.sh`.
 
+The test suite requires `stty -tostop` to be set in the running terminal,
+which is typically the default.
+
 Options
 -------
 


### PR DESCRIPTION
Make tig the process-group leader and give it the foreground connection to the TTY.  This announces to the OS "I am the interactive program taking input".

Being process-group leader allows for a simple and robust idiom for cleaning all child processes at exit time: tig can signal HUP to the entire process group (which tig can be certain that it owns).  While tig doesn't intentionally keep very long running child processes, it does depend on child processes quite a bit, so this cleanup is just good practice.

As noted in `test/README.adoc`, this PR adds a minor issue: if the user sets `stty tostop` in their interactive shell, then tig's test suite will not be able to run.  Actually, it will run, but then constantly stop again as output is generated.  That is as intended for `stty tostop`: not to let multiple processes contend for writes to the terminal.  The same problem would occur with `tig-pick`. 

However 
 * `stty tostop` is not the default setting on any Unixlike so far as I know
 * the test suite and `tig-pick` are edge uses

If a bug report does come in regarding `tig-pick`, I'm sure there's a fix with some added complexity in either `tig` or `tig-pick`.