### PR TITLE
Introduce reflog view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ TIG_OBJS = \
 	src/watch.o \
 	src/pager.o \
 	src/log.o \
+	src/reflog.o \
 	src/diff.o \
 	src/help.o \
 	src/tree.o \

--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -96,6 +96,10 @@ The log view::
 	Presents a more rich view of the revision log showing the whole log
 	message and the diffstat.
 
+The reflog view::
+	Presents a view of the reflog allowing to navigate the repo
+	history.
+
 The diff view::
 	Shows either the diff of the current working tree, that is, what
 	has changed since the last commit, or the commit diff complete

--- a/doc/tig.1.adoc
+++ b/doc/tig.1.adoc
@@ -14,6 +14,7 @@ _______________________________________________________________________
 tig        [options] [revisions] [--] [paths]
 tig log    [options] [revisions] [--] [paths]
 tig show   [options] [revisions] [--] [paths]
+tig reflog [options] [revisions]
 tig blame  [options] [rev] [--] path
 tig grep   [options] [pattern]
 tig refs
@@ -52,6 +53,9 @@ status::
 
 log::
 	Start up in log view, displaying git-log(1) output.
+
+reflog::
+	Start up in reflog view.
 
 refs::
 	Start up in refs view.

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -436,7 +436,7 @@ they support:
 blob-view, diff-view, log-view, pager-view, stage-view:: line-number, text
 blame-view:: author, date, file-name, id, line-number, text
 grep-view:: file-name, line-number, text
-main-view:: author, date, commit-title, id, line-number
+main-view, reflog-view:: author, date, commit-title, id, line-number, ref
 refs-view:: author, date, commit-title, id, line-number, ref
 stash-view:: author, date, commit-title, id, line-number
 status-view:: file-name, line-number, status
@@ -592,10 +592,10 @@ Tig respects but does not require an `$if tig` section in `~/.inputrc`.
 
 Keymaps::
 
-Valid keymaps are: *main*, *diff*, *log*, *help*, *pager*, *status*, *stage*,
-*tree*, *blob*, *blame*, *refs*, *stash*, *grep* and *generic*. Use *generic*
-to set key mapping in all keymaps. Use *search* to define keys for navigating
-search results during search.
+Valid keymaps are: *main*, *diff*, *log*, *reflog*, *help*, *pager*, *status*,
+*stage*, *tree*, *blob*, *blame*, *refs*, *stash*, *grep* and *generic*. Use
+*generic* to set key mapping in all keymaps. Use *search* to define keys for
+navigating search results during search.
 
 Key values::
 
@@ -818,6 +818,7 @@ View switching
 |view-main               |Show main view
 |view-diff               |Show diff view
 |view-log                |Show log view
+|view-reflog             |Show reflog view
 |view-tree               |Show tree view
 |view-blob               |Show blob view
 |view-blame              |Show blame view

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -54,6 +54,7 @@ typedef struct view_column *view_settings;
 	_(line_graphics,		enum graphic,		VIEW_RESET_DISPLAY) \
 	_(log_options,			const char **,		VIEW_LOG_LIKE) \
 	_(log_view,			view_settings,		VIEW_NO_FLAGS) \
+	_(reflog_view,			view_settings,		VIEW_NO_FLAGS) \
 	_(mailmap,			bool,			VIEW_DIFF_LIKE | VIEW_LOG_LIKE) \
 	_(main_options,			const char **,		VIEW_LOG_LIKE) \
 	_(main_view,			view_settings,		VIEW_NO_FLAGS) \

--- a/include/tig/reflog.h
+++ b/include/tig/reflog.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2006-2019 Jonas Fonseca <jonas.fonseca@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef TIG_REFLOG_H
+#define TIG_REFLOG_H
+
+#include "tig/view.h"
+
+extern struct view reflog_view;
+
+static inline void
+open_reflog_view(struct view *prev, enum open_flags flags)
+{
+	open_view(prev, &reflog_view, flags);
+}
+
+#endif
+/* vim: set ts=8 sw=8 noexpandtab: */

--- a/include/tig/tig.h
+++ b/include/tig/tig.h
@@ -160,6 +160,7 @@ void TIG_NORETURN usage(const char *message);
 	_(MAIN,   main), \
 	_(DIFF,   diff), \
 	_(LOG,    log), \
