### PR TITLE
only accept "-C" before a subcommand

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -515,6 +515,7 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 
 	} else {
 		subcommand = NULL;
+		i--; /* revisit option in loop below */
 	}
 
 	for (; i < argc; i++) {

--- a/src/tig.c
+++ b/src/tig.c
@@ -475,10 +475,22 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 
 	request = pager_mode ? REQ_VIEW_PAGER : REQ_VIEW_MAIN;
 
-	if (argc <= 1)
+	/* Options that must come before any subcommand. */
+	for (i = 1; i < argc; i++) {
+		const char *opt = argv[i];
+		if (!strncmp(opt, "-C", 2)) {
+			if (chdir(opt + 2))
+				die("Failed to change directory to %s", opt + 2);
+			continue;
+		} else {
+			break;
+		}
+	}
+
+	if (i >= argc)
 		return request;
 
-	subcommand = argv[1];
+	subcommand = argv[i++];
 	if (!strcmp(subcommand, "status")) {
 		request = REQ_VIEW_STATUS;
 
@@ -505,7 +517,7 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 		subcommand = NULL;
 	}
 
-	for (i = 1 + !!subcommand; i < argc; i++) {
+	for (; i < argc; i++) {
 		const char *opt = argv[i];
 
 		// stop parsing our options after -- and let rev-parse handle the rest
@@ -532,11 +544,6 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 			} else if (!strcmp(opt, "-h") || !strcmp(opt, "--help")) {
 				printf("%s\n", usage_string);
 				exit(EXIT_SUCCESS);
-
-			} else if (!strncmp(opt, "-C", 2)) {
-				if (chdir(opt + 2))
-					die("Failed to change directory to %s", opt + 2);
-				continue;
 
 			} else if (strlen(opt) >= 2 && *opt == '+' && string_isnumber(opt + 1)) {
 				int lineno = atoi(opt + 1);


### PR DESCRIPTION
Since commit ed36f75 (Add -C option to specify the working directory, 2019-03-21), we allow:

```
tig -C/path/to/repo
```

to change into the repo directory before running any git commands. But because of the way tig's command-line parser works, this eats any "-C" we meant to pass to a git command, like:

```
tig blame -C foo.c
```

which used to enable copy-detection in the blame. Let's require that -C come before any sub-command. That will continue to allow:

```
tig -C/path/to/repo
```

with no subcommand. It also means that using "-C" with a subcommand looks like this:

```
tig -C/path/to/repo blame foo.c
```

which matches git's global -C option to change directories. And of course it allows:

```
tig blame -C foo.c
```

to work as it used to prior to ed36f75, enabling copy detection.
