### PR TITLE
Update INSTALL - improve installation w/ configure

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -43,6 +43,7 @@ Installation using `configure`
 
 Optionally, you can use the `configure` script to detect dependencies:
 
+	$ make configure	# if you're building from the Tig repository (requires `autoconf`)
 	$ ./configure
 	$ make
 	$ make install

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -43,7 +43,7 @@ Installation using `configure`
 
 Optionally, you can use the `configure` script to detect dependencies:
 
-	$ make configure	# if you're building from the Tig repository (requires `autoconf`)
+	$ ./autogen.sh	    # if you're building from the Tig repository (requires `autoconf`)
 	$ ./configure
 	$ make
 	$ make install


### PR DESCRIPTION
I was building from the github repo and found it weird that the `configure` file was not present.
Only randomly I happened to notice that the `make configure` is what generates it.

I know I should've read the whole thing, but sometimes you might not have enough time and/or you just want things to work, thus I made this change.

(I tried moving up the `Note` part, but it looked kinda out-of-place, so I guess you could experiment with it yourself so that it's not annoying for those who build from the release but those who build from source see it before actually building).