### PR TITLE
Improve behaviour of auto and periodic refresh modes

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -800,6 +800,13 @@ get_input(int prompt_position, struct key *key)
 
 		if (update_views())
 			delay = 0;
+		else
+			/* Check there is no pending update after update_views() */
+			foreach_displayed_view (view, i)
+				if (view->watch.changed) {
+					delay = 0;
+					break;
+				}
 
 		/* Update the cursor position. */
 		if (prompt_position) {

--- a/src/display.c
+++ b/src/display.c
@@ -780,10 +780,11 @@ get_input(int prompt_position, struct key *key)
 	while (true) {
 		int delay = -1;
 
-		if (opt_refresh_mode == REFRESH_MODE_PERIODIC) {
+		if (opt_refresh_mode != REFRESH_MODE_MANUAL) {
 			bool refs_refreshed = false;
 
-			delay = watch_periodic(opt_refresh_interval);
+			if (opt_refresh_mode == REFRESH_MODE_PERIODIC)
+				delay = watch_periodic(opt_refresh_interval);
 
 			foreach_displayed_view (view, i) {
 				if (view_can_refresh(view) &&

--- a/src/display.c
+++ b/src/display.c
@@ -788,6 +788,7 @@ get_input(int prompt_position, struct key *key)
 
 			foreach_displayed_view (view, i) {
 				if (view_can_refresh(view) &&
+					!view->pipe &&
 					watch_dirty(&view->watch)) {
 					if (!refs_refreshed) {
 						load_refs(true);

--- a/src/tig.c
+++ b/src/tig.c
@@ -340,7 +340,6 @@ view_driver(struct view *view, enum request request)
 		if (view->prev && view->prev != view) {
 			maximize_view(view->prev, true);
 			view->prev = view;
-			watch_unregister(&view->watch);
 			view->parent = NULL;
 			break;
 		}


### PR DESCRIPTION
This PR should improve the current situation or, at least, make all the modes do something. There are still some (pre-existing) problems remaining but none of them is related in the existing issues. 

As I don't use the periodic mode personally, I didn't look further but it looks to me that in this mode Tig refreshes unexpectedly 2 or 3 time at startup (hence the claim that it was working sometimes). Not the end of the world but for large repos it can be annoying.

The special handling of the stage view prevents a correct refresh of the status view in some cases.