### PR TITLE
 Fix #631 crossing branch lines have the wrong color

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -460,8 +460,13 @@ author::
 	  sizing content, up to this limit.
 
 commit-title::
-	- 'graph' (mixed) [no|v2|v1]: Whether to show the revision graph in the
-	  main view on start-up. "v1" refers to the old graph rendering, which
+	- 'graph' (mixed) [no|v2|v2-horizontal-crossover|v1]:
+	  Whether to show the revision graph in the main view on start-up.
+	  "v2" refers to the newer graph rendering where a vertical path is placed over a horizontal path,
+	  but the horizontal path is miscolored.
+	  "v2-horizontal-crossover" refers to the newer graph rendering where a horizontal path is placed over a vertical path,
+	  and the horizontal path is correctly colored.
+	  "v1" refers to the old graph rendering, which
 	  is less accurate but faster and thus recommended in large
 	  repositories.  See also the 'line-graphics' options.
 	- 'refs' (bool): Whether to show references (branches, tags, and

--- a/include/tig/types.h
+++ b/include/tig/types.h
@@ -82,6 +82,7 @@ bool map_enum_do(const struct enum_map_entry *map, size_t map_size, int *value, 
 #define GRAPH_DISPLAY_ENUM(_) \
 	_(GRAPH_DISPLAY, NO), \
 	_(GRAPH_DISPLAY, V2), \
+	_(GRAPH_DISPLAY, V2_HORIZONTAL_CROSSOVER), \
 	_(GRAPH_DISPLAY, V1)
 
 #define DATE_ENUM(_) \

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -695,7 +695,6 @@ graph_generate_symbols(struct graph_v2 *graph, struct graph_canvas *canvas)
 	for (pos = 0; pos < row->size; pos++) {
 		struct graph_column *column = &row->columns[pos];
 		struct graph_symbol *symbol = &column->symbol;
-		const char *id = next_row->columns[pos].id;
 
 		symbol->commit            = (pos == graph->position);
 		symbol->boundary          = (pos == graph->position && next_row->columns[pos].symbol.boundary);
@@ -723,10 +722,8 @@ graph_generate_symbols(struct graph_v2 *graph, struct graph_canvas *canvas)
 		symbol->new_column        = new_column(row, prev_row, pos);
 		symbol->empty             = (!graph_column_has_commit(&row->columns[pos]));
 
-		if (graph_column_has_commit(column)) {
-			id = column->id;
-		}
-		symbol->color = get_color(graph, id);
+		// Do initial assignment of symbol colors
+		symbol->color = get_color(graph, column->id ? column->id : next_row->columns[pos].id);
 
 		graph_canvas_append_symbol(graph, canvas, symbol);
 	}
@@ -1085,6 +1082,15 @@ graph_symbol_to_utf8(const struct graph_symbol *symbol)
 	return "  ";
 }
 
+static const char *
+graph_symbol_to_utf8_horiz(const struct graph_symbol *symbol)
+{
+	return
+	  graph_symbol_cross_over(symbol)           ? "──"
+	: graph_symbol_turn_down_cross_over(symbol) ? " ╭"
+	: graph_symbol_to_utf8(symbol);
+}
+
 static const chtype *
 graph_symbol_to_chtype(const struct graph_symbol *symbol)
 {
@@ -1156,6 +1162,16 @@ graph_symbol_to_chtype(const struct graph_symbol *symbol)
 	return graphics;
 }
 
+static const chtype *
+graph_symbol_to_chtype_horiz(const struct graph_symbol *symbol)
+{
+	static chtype graphics[2];
+	return
+	  graph_symbol_cross_over(symbol)           ? (graphics[0] = ACS_HLINE, graphics[1] = ACS_HLINE,    graphics)
+	: graph_symbol_turn_down_cross_over(symbol) ? (graphics[0] = ' ',       graphics[1] = ACS_ULCORNER, graphics)
+	: graph_symbol_to_chtype(symbol);
+}
+
 static const char *
 graph_symbol_to_ascii(const struct graph_symbol *symbol)
 {
@@ -1208,6 +1224,33 @@ graph_symbol_to_ascii(const struct graph_symbol *symbol)
 	return "  ";
 }
 
+static const char *
+graph_symbol_to_ascii_horiz(const struct graph_symbol *symbol)
+{
+	return
+	  graph_symbol_cross_over(symbol)           ? "--"
+	: graph_symbol_turn_down_cross_over(symbol) ? " ."
+	: graph_symbol_to_ascii(symbol);
+}
+
+/* Re-color the symbols array of the given graph_canvas
+ * so that horizontal cross-over symbols are properly colored
+ */
+static void
+graph_symbol_recolor(const struct graph_canvas *canvas)
+{
+	struct graph_symbol *sy = &canvas->symbols[canvas->size - 1];
+	size_t merge_c = 0;
+	int i;
+
+	for (i = canvas->size - 1; i >= 0; i--, sy--) {
+		if (graph_symbol_merge(sy) || graph_symbol_turn_left(sy))
+			if (!merge_c) merge_c = sy->color;
+		if (graph_symbol_cross_over(sy))
+			sy->color = merge_c;
+	}
+}
+
 static void
 graph_foreach_symbol(const struct graph *graph, const struct graph_canvas *canvas,
 		     graph_symbol_iterator_fn fn, void *data)
@@ -1223,8 +1266,16 @@ graph_foreach_symbol(const struct graph *graph, const struct graph_canvas *canva
 	}
 }
 
