### PR TITLE
Fix incorrect cppcheck warning about realloc() use

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -1663,8 +1663,8 @@ add_line_format(struct view *view, enum line_type type, const char *fmt, ...)
 bool
 append_line_format(struct view *view, struct line *line, const char *fmt, ...)
 {
-	struct box *box = line->data;
-	size_t textlen = box_text_length(box);
+	struct box *box;
+	size_t textlen = box_text_length(line->data);
 	int fmtlen, retval;
 	va_list args;
 	char *text;
@@ -1676,7 +1676,7 @@ append_line_format(struct view *view, struct line *line, const char *fmt, ...)
 	if (fmtlen <= 0)
 		return false;
 
-	box = realloc(box, box_sizeof(box, 0, fmtlen));
+	box = realloc(line->data, box_sizeof(line->data, 0, fmtlen));
 	if (!box)
 		return false;
 


### PR DESCRIPTION
cppcheck reports:
[view.c:1679]:
(error) Common realloc mistake: 'box' nulled but not freed upon failure

Indeed, writing the result of realloc() to its first argument is a bad
practice. It is OK here only because box and line->data are equal when
realloc() is called. Even if box becomes NULL, line->data survives.

To avoid the confusion, initialize box with the result of realloc(). Use
line->data until that point.