### PR TITLE
Git diff colors: interpret 'ul' as 'underline'

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -1354,6 +1354,9 @@ parse_git_color_option(struct line_info *info, char *value)
 	for (i = 0; i < argc; i++) {
 		int attr = 0;
 
+		if (!strncmp(argv[i], "ul", 2)) {
+			argv[i] = "underline";
+		}
 		if (set_attribute(&attr, argv[i])) {
 			info->attr |= attr;
 


### PR DESCRIPTION
# Why this change?
The official `git config` uses `ul` for `underline`.
It is this setting that is used by `diff-highlight` or `diff-so-fancy`.

The change allows for `.gitconfig` that works for both `tig` and `diff-highlight`

# Alternatives

There is probably a better manner or place to do it, I am not very fluent in C.

It could also be possible to use a separate `diff-add-highlight color color underline` in `.tigrc`. In this case `.tigrc` should take precedence over `.gitconfig` (this is not in effect currently).