### PR TITLE
Fix incorrect behaviour of up and down keys in diff view when opened from diff preview

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -235,7 +235,7 @@ view_driver(struct view *view, enum request request)
 
 	case REQ_NEXT:
 	case REQ_PREVIOUS:
-		if (view->parent) {
+		if (view->parent && view == display[1]) {
 			int line;
 
 			view = view->parent;


### PR DESCRIPTION
I believe issue #802 is the main reason why so many people ask about remapping up and down keys. If the current behaviour is actually a feature maybe a parameter can be introduced.