### PR TITLE
Fix error when trying to open diff view from split view on (Un)staged changes line

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -200,7 +200,10 @@ view_driver(struct view *view, enum request request)
 		open_main_view(view, OPEN_DEFAULT);
 		break;
 	case REQ_VIEW_DIFF:
-		open_diff_view(view, OPEN_DEFAULT);
+		if (view && string_rev_is_null(view->env->commit))
+			open_stage_view(view, NULL, 0, OPEN_DEFAULT);
+		else
+			open_diff_view(view, OPEN_DEFAULT);
 		break;
 	case REQ_VIEW_LOG:
 		open_log_view(view, OPEN_DEFAULT);


### PR DESCRIPTION
The problem occurs when you have staged or unstaged changes in the repository and is mostly visible when diff-highlight is true. If you press d or enter in the main view it will automatically switch to stage view while if you press d from the split view it opens diff view and you get an annoying "Failed run the diff-highlight program: diff-highlight". For consistency, switch to stage view as it is done for the main view when there is no commit associated to the selected line.