### PR TITLE
Show annotated commits in main view

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -1031,6 +1031,7 @@ setting the *default* color option.
 			 attribute enabled to give a brighter color.
 			 Example: palette-0 = red
 |main-commit		|The commit comment.
+|main-annotated		|The commit comment of an annotated commit.
 |main-head		|Label of the current branch.
 |main-remote		|Label of a remote.
 |main-tracked		|Label of the remote tracked by the current branch.

--- a/include/tig/git.h
+++ b/include/tig/git.h
@@ -47,13 +47,13 @@
 #define GIT_DIFF_BLAME_NO_PARENT(encoding_arg, context_arg, space_arg, new_name) \
 	GIT_DIFF_INITIAL(encoding_arg, "", context_arg, space_arg, "/dev/null", new_name)
 
-#define GIT_MAIN_LOG(encoding_arg, commit_order_arg, mainargs, diffargs, revargs, fileargs, pretty_arg) \
+#define GIT_MAIN_LOG(encoding_arg, commit_order_arg, mainargs, diffargs, revargs, fileargs, show_notes_arg, pretty_arg) \
 	"git", "log", (encoding_arg), \
 		(commit_order_arg), (mainargs), (diffargs), (revargs), "--date=raw", "--parents", \
-		"--no-color", (pretty_arg), "--", (fileargs), NULL
+		"--no-color", (show_notes_arg), (pretty_arg), "--", (fileargs), NULL
 
