### PR TITLE
Fix typo in manual heading (fixes #954)

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -266,7 +266,7 @@ TIGRC_SYSTEM::
 
 [[history-files]]
 History Files
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 If compiled with readline support, Tig writes a persistent command and search
 history to `~/.tig_history` or `$XDG_DATA_HOME/tig/history`.


### PR DESCRIPTION
Fix formatting for the "History Files" heading. Fixes #954