### PR TITLE
Fix memory leak in main view

### DIFF
--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -257,6 +257,8 @@ done_graph(struct graph *graph_ref)
 {
 	struct graph_v2 *graph = graph_ref->private;
 
+	htab_delete(graph->colors.id_map);
+
 	free(graph);
 
 	if (intern_string_htab)


### PR DESCRIPTION
When the `main_done()` is called, `done_graph()` is called, which calls `free(graph)`, where `graph` is a pointer to a `struct graph`. `struct graph` points to a hash table `colors.id_map`, which should be freed before `free(graph)` is called.

The memory leak can be induced in the main view by defining the keybinding on the prompt line `:bind main t !t true`, where `true` is essentially a shell no-op. Pressing `t` in the main view and then quitting will get a LeakSanitizer report of a direct leak. The leak happens for each `t` command so that the amount leaked is proportional to the number of times `main_done()` is called.

> Direct leak of 112 byte(s) in 1 object(s) allocated from:
>     #0 0x7effa34b7d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
>     #1 0x5639427502ac in htab_create_typed_alloc compat/hashtab.c:358
>     #2 0x563942750421 in htab_create_alloc compat/hashtab.c:286
>     #3 0x56394274ec1c in colors_init src/graph-v2.c:219
>     #4 0x56394274ec1c in get_color src/graph-v2.c:231
>     #5 0x56394274ec1c in graph_generate_symbols src/graph-v2.c:727
>     #6 0x56394274ec1c in graph_render_parents src/graph-v2.c:748
>     #7 0x56394274533f in main_read src/main.c:461
>     #8 0x5639427213bb in update_view src/view.c:611
>     #9 0x56394271961b in update_views src/display.c:757
>     #10 0x56394271961b in get_input src/display.c:802
>     #11 0x56394270f856 in prompt_input src/prompt.c:55
>     #12 0x5639426ec9ad in read_key_combo src/tig.c:745
>     #13 0x5639426e9976 in main src/tig.c:855
>     #14 0x7effa2967b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)