+static void
+graph_foreach_symbol_horiz(const struct graph *graph, const struct graph_canvas *canvas,
+		     graph_symbol_iterator_fn fn, void *data)
+{
+	graph_symbol_recolor(canvas);
+	graph_foreach_symbol(graph, canvas, fn, data);
+}
+
 struct graph *
-init_graph_v2(void)
+init_graph_v2(bool crossover)
 {
 	struct graph_v2 *graph = calloc(1, sizeof(*graph));
 	struct graph *api;
@@ -1240,10 +1291,10 @@ init_graph_v2(void)
 	api->add_parent = graph_add_parent;
 	api->is_merge = graph_is_merge;
 	api->render_parents = graph_render_parents;
-	api->foreach_symbol = graph_foreach_symbol;
-	api->symbol_to_ascii = graph_symbol_to_ascii;
-	api->symbol_to_utf8 = graph_symbol_to_utf8;
-	api->symbol_to_chtype = graph_symbol_to_chtype;
+	api->foreach_symbol   = crossover ? graph_foreach_symbol_horiz   : graph_foreach_symbol   ;
+	api->symbol_to_ascii  = crossover ? graph_symbol_to_ascii_horiz  : graph_symbol_to_ascii  ;
+	api->symbol_to_utf8   = crossover ? graph_symbol_to_utf8_horiz   : graph_symbol_to_utf8   ;
+	api->symbol_to_chtype = crossover ? graph_symbol_to_chtype_horiz : graph_symbol_to_chtype ;
 
 	return api;
 }

--- a/src/graph.c
+++ b/src/graph.c
@@ -15,7 +15,7 @@
 #include "tig/graph.h"
 
 struct graph *init_graph_v1(void);
-struct graph *init_graph_v2(void);
+struct graph *init_graph_v2(bool);
 
 struct graph *
 init_graph(enum graph_display display)
@@ -23,7 +23,9 @@ init_graph(enum graph_display display)
 	if (display == GRAPH_DISPLAY_V1)
 		return init_graph_v1();
 	if (display == GRAPH_DISPLAY_V2)
-		return init_graph_v2();
+		return init_graph_v2(false);
+	if (display == GRAPH_DISPLAY_V2_HORIZONTAL_CROSSOVER)
+		return init_graph_v2(true);
 	return NULL;
 }
 

--- a/test/main/default-test
+++ b/test/main/default-test
@@ -22,6 +22,7 @@ steps '
 	:save-display main-no-refs.screen
 	:toggle commit-title-graph
 	:toggle commit-title-graph
+	:toggle commit-title-graph
 	:save-display main-no-graph.screen
 
 	:957f2b368e6fa5c0757f36b1441e32729ee5e9c7


### PR DESCRIPTION
Issue #631 notes that

> When branch lines are crossing each other, the horizontal line has the color of the branch it is crossing (the one going vertically), instead of being the same color that continues after the crossing. It is especially apparent if the line crosses multiple, differently colored vertical lines.

The mis-coloring occurs because of three factors:
1. A crossover symbol shows vertical and horizontal lines, for example, "─│" for UTF-8 line-graphics.
2. A symbol can have one color assignment.
3. Graphs are rendered with vertical lines taking priority over horizontal lines, ie, the vertical line will have the correct color while the horizontal line will be mis-colored.

An obvious fix is to simplify the crossover symbol by removing the mis-colored horizontal component, for example, use " │" for"'─│", but the result is unsatisfying because the path in which the horizontal line was part of becomes too broken.

The chosen fix is to remove the vertical component instead, ie, use "──" for "─│", and then use the same color as the right-hand neighbour. Another crossover symbol to fix is "─╭"; here we remove the horizontal component and simplify the symbol to " ╭". The resultant vertical path extend further on the screen, and so to the eye, it does not break as much as the horizontal path. A graph using horizontal crossover symbols is quite satisfying and may actually be preferred.

We introduce a new toggle option for `commit-title-graph` to enable the user to switch between the old and the new ways. If the command `set main-view-commit-title-graph = v2-horizontal-crossover` is used instead of the default `set main-view-commit-title-graph = v2`, then the cross-over symbols will give priority to horizontal paths and as a result there will not be mis-colorings.

The PR is organized into three commits.
1. The main commit; code changes are summarized in the commit message.
2. Update the relevant test suite.
3. Update the tigrc man page.