### PR TITLE
make-builtin-config: Fix unportable sed usage in read_tigrc()

### DIFF
--- a/tools/make-builtin-config.sh
+++ b/tools/make-builtin-config.sh
@@ -21,7 +21,7 @@ TIGRC="${1:-tigrc}"
 
 read_tigrc() {
 	if test -z "$NO_BUILTIN_TIGRC"; then
-		sed 's/\s*#.*//' "$TIGRC" | sed 's,\\,\\\\,g' | sed 's,",\\",g' | sed 's/	\+/	/g'
+		sed 's/[[:space:]]*#.*//' "$TIGRC" | sed 's,\\,\\\\,g' | sed 's,",\\",g' | sed 's/	\+/	/g'
 	else
 		echo '#'
 	fi


### PR DESCRIPTION
read_tigrc() uses an unportable sed expression at them moment as
`\s` is silently ignored in BSD sed and actually just matches `s`.
In the future this may become a fatal error on FreeBSD.

`[[:space:]]` should work just as well on Linux or elsewhere while
actually doing what was intended (strip leading whitespace) on
FreeBSD.

Downstream bug report:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=233423