### PR TITLE
tigrc: use color15 for cursor by default (bright white)

### DIFF
--- a/tigrc
+++ b/tigrc
@@ -365,7 +365,7 @@ color "    Acked-by"		yellow	default
 color "    Tested-by"		yellow	default
 color "    Reviewed-by"		yellow	default
 color default			default	default	normal
-color cursor			white	green	bold
+color cursor			color15	green	bold
 color status			green	default
 color delimiter			magenta	default
 color date			blue	default


### PR DESCRIPTION
"bold" does not necessarily mean "bright", and default white is hardly
visible on green (using solarized colors myself).

Ref: https://github.com/kovidgoyal/kitty/issues/197

Could also be changed in https://github.com/blueyed/tig/blob/4e03fe46a9cc48500abc9e70a54d4d734ab335ce/contrib/chocolate.theme.tigrc#L8 maybe.  /cc @edi9999