### PR TITLE
Add comments for bind commands [#809]

### DIFF
--- a/include/tig/argv.h
+++ b/include/tig/argv.h
@@ -24,6 +24,7 @@
 #define DIFF_ARGS "%(diffargs)"
 
 bool argv_to_string(const char *argv[], char *buf, size_t buflen, const char *sep);
+char *argv_to_string_alloc_prefix(const char *argv[], const char *sep, const char *prefix);
 char *argv_to_string_alloc(const char *argv[], const char *sep);
 bool argv_to_string_quoted(const char *argv[SIZEOF_ARG], char *buf, size_t buflen, const char *sep);
 bool argv_from_string_no_quotes(const char *argv[SIZEOF_ARG], int *argc, char *cmd);

--- a/include/tig/keys.h
+++ b/include/tig/keys.h
@@ -90,6 +90,7 @@ struct run_request {
 	struct keymap *keymap;
 	struct run_request_flags flags;
 	const char **argv;
+	char *name;
 	char *help;
 };
 

--- a/include/tig/keys.h
+++ b/include/tig/keys.h
@@ -90,10 +90,11 @@ struct run_request {
 	struct keymap *keymap;
 	struct run_request_flags flags;
 	const char **argv;
+	char *help;
 };
 
 struct run_request *get_run_request(enum request request);
-enum status_code add_run_request(struct keymap *keymap, const struct key key[], size_t keys, const char **argv);
+enum status_code add_run_request(struct keymap *keymap, const struct key key[], size_t keys, const char **argv, const char *help);
 enum status_code parse_run_request_flags(struct run_request_flags *flags, const char **argv);
 const char *format_run_request_flags(const struct run_request *req);
 

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -216,7 +216,7 @@ struct option_info *find_column_option_info(enum view_column_type type, union vi
 					const char *option, struct option_info *column_info, const char **column_name);
 enum status_code parse_int(int *opt, const char *arg, int min, int max);
 enum status_code parse_step(double *opt, const char *arg);
-enum status_code set_option(const char *opt, int argc, const char *argv[]);
+enum status_code set_option(const char *opt, int argc, const char *argv[], const char *help);
 enum status_code load_options(void);
 enum status_code load_git_config(void);
 enum status_code save_options(const char *path);

--- a/src/argv.c
+++ b/src/argv.c
@@ -56,16 +56,43 @@ concat_argv(const char *argv[], char *buf, size_t buflen, const char *sep, bool 
 }
 
 char *
-argv_to_string_alloc(const char *argv[], const char *sep)
+argv_to_string_alloc_prefix(const char *argv[], const char *sep, const char *prefix)
 {
-	size_t i, size = 0;
-	char *buf;
-
+	size_t i, size = 1;
 	for (i = 0; argv[i]; i++)
 		size += strlen(argv[i]);
 
-	buf = malloc(size + 1);
-	if (buf && argv_to_string(argv, buf, size + 1, sep))
+	/* Increase buffer size by separator size and number of separators */
+	if (sep) if (i) size += strlen(sep) * (i - 1);
+
+	/* Increase buffer size by prefix size */
+	if (prefix) size += strlen(prefix);
+
+	char *buf = malloc(size);
+	if (buf) {
+
+		/* Preload buffer with prefix */
+		for (i = 0; prefix[i]; i++) buf[i] = prefix[i];
+
+		/* Load buffer after prefix with concatenated version of argv */
+		if (concat_argv(argv, buf + i, size, sep, false)) return buf;
+	}
+	free(buf);
+	return NULL;
+}
+
+char *
+argv_to_string_alloc(const char *argv[], const char *sep)
+{
+	size_t i, size = 1;
+	for (i = 0; argv[i]; i++)
+		size += strlen(argv[i]);
+
+	/* Increase buffer size by separator size and number of separators */
+	if (sep) if (i) size += strlen(sep) * (i - 1);
+
+	char *buf = malloc(size);
+	if (buf && concat_argv(argv, buf, size, sep, false))
 		return buf;
 	free(buf);
 	return NULL;

--- a/src/help.c
+++ b/src/help.c
@@ -105,11 +105,8 @@ help_grep(struct view *view, struct line *line)
 	} else if (help->request > REQ_RUN_REQUESTS) {
 		struct run_request *req = get_run_request(help->request);
 		const char *key = get_keys(keymap, help->request, true);
-		char buf[SIZEOF_STR] = "";
-		const char *text[] = { key, buf, NULL };
 
-		if (!argv_to_string(req->argv, buf, sizeof(buf), " "))
-			return false;
+		const char *text[] = { key, req->name, req->help, NULL };
 
 		return grep_text(view, text);
 

--- a/src/help.c
+++ b/src/help.c
@@ -62,6 +62,7 @@ help_draw(struct view *view, struct line *line, unsigned int lineno)
 				return true;
 			sep = " ";
 		}
+		if (req->help) draw_text(view, LINE_DEFAULT, req->help);
 
 	} else {
 		const struct request_info *req_info = help->data.req_info;

--- a/src/keys.c
+++ b/src/keys.c
@@ -490,8 +490,8 @@ add_run_request(struct keymap *keymap, const struct key key[],
 {
 	struct run_request *req;
 	struct run_request_flags flags = {0};
-	enum status_code code = parse_run_request_flags(&flags, argv);
 
+	enum status_code code = parse_run_request_flags(&flags, argv);
 	if (code != SUCCESS)
 		return code;
 
@@ -504,6 +504,13 @@ add_run_request(struct keymap *keymap, const struct key key[],
 	req = &run_request[run_requests++];
 	req->flags = flags;
 	req->keymap = keymap;
+
+	/* Duplicate a displayable version of **argv into the run_request struct */
+	req->name = NULL;
+	if (argv) {
+		if ((req->name = argv_to_string_alloc_prefix(argv, " ", format_run_request_flags(req))) == NULL)
+			return ERROR_OUT_OF_MEMORY;
+	}
 
 	/* If there is help text, then dupe it into the run_request struct */
 	req->help = NULL;

--- a/src/keys.c
+++ b/src/keys.c
@@ -486,7 +486,7 @@ parse_run_request_flags(struct run_request_flags *flags, const char **argv)
 
 enum status_code
 add_run_request(struct keymap *keymap, const struct key key[],
-		size_t keys, const char **argv)
+		size_t keys, const char **argv, const char *help)
 {
 	struct run_request *req;
 	struct run_request_flags flags = {0};
@@ -504,6 +504,12 @@ add_run_request(struct keymap *keymap, const struct key key[],
 	req = &run_request[run_requests++];
 	req->flags = flags;
 	req->keymap = keymap;
+
+	/* If there is help text, then dupe it into the run_request struct */
+	req->help = NULL;
+	if (help)
+		if ((req->help = strdup(help)) == NULL)
+			return ERROR_OUT_OF_MEMORY;
 
 	return add_keybinding(keymap, REQ_RUN_REQUESTS + run_requests, key, keys);
 }

--- a/src/options.c
+++ b/src/options.c
@@ -790,7 +790,7 @@ option_set_command(int argc, const char *argv[])
 
 /* Wants: mode request key */
 static enum status_code
-option_bind_command(int argc, const char *argv[])
+option_bind_command(int argc, const char *argv[], const char *help)
 {
 	struct key key[16];
 	size_t keys = 0;
@@ -870,7 +870,7 @@ option_bind_command(int argc, const char *argv[])
 			const char *toggle[] = { ":toggle", mapped, arg, NULL};
 			const char *other[] = { mapped, NULL };
 			const char **prompt = *mapped == ':' ? other : toggle;
-			enum status_code code = add_run_request(keymap, key, keys, prompt);
+			enum status_code code = add_run_request(keymap, key, keys, prompt, NULL);
 
 			if (code == SUCCESS)
 				code = error("%s has been replaced by `%s%s%s%s'",
@@ -882,7 +882,7 @@ option_bind_command(int argc, const char *argv[])
 	}
 
 	if (request == REQ_UNKNOWN)
-		return add_run_request(keymap, key, keys, argv + 2);
+		return add_run_request(keymap, key, keys, argv + 2, help);
 
 	return add_keybinding(keymap, request, key, keys);
 }
@@ -916,7 +916,7 @@ option_source_command(int argc, const char *argv[])
 }
 
 enum status_code
-set_option(const char *opt, int argc, const char *argv[])
+set_option(const char *opt, int argc, const char *argv[], const char *help)
 {
 	if (!strcmp(opt, "color"))
 		return option_color_command(argc, argv);
@@ -925,7 +925,7 @@ set_option(const char *opt, int argc, const char *argv[])
 		return option_set_command(argc, argv);
 
 	if (!strcmp(opt, "bind"))
-		return option_bind_command(argc, argv);
+		return option_bind_command(argc, argv, help);
 
 	if (!strcmp(opt, "source"))
 		return option_source_command(argc, argv);
@@ -957,7 +957,8 @@ read_option(char *opt, size_t optlen, char *value, size_t valuelen, void *data)
 		const char *argv[SIZEOF_ARG];
 		int argc = 0;
 
-		if (len < valuelen) {
+		bool have_comments = len < valuelen;
+		if (have_comments) {
 			valuelen = len;
 			value[valuelen] = 0;
 		}
@@ -965,7 +966,7 @@ read_option(char *opt, size_t optlen, char *value, size_t valuelen, void *data)
 		if (!argv_from_string(argv, &argc, value))
 			status = error("Too many option arguments for %s", opt);
 		else
-			status = set_option(opt, argc, argv);
+			status = set_option(opt, argc, argv, have_comments ? string_trim(value + len + 1) : NULL);
 	}
 
 	if (status != SUCCESS) {
@@ -1322,16 +1323,15 @@ set_remote_branch(const char *name, const char *value, size_t valuelen)
 }
 
 static void
-set_repo_config_option(char *name, char *value, enum status_code (*cmd)(int, const char **))
+set_repo_config_option(char *name, char *value, const char *cmd)
 {
-	const char *argv[SIZEOF_ARG] = { name, "=" };
-	int argc = 1 + (cmd == option_set_command);
-	enum status_code code;
+	const char *argv[SIZEOF_ARG]; int argc;
+	if (!strcmp(cmd, "set")) { argv[0] = name; argv[1] = "=";  argc = 2; }
+	else                     { argv[0] = name;                 argc = 1; }
 
-	if (!argv_from_string(argv, &argc, value))
-		code = error("Too many arguments");
-	else
-		code = cmd(argc, argv);
+	enum status_code code = !argv_from_string(argv, &argc, value)
+		? error("Too many arguments")
+		: set_option(cmd, argc, argv, NULL);
 
 	if (code != SUCCESS)
 		warn("Option 'tig.%s': %s", name, get_status_message(code));
@@ -1443,13 +1443,13 @@ read_repo_config_option(char *name, size_t namelen, char *value, size_t valuelen
 		parse_bool(&opt_status_show_untracked_files, value);
 
 	else if (!prefixcmp(name, "tig.color."))
-		set_repo_config_option(name + 10, value, option_color_command);
+		set_repo_config_option(name + 10, value, "color");
 
 	else if (!prefixcmp(name, "tig.bind."))
-		set_repo_config_option(name + 9, value, option_bind_command);
+		set_repo_config_option(name + 9, value, "bind");
 
 	else if (!prefixcmp(name, "tig."))
-		set_repo_config_option(name + 4, value, option_set_command);
+		set_repo_config_option(name + 4, value, "set");
 
 	else if (!prefixcmp(name, "color."))
 		set_git_color_option(name + STRING_SIZE("color."), value);

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -1051,7 +1051,7 @@ run_prompt_command(struct view *view, const char *argv[])
 		if (request != REQ_UNKNOWN)
 			return request;
 
-		code = set_option(argv[0], argv_size(argv + 1), &argv[1]);
+		code = set_option(cmd, argv_size(argv + 1), &argv[1], NULL);
 		if (code != SUCCESS) {
 			report("%s", get_status_message(code));
 			return REQ_NONE;

--- a/test/help/user-command-comment-test
+++ b/test/help/user-command-comment-test
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+. libtest.sh
+
+export TIGRC_SYSTEM=does-not-exist
+
+test_case user-command-comment \
+	--args='status' \
+	--tigrc="
+		bind generic : prompt # User comment for a builtin command is not exposed
+		bind generic , none # User comment does not interfere with a null binding
+		bind generic u1 !user
+		bind generic u2 !user # This is a user commentary for a simple user command
+		bind generic u3 !user 1 2 3 # This is a user commentary for a user command with parameters
+		bind generic u4 !user command with a long parameter list but no user commentary
+		" \
+	--script="
+		:bind generic p1 !true
+		:view-help
+		" \
+	<<EXPECTED_HELP_VIEW
+Quick reference for tig keybindings:
+ 
+[-] generic bindings
+Misc
+   : prompt      Open the prompt
+External commands:
+  u1 !user
+  u2 !user       This is a user commentary for a simple user command
+  u3 !user 1 2 3 This is a user commentary for a user command with parameters
+  u4 !user command with a long parameter list but no user commentary
+  p1 !true
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+[help] - line 1 of 11                                                       100%
+EXPECTED_HELP_VIEW
+
+run_test_cases

--- a/test/tigrc/parse-test
+++ b/test/tigrc/parse-test
@@ -115,7 +115,7 @@ Misc
    : prompt    Open the prompt
 [-] main bindings
 Internal commands:
-   # :/s e a r c h
+   # :/s e a r c h    Toggle option
 External commands:
    1 !external command
    2 @silent command


### PR DESCRIPTION
A user may have defined numerous and complex key bindings. The user will show the help screen to be reminded of the key bindings. The user will see keybindings for built-in actions accompanied by help text, because they are built into the source code. However, the user will see user-defined key bindings without help text, because any comments typed in the configuration file are stripped when parsed. Without seeing the comments, the user may not remember the meaning of a key binding from seeing just the action name.

The PR adds code to enable comments in bind options to be shown in the help screen. For example, `bind keymap key action # comments` will result in `comments` displayed next to `action`, in the same way that help text for built-in actions are shown. Also, if a / search is done, the PR adds code to ensure that comment text are searched.

There are two exceptions.

1. If a `bind` is defined in a repo configuration file, `tig` will first strip comments by using `git config --list` before parsing the `bind` option. Consequently, comments can't be shown in the help screen for `bind` options appearing in repo config files.

1. If a `bind` is defined on the prompt line, `tig` will not parsed any comments introduced by a hash mark, because it's not expected the user will type any. Consequently, comments will be parsed as command parameters.

The PR is organized into several commits. See details in the various commit messages.

1. A prepatory commit. Add a new function to argv.c similar to `argv_to_string_alloc()`, but it adds a prefix to the allocated text buffer. In the process, a bug is discovered and fixed in `argv_to_string_alloc()`: if a non-empty separator is specified, `argc` will fail to count the addition of separators. Since existing calls of the function always specify empty separators, there has been no impact from the bug.

1. Add code to show the comment text in the help screen. At this stage, comment text is shown as free-form text and not aligned with built-in help text.

1. Add code to align comment text when shown in the help screen; the code uses the function introduced in the first commit. Only keybindings with comment text will participate in calculating the field width; keybindings with no comments but with long action names may overflow the field.

1. The expected output of two existing test cases have changed and have been corrected. A modest test case is added for the new behaviour.

1. Make sure that new comment text for keybindings can participate in grep searches, ie, if the user initiates a / search on the prompt line, matches in comment text should show up. Unfortunately, I can't come up with a unit test for this.

1. Simplify the code a bit and trade a bit of space for time by caching key strings during `help_open()` so that `help_draw()` doesn't need to recalculate them when drawing a help line.

I can follow up with another commit to make the necessary changes to documentation.