### PR TITLE
Fix deleted file mode line remains highlighted after hovering in diff or stage view

### DIFF
--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -34,6 +34,7 @@ struct ref;
 	_(DIFF_INDEX,		"index "), \
 	_(DIFF_OLDMODE,		"old file mode "), \
 	_(DIFF_NEWMODE,		"new file mode "), \
+	_(DIFF_DELMODE,		"deleted file mode "), \
 	_(DIFF_SIMILARITY,	"similarity "), \
 	_(DIFF_ADD_HIGHLIGHT,	""), \
 	_(DIFF_DEL_HIGHLIGHT,	""), \


### PR DESCRIPTION
Taking benefit of the half time break, here is one more patch. This was the last recurring annoyance I encounter with tig. Do you plan a new release soon ?