-#define GIT_MAIN_LOG_RAW(encoding_arg, commit_order_arg, mainargs, diffargs, revargs, fileargs) \
-	GIT_MAIN_LOG(encoding_arg, commit_order_arg, mainargs, diffargs, revargs, fileargs, \
+#define GIT_MAIN_LOG_RAW(encoding_arg, commit_order_arg, mainargs, diffargs, revargs, fileargs, show_notes_arg) \
+	GIT_MAIN_LOG(encoding_arg, commit_order_arg, mainargs, diffargs, revargs, fileargs, show_notes_arg, \
 		     "--pretty=raw")
 
 #endif

--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -64,6 +64,7 @@ struct ref;
 	_(HEADER,		""), \
 	_(SECTION,		""), \
 	_(MAIN_COMMIT,		""), \
+	_(MAIN_ANNOTATED,	""), \
 	_(MAIN_TAG,		""), \
 	_(MAIN_LOCAL_TAG,	""), \
 	_(MAIN_REMOTE,		""), \

--- a/src/draw.c
+++ b/src/draw.c
@@ -437,7 +437,7 @@ draw_graph(struct view *view, const struct graph *graph, const struct graph_canv
 }
 
 static bool
-draw_commit_title(struct view *view, struct view_column *column,
+draw_commit_title(struct view *view, struct view_column *column, enum line_type type,
 		  const struct graph *graph, const struct graph_canvas *graph_canvas,
 		  const struct ref *refs, const char *commit_title)
 {
@@ -446,7 +446,7 @@ draw_commit_title(struct view *view, struct view_column *column,
 		return true;
 	if (draw_refs(view, column, refs))
 		return true;
-	return draw_text_overflow(view, commit_title, LINE_DEFAULT,
+	return draw_text_overflow(view, commit_title, type,
 			column->opt.commit_title.overflow, 0);
 }
 
@@ -509,8 +509,8 @@ view_column_draw(struct view *view, struct line *line, unsigned int lineno)
 			continue;
 
 		case VIEW_COLUMN_COMMIT_TITLE:
-			if (draw_commit_title(view, column, column_data.graph, column_data.graph_canvas,
-					      column_data.refs, column_data.commit_title))
+			if (draw_commit_title(view, column, line->type == LINE_MAIN_ANNOTATED ? LINE_MAIN_ANNOTATED : LINE_MAIN_COMMIT,
+					      column_data.graph, column_data.graph_canvas, column_data.refs, column_data.commit_title))
 				return true;
 			continue;
 

--- a/src/main.c
+++ b/src/main.c
@@ -266,11 +266,12 @@ main_open(struct view *view, enum open_flags flags)
 	const char *pretty_custom_argv[] = {
 		GIT_MAIN_LOG(encoding_arg, commit_order_arg_with_graph(graph_display),
 			"%(mainargs)", "%(cmdlineargs)", "%(revargs)", "%(fileargs)",
-			log_custom_pretty_arg())
+			show_notes_arg(), log_custom_pretty_arg())
 	};
 	const char *pretty_raw_argv[] = {
 		GIT_MAIN_LOG_RAW(encoding_arg, commit_order_arg_with_graph(graph_display),
-			"%(mainargs)", "%(cmdlineargs)", "%(revargs)", "%(fileargs)")
+			"%(mainargs)", "%(cmdlineargs)", "%(revargs)", "%(fileargs)",
+			show_notes_arg())
 	};
 	struct main_state *state = view->private;
 	const char **main_argv = pretty_custom_argv;
@@ -459,8 +460,12 @@ main_read(struct view *view, struct buffer *buf, bool force_stop)
 			parse_author_line(author, &commit->author, &commit->time);
 			if (state->with_graph)
 				graph->render_parents(graph, &commit->graph);
-			if (title)
-				main_add_commit(view, LINE_MAIN_COMMIT, commit, title, false);
+			if (title) {
+				char *notes = io_memchr(buf, title, 0);
+
+				main_add_commit(view, notes && *notes ? LINE_MAIN_ANNOTATED : LINE_MAIN_COMMIT,
+						commit, title, false);
+			}
 		}
 
 		return true;

--- a/src/options.c
+++ b/src/options.c
@@ -150,8 +150,8 @@ const char *
 log_custom_pretty_arg(void)
 {
 	return opt_mailmap
-		? "--pretty=format:commit %m %H %P%x00%aN <%aE> %ad%x00%s"
-		: "--pretty=format:commit %m %H %P%x00%an <%ae> %ad%x00%s";
+		? "--pretty=format:commit %m %H %P%x00%aN <%aE> %ad%x00%s%x00%N"
+		: "--pretty=format:commit %m %H %P%x00%an <%ae> %ad%x00%s%x00%N";
 }
 
 #define ENUM_ARG(enum_name, arg_string) ENUM_MAP_ENTRY(arg_string, enum_name)

--- a/src/refs.c
+++ b/src/refs.c
@@ -66,7 +66,7 @@ refs_request(struct view *view, enum request request, struct line *line)
 		const char *all_references_argv[] = {
 			GIT_MAIN_LOG(encoding_arg, commit_order_arg(),
 				"%(mainargs)", "",
-				refs_is_all(reference) ? "--all" : ref->name, "",
+				refs_is_all(reference) ? "--all" : ref->name, "", "",
 				log_custom_pretty_arg())
 		};
 

--- a/test/main/filter-args-test
+++ b/test/main/filter-args-test
@@ -38,7 +38,7 @@ git rev-parse --git-dir --is-inside-work-tree --show-cdup --show-prefix HEAD --s
 EOF
 
 assert_equals 'log.trace' <<EOF
-git log --encoding=UTF-8 --topo-order --exclude=refs/remotes/origin/* --exclude=refs/heads/master --all --date=raw --parents --no-color --pretty=format:commit %m %H %P%x00%an <%ae> %ad%x00%s -- common tracer
+git log --encoding=UTF-8 --topo-order --exclude=refs/remotes/origin/* --exclude=refs/heads/master --all --date=raw --parents --no-color --show-notes --pretty=format:commit %m %H %P%x00%an <%ae> %ad%x00%s%x00%N -- common tracer
 EOF
 
 assert_equals 'filtered.screen' <<EOF

--- a/tigrc
+++ b/tigrc
@@ -384,6 +384,7 @@ color line-number		cyan	default
 color title-blur		white	blue
 color title-focus		white	blue	bold
 color main-commit		default	default
+color main-annotated		default	default	bold
 color main-tag			magenta	default	bold
 color main-local-tag		magenta	default
 color main-remote		yellow	default


### PR DESCRIPTION
Show annotated commits title in main-annotated color (the default
configuration in tigrc uses "default default bold" to follow the
same logic as tags). You can choose a different notes tree using
tig --notes=foo. To see all notes, use tig --notes=*.

Closes #819