### PR TITLE
Add support for hiding diff signs (leading + and -)

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -277,6 +277,16 @@ The following variables can be set:
 	that disabling signs only makes sense when coloring is used to
 	distinguish added and removed lines. On by default.
 
+'diff-column-highlight' (enum) [no|all|only-empty]::
+
+	Highlight the left-most column in diff views visually when the option
+	'diff-show-signs' is not in effect. All added/removed lines can be
+	highlighted, or only empty lines. Changed lines are indicated in the
+	first column by a space highlighted by the color `diff-add-highlight` or
+	`diff-del-highlight`, respectively. Keeping the `standout` (reverse)
+	property set for these is suggested, as white space is otherwise
+	invisible. Default is to highlight only empty lines.
+
 'diff-highlight' (mixed)::
 
 	Whether to highlight diffs using Git's 'diff-highlight' program. Defaults

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -270,6 +270,13 @@ The following variables can be set:
 
 	Number of context lines to show for diffs.
 
+'diff-show-signs' (bool)::
+
+	Show (or hide) the leading `+` and `-` signs in diff output. Copy-paste
+	of lines from the diff view may be aided by hiding these signs. Note
+	that disabling signs only makes sense when coloring is used to
+	distinguish added and removed lines. On by default.
+
 'diff-highlight' (mixed)::
 
 	Whether to highlight diffs using Git's 'diff-highlight' program. Defaults

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -38,6 +38,7 @@ typedef struct view_column *view_settings;
 	_(diff_context,			int,			VIEW_DIFF_LIKE) \
 	_(diff_noprefix,		bool,			VIEW_NO_FLAGS) \
 	_(diff_show_signs,		bool,			VIEW_NO_FLAGS) \
+	_(diff_column_highlight,	enum diff_column_highlight,	VIEW_NO_FLAGS) \
 	_(diff_options,			const char **,		VIEW_DIFF_LIKE) \
 	_(diff_highlight,		const char *,		VIEW_DIFF_LIKE) \
 	_(diff_view,			view_settings,		VIEW_NO_FLAGS) \

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -37,6 +37,7 @@ typedef struct view_column *view_settings;
 	_(commit_order,			enum commit_order,	VIEW_LOG_LIKE) \
 	_(diff_context,			int,			VIEW_DIFF_LIKE) \
 	_(diff_noprefix,		bool,			VIEW_NO_FLAGS) \
+	_(diff_show_signs,		bool,			VIEW_NO_FLAGS) \
 	_(diff_options,			const char **,		VIEW_DIFF_LIKE) \
 	_(diff_highlight,		const char *,		VIEW_DIFF_LIKE) \
 	_(diff_view,			view_settings,		VIEW_NO_FLAGS) \

