### PR TITLE
Fix memory leak induced by 'tig grep'

### DIFF
--- a/src/grep.c
+++ b/src/grep.c
@@ -145,7 +145,10 @@ grep_open(struct view *view, enum open_flags flags)
 		state->no_file_group = !column || column->opt.file_name.display != FILENAME_NO;
 	}
 
-	return begin_update(view, NULL, argv, flags);
+	enum status_code r = begin_update(view, NULL, argv, flags);
+	argv_free(argv);
+	free(argv);
+	return r;
 }
 
 static enum request


### PR DESCRIPTION
In `grep_open()`, the `argv` array of strings, which starts as `NULL` and then is pointed to an allocation, needs to be freed before returning from the function.

Without the fix, if I do a `valgrind --leak-check=yes src/tig grep` and then quit `tig`, `valgrind` reports memory definitely lost:

> ==28715== 294 (256 direct, 38 indirect) bytes in 1 blocks are definitely lost in loss record 40 of 96
> ==28715==    at 0x4C2FA3F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==28715==    by 0x4C31D84: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==28715==    by 0x11659D: chunk_allocator (util.c:447)
> ==28715==    by 0x117064: argv_realloc (argv.c:209)
> ==28715==    by 0x117064: argv_appendn (argv.c:220)
> ==28715==    by 0x1172F2: argv_append (argv.c:235)
> ==28715==    by 0x1172F2: argv_append_array (argv.c:244)
> ==28715==    by 0x137FEE: grep_open (grep.c:138)
> ==28715==    by 0x12A365: load_view (view.c:773)
> ==28715==    by 0x113D37: view_driver (tig.c:196)
> ==28715==    by 0x113D37: main (tig.c:853)
> 