### PR TITLE
Fix resize not working after entering command (#845)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ case "$ax_cv_ncursesw" in "no")
 esac
 AC_SUBST(CURSES_LIBS)
 
-AX_LIB_READLINE(6.2)
+AX_LIB_READLINE(6.3)
 
 AM_ICONV
 

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -471,6 +471,10 @@ readline_init(void)
 	rl_attempted_completion_function = readline_completion;
 
 	rl_completion_display_matches_hook = readline_display_matches;
+
+	/* Let ncurses deal with the LINES and COLUMNS environment variables */
+	rl_change_environment = 0;
+	rl_catch_sigwinch = 0;
 }
 
 static void sigint_absorb_handler(int sig) {

--- a/tools/ax_lib_readline.m4
+++ b/tools/ax_lib_readline.m4
@@ -211,21 +211,23 @@ AC_DEFUN([AX_LIB_READLINE], [
   	[search for readline in DIR/include and DIR/lib])],
 	[ac_cv_rl_prefix=$with_readline])
 
-  AC_CHECK_HEADERS([readline/readline.h], [
-    AC_CHECK_HEADERS([readline/history.h], [
-      RL_LIB_READLINE_VERSION
+  AS_IF([test "x$with_readline" != xno], [
+    AC_CHECK_HEADERS([readline/readline.h], [
+      AC_CHECK_HEADERS([readline/history.h], [
+        RL_LIB_READLINE_VERSION
+      ])
     ])
+
+    if test $RL_MAJOR -gt $RL_MAJOR_REQUIRED || {
+       test $RL_MAJOR = $RL_MAJOR_REQUIRED && test $RL_MINOR -ge $RL_MINOR_REQUIRED ; } ; then
+      LIBS="$LIBS -lreadline ${TERMCAP_LIB}"
+      CFLAGS="$CFLAGS -I${RL_INCLUDEDIR}"
+      LDFLAGS="$LDFLAGS -L${RL_LIBDIR}"
+
+      AC_DEFINE(HAVE_READLINE, 1, [Define if you have a GNU readline compatible library])
+
+    elif test -n "$ac_cv_rl_prefix"; then
+      AC_MSG_WARN([Minimum required version of readline is $RL_VERSION_REQUIRED])
+    fi
   ])
-
-  if test $RL_MAJOR -ge $RL_MAJOR_REQUIRED || {
-     test $RL_MAJOR = $RL_MAJOR_REQUIRED && test $RL_MINOR -ge $RL_MINOR_REQUIRED ; } ; then
-    LIBS="$LIBS -lreadline ${TERMCAP_LIB}"
-    CFLAGS="$CFLAGS -I${RL_INCLUDEDIR}"
-    LDFLAGS="$LDFLAGS -L${RL_LIBDIR}"
-
-    AC_DEFINE(HAVE_READLINE, 1, [Define if you have a GNU readline compatible library])
-
-  elif test -n "$ac_cv_rl_prefix"; then
-    AC_MSG_WARN([Minimum required version of readline is $RL_VERSION_REQUIRED])
-  fi
 ])


### PR DESCRIPTION
Mininum Readline version is now 6.3 due to the use of the
rl_change_environment variable.

Also fixed check against major required version and added support for
configure --without-readline.