### PR TITLE
Don't shift signed int by 31 bits

### DIFF
--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -71,8 +71,7 @@ enum view_flag {
 	VIEW_GREP_LIKE		= 1 << 14,
 	VIEW_SORTABLE		= 1 << 15,
 	VIEW_FLEX_WIDTH		= 1 << 16,
-
-	VIEW_RESET_DISPLAY	= 1 << 31,
+	VIEW_RESET_DISPLAY	= 1 << 17,
 };
 
 #define view_has_flags(view, flag)	((view)->ops->flags & (flag))


### PR DESCRIPTION
cppcheck reports an issue in tig:

[view.h:75]:
(error) Shifting signed 32-bit value by 31 bits is undefined behaviour

There is no good reason to make VIEW_RESET_DISPLAY the largest value in
enum. Just use 1 << 17 for it, which is the next available power of two.