### PR TITLE
Fix tig-pick output redirection

### DIFF
--- a/contrib/tig-pick
+++ b/contrib/tig-pick
@@ -20,14 +20,14 @@ trap "rm -f '$CONFIG'" EXIT
 
 # Prepare config file: source user config, if present
 if [ ! -z "$TIGRC_USER" ]; then
-	echo "source $TIGRC_USER" >> $CONFIG
+	echo "source $TIGRC_USER" >> "$CONFIG"
 elif [ -f "$HOME/.tigrc" ]; then
-	echo "source $HOME/.tigrc" >> $CONFIG
+	echo "source $HOME/.tigrc" >> "$CONFIG"
 fi
 
 # Bind Enter to print the selected commit ID to error output and exit after
 # that.
-echo 'bind main <Enter> <sh -c "echo %(commit) >&2"' >> $CONFIG
+echo 'bind main <Enter> <sh -c "echo %(commit) >&2"' >> "$CONFIG"
 
 
 # Run tig with the standard and error output channels swapped.

--- a/contrib/tig-pick
+++ b/contrib/tig-pick
@@ -40,7 +40,7 @@ stderr=$(tig "$@" 3>&2 2>&1 1>&3 3>&-) || {
 commit=$(echo "$stderr" | tail -n1)
 
 # Check return value for valid commit ID
-if ! echo -n "$commit" | grep -iqE '^[0-9a-f]{40}$'; then
+if ! printf '%s' "$commit" | grep -iqE '^[0-9a-f]{40}$'; then
 	echo "$stderr" >&2
 	exit 1
 fi


### PR DESCRIPTION
Current version doesn't work for my environment (bash bundled with macOS):

	$ sh --version
	GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)
	Copyright (C) 2007 Free Software Foundation, Inc.

The result commit is printed to stderr instead of stdout. I can't pinpoint the
problem but other traits in the script suggest that it is intended for bash
anyway. And it works fine with explicit bash for me.