+	_(REFLOG, reflog), \
 	_(TREE,   tree), \
 	_(BLOB,   blob), \
 	_(BLAME,  blame), \

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -1,0 +1,82 @@
+/* Copyright (c) 2006-2019 Jonas Fonseca <jonas.fonseca@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "tig/display.h"
+#include "tig/draw.h"
+#include "tig/git.h"
+#include "tig/main.h"
+
+static enum status_code
+reflog_open(struct view *view, enum open_flags flags)
+{
+	struct main_state *state = view->private;
+	const char *reflog_argv[] = {
+		"git", "reflog", "show", encoding_arg, "%(cmdlineargs)",
+			"%(revargs)", "--no-color", "--pretty=raw", NULL
+	};
+
+	if (is_initial_view(view) && opt_file_args)
+		die("No revisions match the given arguments.");
+
+	state->with_graph = false;
+	watch_register(&view->watch, WATCH_HEAD | WATCH_REFS);
+	return begin_update(view, NULL, reflog_argv, flags);
+}
+
+static enum request
+reflog_request(struct view *view, enum request request, struct line *line)
+{
+	struct commit *commit = line->data;
+
+	switch (request) {
+	case REQ_ENTER:
+	{
+		const char *main_argv[] = {
+			GIT_MAIN_LOG(encoding_arg, commit_order_arg(),
+				"%(mainargs)", "", commit->id, "",
+				show_notes_arg(), log_custom_pretty_arg())
+		};
+
+		if (!argv_format(main_view.env, &main_view.argv, main_argv, false, false))
+			report("Failed to format argument");
+		else
+			open_view(view, &main_view, OPEN_SPLIT | OPEN_PREPARED);
+		return REQ_NONE;
+	}
+
+	default:
+		return main_request(view, request, line);
+	}
+}
+
+static struct view_ops reflog_ops = {
+	"reference",
+	argv_env.head,
+	VIEW_LOG_LIKE | VIEW_REFRESH,
+	sizeof(struct main_state),
+	reflog_open,
+	main_read,
+	view_column_draw,
+	reflog_request,
+	view_column_grep,
+	main_select,
+	main_done,
+	view_column_bit(AUTHOR) | view_column_bit(COMMIT_TITLE) |
+		view_column_bit(DATE) | view_column_bit(ID) |
+		view_column_bit(LINE_NUMBER),
+	main_get_column_data,
+};
+
+DEFINE_VIEW(reflog);
+
+/* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/tig.c
+++ b/src/tig.c
@@ -41,6 +41,7 @@
 #include "tig/grep.h"
 #include "tig/help.h"
 #include "tig/log.h"
+#include "tig/reflog.h"
 #include "tig/main.h"
 #include "tig/pager.h"
 #include "tig/refs.h"
@@ -208,6 +209,9 @@ view_driver(struct view *view, enum request request)
 	case REQ_VIEW_LOG:
 		open_log_view(view, OPEN_DEFAULT);
 		break;
+	case REQ_VIEW_REFLOG:
+		open_reflog_view(view, OPEN_DEFAULT);
+		break;
 	case REQ_VIEW_TREE:
 		open_tree_view(view, OPEN_DEFAULT);
 		break;
@@ -370,6 +374,7 @@ static const char usage_string[] =
 "Usage: tig        [options] [revs] [--] [paths]\n"
 "   or: tig log    [options] [revs] [--] [paths]\n"
 "   or: tig show   [options] [revs] [--] [paths]\n"
+"   or: tig reflog [options] [revs]\n"
 "   or: tig blame  [options] [rev] [--] path\n"
 "   or: tig grep   [options] [pattern]\n"
 "   or: tig refs\n"
@@ -505,6 +510,9 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 
 	} else if (!strcmp(subcommand, "log")) {
 		request = REQ_VIEW_LOG;
+
+	} else if (!strcmp(subcommand, "reflog")) {
+		request = REQ_VIEW_REFLOG;
 
 	} else if (!strcmp(subcommand, "stash")) {
 		request = REQ_VIEW_STASH;

--- a/src/view.c
+++ b/src/view.c
@@ -1721,6 +1721,7 @@ append_line_format(struct view *view, struct line *line, const char *fmt, ...)
 #include "tig/main.h"
 #include "tig/diff.h"
 #include "tig/log.h"
+#include "tig/reflog.h"
 #include "tig/tree.h"
 #include "tig/blob.h"
 #include "tig/blame.h"

--- a/test/help/all-keybindings-test
+++ b/test/help/all-keybindings-test
@@ -3,7 +3,7 @@
 . libtest.sh
 
 export COLUMNS=90
-export LINES=120
+export LINES=125
 
 steps '
 	:view-help

--- a/test/help/all-keybindings-test.expected
+++ b/test/help/all-keybindings-test.expected
@@ -5,6 +5,7 @@ View switching
                            m view-main           Show main view
                            d view-diff           Show diff view
                            l view-log            Show log view
+                           L view-reflog         Show reflog view
                            t view-tree           Show tree view
                            f view-blob           Show blob view
                            b view-blame          Show blame view
@@ -85,6 +86,10 @@ Option toggling:
                            ] :toggle diff-context +1
 Internal commands:
                            @ :/^@@
+[-] reflog bindings
+External commands:
+                           C ?git checkout %(branch)
+                           ! ?git reset --hard %(commit)
 [-] refs bindings
 External commands:
                            C ?git checkout %(branch)
@@ -116,4 +121,4 @@ External commands:
 
 
 
-[help] - line 1 of 114                                                                100%
+[help] - line 1 of 119                                                                100%

--- a/test/help/default-test
+++ b/test/help/default-test
@@ -30,6 +30,7 @@ View switching
                            m view-main           Show main view
                            d view-diff           Show diff view
                            l view-log            Show log view
+                           L view-reflog         Show reflog view
                            t view-tree           Show tree view
                            f view-blob           Show blob view
                            b view-blame          Show blame view
@@ -50,8 +51,7 @@ View manipulation
                      R, <F5> refresh             Reload and refresh view
                            O maximize            Maximize the current view
                            q view-close          Close the current view
-                 Q, <Ctrl-C> quit                Close all views and quit
-[help] - line 1 of 114                                                       24%
+[help] - line 1 of 119                                                       23%
 EOF
 
 assert_equals 'help-search.screen' <<EOF
@@ -62,6 +62,7 @@ View switching
                            m view-main           Show main view
                            d view-diff           Show diff view
                            l view-log            Show log view
+                           L view-reflog         Show reflog view
                            t view-tree           Show tree view
                            f view-blob           Show blob view
                            b view-blame          Show blame view
@@ -82,8 +83,7 @@ View manipulation
                      R, <F5> refresh             Reload and refresh view
                            O maximize            Maximize the current view
                            q view-close          Close the current view
-                 Q, <Ctrl-C> quit                Close all views and quit
-[help] - line 18 of 114                                                      24%
+[help] - line 19 of 119                                                      23%
 EOF
 
 assert_equals 'help-collapsed.screen' <<EOF
@@ -103,6 +103,10 @@ Option toggling:
   ] :toggle diff-context +1
 Internal commands:
   @ :/^@@
+[-] reflog bindings
+External commands:
+  C ?git checkout %(branch)
+  ! ?git reset --hard %(commit)
 [-] refs bindings
 External commands:
   C ?git checkout %(branch)
@@ -111,9 +115,5 @@ External commands:
 View-specific actions
   u status-update     Stage/unstage chunk or file changes
   ! status-revert     Revert chunk or file changes
-  M status-merge      Merge file using external tool
-External commands:
-  C !git commit
-[-] stage bindings
-[help] - line 4 of 43                                                        65%
+[help] - line 4 of 47                                                        59%
 EOF

--- a/test/help/user-command-test
+++ b/test/help/user-command-test
@@ -55,5 +55,5 @@ Searching
 [-] main bindings
 Cursor navigation
                               G move-last-line      Move cursor to last line
-[help] - line 78 of 140                                                                          75%
+[help] - line 79 of 145                                                                          73%
 EOF

--- a/test/reflog/default-test
+++ b/test/reflog/default-test
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Test display and options specific to the reflog view.
+
+. libtest.sh
+. libgit.sh
+
+tigrc <<EOF
+set line-graphics = ascii
+EOF
+
+steps '
+	:exec @git checkout r1.0
+	:exec @git checkout r1.1.2
+	:enter
+	:save-display reflog-default.screen
+'
+
+in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"
+
+test_tig reflog
+
+assert_equals 'reflog-default.screen' <<EOF
+HEAD@{0} [r1.1.2] [r1.1.x] <v1.1> checkout: moving from r1.0 to r1.1.2
+HEAD@{1} [r1.0] <v1.0> checkout: moving from master to r1.0
+HEAD@{2} [master] {origin/master} {max-power/master} {origin/HEAD} reset: moving
+HEAD@{3} [master] {origin/master} {max-power/master} {origin/HEAD} clone: from /
+
+
+
+
+
+[reflog] b45b5704c34dbd4c5fd89d58d45238ad136ae166 - reference 1 of 4        100%
+2009-12-26 01:11 +0000 作者                  * [r1.1.2] [r1.1.x] <v1.1> Commit 8
+2009-12-17 12:49 +0000 René Lévesque         * [r1.0] <v1.0> Commit 8 B
+2009-12-09 00:27 +0000 A. U. Thor            * Commit 8 A
+2009-11-30 12:05 +0000 Max Power             * {max-power/mp/gh-123} Commit 7 E
+2009-11-21 23:43 +0000 Jørgen Thygesen Brahe * Commit 7 D
+2009-11-13 11:20 +0000 作者                  * Commit 7 C
+2009-11-04 22:58 +0000 René Lévesque         * Commit 7 B
+2009-10-27 10:36 +0000 A. U. Thor            * Commit 7 A
+2009-10-18 22:14 +0000 Max Power             * Commit 6 E
+2009-10-10 09:52 +0000 Jørgen Thygesen Brahe * Commit 6 D
+2009-10-01 21:30 +0000 作者                  * Commit 6 C
+2009-09-23 09:07 +0000 René Lévesque         * Commit 6 B
+2009-09-14 20:45 +0000 A. U. Thor            * Commit 6 A
+2009-09-06 08:23 +0000 Max Power             * Commit 5 E
+2009-08-28 20:01 +0000 Jørgen Thygesen Brahe * Commit 5 D
+2009-08-20 07:39 +0000 作者                  * Commit 5 C
+2009-08-11 19:17 +0000 René Lévesque         * Commit 5 B
+2009-08-03 06:54 +0000 A. U. Thor            * Commit 5 A
+[main] b45b5704c34dbd4c5fd89d58d45238ad136ae166 - commit 1 of 38             47%
+EOF

--- a/tigrc
+++ b/tigrc
@@ -70,6 +70,7 @@
 set blame-view	= id:yes,color file-name:auto author:full date:default line-number:yes,interval=1 text
 set grep-view	= file-name:no line-number:yes,interval=1 text
 set main-view	= line-number:no,interval=5 id:no date:default author:full commit-title:yes,graph,refs,overflow=no
+set reflog-view	= line-number:no,interval=5 id:yes date:no author:no commit-title:yes,refs,overflow=no
 set refs-view	= line-number:no id:no date:default author:full ref commit-title
 set stash-view	= line-number:no,interval=5 id:no date:default author:full commit-title
 set status-view	= line-number:no,interval=5 status:short file-name
@@ -183,6 +184,8 @@ bind stash	P	?git stash pop %(stash)
 bind stash	!	?git stash drop %(stash)
 bind refs	C	?git checkout %(branch)
 bind refs	!	?git branch -D %(branch)
+bind reflog	C	?git checkout %(branch)
+bind reflog	!	?git reset --hard %(commit)
 
 # Normal commands
 # ---------------
@@ -191,6 +194,7 @@ bind refs	!	?git branch -D %(branch)
 bind generic	m	view-main
 bind generic	d	view-diff
 bind generic	l	view-log
+bind generic	L	view-reflog
 bind generic	t	view-tree
 bind generic	f	view-blob
 bind generic	b	view-blame


### PR DESCRIPTION
Press L to open the reflog view or start with tig reflog.

The main benefit over git reflog --pretty=raw | tig --pretty=raw
is the ability to browse the full chain of commits for each reflog.

Closes #538