--- a/include/tig/types.h
+++ b/include/tig/types.h
@@ -161,6 +161,11 @@ bool map_enum_do(const struct enum_map_entry *map, size_t map_size, int *value, 
 	_(REFRESH_MODE, AFTER_COMMAND), \
 	_(REFRESH_MODE, PERIODIC),
 
+#define DIFF_COLUMN_HIGHLIGHT_ENUM(_) \
+	_(DIFF_COLUMN_HIGHLIGHT, NO), \
+	_(DIFF_COLUMN_HIGHLIGHT, ALL), \
+	_(DIFF_COLUMN_HIGHLIGHT, ONLY_EMPTY)
+
 #define ENUM_INFO(_) \
 	_(author, AUTHOR_ENUM) \
 	_(commit_order, COMMIT_ORDER_ENUM) \
@@ -176,6 +181,7 @@ bool map_enum_do(const struct enum_map_entry *map, size_t map_size, int *value, 
 	_(reference_type, REFERENCE_ENUM) \
 	_(refresh_mode, REFRESH_MODE_ENUM) \
 	_(status_label, STATUS_LABEL_ENUM) \
+	_(diff_column_highlight, DIFF_COLUMN_HIGHLIGHT_ENUM) \
 
 #define DEFINE_ENUMS(name, macro) DEFINE_ENUM(name, macro)
 ENUM_INFO(DEFINE_ENUMS)

--- a/src/draw.c
+++ b/src/draw.c
@@ -75,7 +75,18 @@ draw_chars(struct view *view, enum line_type type, const char *string, int lengt
 
 	set_view_attr(view, type);
 	if (len > 0)
-		waddnstr(view->win, string, len);
+	{
+		if (view_has_flags(view, VIEW_DIFF_LIKE) &&
+		    !opt_diff_show_signs &&
+		    view->col == 0 &&
+		    (type == LINE_DIFF_ADD || type == LINE_DIFF_DEL || type == LINE_DEFAULT) &&
+		    (string[0] == ' ' || string[0] == '+' || string[0] == '-') 
+		   ) {
+			waddnstr(view->win, string+1, len-1);
+		} else {
+			waddnstr(view->win, string, len);
+		}
+	}
 
 	if (trimmed && use_tilde) {
 		set_view_attr(view, LINE_DELIMITER);

--- a/src/draw.c
+++ b/src/draw.c
@@ -80,8 +80,29 @@ draw_chars(struct view *view, enum line_type type, const char *string, int lengt
 		    !opt_diff_show_signs &&
 		    view->col == 0 &&
 		    (type == LINE_DIFF_ADD || type == LINE_DIFF_DEL || type == LINE_DEFAULT) &&
-		    (string[0] == ' ' || string[0] == '+' || string[0] == '-') 
+		    (string[0] == ' ' || string[0] == '+' || string[0] == '-')
 		   ) {
+			if (opt_diff_column_highlight == DIFF_COLUMN_HIGHLIGHT_ALL) {
+				if (type == LINE_DIFF_ADD) {
+					set_view_attr(view, LINE_DIFF_ADD_HIGHLIGHT);
+				} else if (type == LINE_DIFF_DEL) {
+					set_view_attr(view, LINE_DIFF_DEL_HIGHLIGHT);
+				}
+				waddch(view->win, ' ');
+				set_view_attr(view, type);
+			}
+			else if (opt_diff_column_highlight == DIFF_COLUMN_HIGHLIGHT_ONLY_EMPTY && len == 1) {
+				if (type == LINE_DIFF_ADD) {
+					set_view_attr(view, LINE_DIFF_ADD_HIGHLIGHT);
+					waddch(view->win, ' ');
+				} else if (type == LINE_DIFF_DEL) {
+					set_view_attr(view, LINE_DIFF_DEL_HIGHLIGHT);
+					waddch(view->win, ' ');
+				}
+
+				set_view_attr(view, type);
+			}
+
 			waddnstr(view->win, string+1, len-1);
 		} else {
 			waddnstr(view->win, string, len);

--- a/test/diff/diff-hide-signs-highlight-all-test
+++ b/test/diff/diff-hide-signs-highlight-all-test
@@ -5,7 +5,7 @@
 
 tigrc <<EOF
 set diff-show-signs = false
-set diff-column-hightlight = no
+set diff-column-highlight = all
 EOF
 
 steps '
@@ -23,23 +23,23 @@ AuthorDate: Sat Mar 1 15:59:02 2014 -0500
 Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
 CommitDate: Sat Mar 1 15:59:02 2014 -0500
  
-   Add type parameter for js.Dynamic
+    Add type parameter for js.Dynamic
 ---
  common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
-1 file changed, 1 insertion(+), 1 deletion(-)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
  
 diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
 index 65f914a..3aa4320 100644
 --- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
 +++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
 @@ -15,7 +15,7 @@ object Benchmark {
-  val benchmarks = js.Array[Benchmark]()
-  val benchmarkApps = js.Array[BenchmarkApp]()
+   val benchmarks = js.Array[Benchmark]()
+   val benchmarkApps = js.Array[BenchmarkApp]()
  
-  val global = js.Dynamic.global.asInstanceOf[js.Dictionary]
-  val global = js.Dynamic.global.asInstanceOf[js.Dictionary[js.Any]]
-  global("runScalaJSBenchmarks") = runBenchmarks _
-  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+   val global = js.Dynamic.global.asInstanceOf[js.Dictionary]
+   val global = js.Dynamic.global.asInstanceOf[js.Dictionary[js.Any]]
+   global("runScalaJSBenchmarks") = runBenchmarks _
+   global("initScalaJSBenchmarkApps") = initBenchmarkApps _
  
  
  

--- a/test/diff/diff-hide-signs-highlight-only-empty-test
+++ b/test/diff/diff-hide-signs-highlight-only-empty-test
@@ -5,7 +5,7 @@
 
 tigrc <<EOF
 set diff-show-signs = false
-set diff-column-hightlight = no
+set diff-column-highlight = only-empty
 EOF
 
 steps '

--- a/test/diff/diff-hide-signs-test
+++ b/test/diff/diff-hide-signs-test
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+tigrc <<EOF
+set diff-show-signs = false
+EOF
+
+steps '
+	:save-display diff-hide-signs.screen
+'
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+test_tig show master^
+
+assert_equals 'diff-hide-signs.screen' '' <<EOF
+commit a1dcf1aaa11470978db1d5d8bcf9e16201eb70ff
+Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
+AuthorDate: Sat Mar 1 15:59:02 2014 -0500
+Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
+CommitDate: Sat Mar 1 15:59:02 2014 -0500
+ 
+   Add type parameter for js.Dynamic
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+1 file changed, 1 insertion(+), 1 deletion(-)
+ 
+diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
+index 65f914a..3aa4320 100644
+--- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
++++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+@@ -15,7 +15,7 @@ object Benchmark {
+  val benchmarks = js.Array[Benchmark]()
+  val benchmarkApps = js.Array[BenchmarkApp]()
+ 
+  val global = js.Dynamic.global.asInstanceOf[js.Dictionary]
+  val global = js.Dynamic.global.asInstanceOf[js.Dictionary[js.Any]]
+  global("runScalaJSBenchmarks") = runBenchmarks _
+  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+ 
+ 
+ 
+ 
+ 
+[diff] a1dcf1aaa11470978db1d5d8bcf9e16201eb70ff - line 1 of 24              100%
+EOF

--- a/tigrc
+++ b/tigrc
@@ -115,6 +115,7 @@ set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 #set diff-highlight		= true		# String (or bool): Path to diff-highlight script,
 						#                   defaults to `diff-highlight`.
 set diff-show-signs		= yes		# Show diff signs (+ and -) at the start of diff lines
+set diff-column-highlight	= only-empty	# Enum: no, all, only-empty
 #set blame-options		= -C -C -C	# User-defined options for `tig blame` (git-blame)
 #set log-options		= --pretty=raw	# User-defined options for `tig log` (git-log)
 #set main-options		= -n 1000	# User-defined options for `tig` (git-log)

--- a/tigrc
+++ b/tigrc
@@ -114,6 +114,7 @@ set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 #set diff-options		= -C		# User-defined options for `tig show` (git-diff)
 #set diff-highlight		= true		# String (or bool): Path to diff-highlight script,
 						#                   defaults to `diff-highlight`.
+set diff-show-signs		= yes		# Show diff signs (+ and -) at the start of diff lines
 #set blame-options		= -C -C -C	# User-defined options for `tig blame` (git-blame)
 #set log-options		= --pretty=raw	# User-defined options for `tig log` (git-log)
 #set main-options		= -n 1000	# User-defined options for `tig` (git-log)


### PR DESCRIPTION
The `+` and `-` signs in diff views can be removed by changing the new
option `diff-show-signs`. When set, only the color of the lines
distinguishes added, removed and context lines.

The (also new) option `diff-column-highlight` tweaks how changed lines
are visualized when the diff signs are suppressed. All changed lines can
be highlighted, only empty lines, or not to highlight in any special way
(except for the coloring of the added/removed text).

Closes #855