### PR TITLE
Add synchronous command description in tigrc

### DIFF
--- a/tigrc
+++ b/tigrc
@@ -151,6 +151,7 @@ set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?
 #   !	Run the command in the foreground with output shown.
 #   @	Run the command in the background with no output.
 #   ?	Prompt the user before executing the command.
+#   +   Run the command synchronously, and echo the first line of output to the status bar.
 #   <	Exit Tig after executing the command.
 #   >	Re-open Tig instantly in the last displayed view after executing the command.
 #


### PR DESCRIPTION
Simply add missing description of  `+` prefix for user-defined command which is in man page