### PR TITLE
Added word-diff=plain colorizing support

### DIFF
--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -94,7 +94,8 @@ struct ref;
 	_(PALETTE_12,		""), \
 	_(PALETTE_13,		""), \
 	_(GRAPH_COMMIT,		""), \
-	_(SEARCH_RESULT,	"")
+	_(SEARCH_RESULT,	""), \
+	_(WDIFF_PLAIN,		"")
 
 enum line_type {
 #define DEFINE_LINE_ENUM(type, line) LINE_##type

--- a/src/diff.c
+++ b/src/diff.c
@@ -276,11 +276,15 @@ diff_common_read_diff_wdiff(struct view *view, const char *text)
 	 *	there could be [-one-] diff part{+s+} in the {+any +} line
 	 */
 
-	while (diff_common_read_diff_wdiff_group(&context));
+	while (diff_common_read_diff_wdiff_group(&context)) {}
 
+    // It's not a word-diff line, continue parsing
+    if (context.text == text)
+        return NULL;
+    
 	diff_common_add_cell(&context, strlen(context.text), false);
-
-	return diff_common_add_line(view, text, LINE_DEFAULT, &context);
+    
+	return diff_common_add_line(view, text, LINE_WDIFF_PLAIN, &context);
 }
 
 static bool
@@ -346,7 +350,9 @@ diff_common_read(struct view *view, const char *data, struct diff_state *state)
 	if (state->reading_diff_chunk && type == LINE_DEFAULT) {
 		if (diff_common_read_diff_wdiff(view, data))
 			return true;
-	} else if (type == LINE_DIFF_HEADER) {
+	}
+	
+	if (type == LINE_DIFF_HEADER) {
 		state->after_diff = true;
 		state->reading_diff_chunk = false;
 

--- a/test/diff/diff-wdiff-context-test
+++ b/test/diff/diff-wdiff-context-test
@@ -1,0 +1,213 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+steps '
+	:save-display diff-default.screen
+
+	:21
+	]
+	:save-display diff-u4.screen
+
+	]
+	:save-display diff-u5.screen
+
+	:toggle diff-context +5
+	:save-display diff-u10.screen
+
+	[
+	[
+	:save-display diff-u8.screen
+
+	:0
+	:set diff-context = 3
+	:view-main
+	:view-diff
+	:save-display diff-default-from-main.screen
+
+	:21
+	]
+	:save-display diff-u4-from-main.screen
+
+	]
+	:save-display diff-u5-from-main.screen
+
+	:toggle diff-context +5
+	:save-display diff-u10-from-main.screen
+
+	[
+	[
+	:save-display diff-u8-from-main.screen
+'
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+test_tig show master^ --word-diff
+
+assert_equals 'diff-default.screen' <<EOF
+commit a1dcf1aaa11470978db1d5d8bcf9e16201eb70ff
+Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
+AuthorDate: Sat Mar 1 15:59:02 2014 -0500
+Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
+CommitDate: Sat Mar 1 15:59:02 2014 -0500
+
+    Add type parameter for js.Dynamic
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
+index 65f914a..3aa4320 100644
+--- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
++++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+@@ -15,7 +15,7 @@ object Benchmark {
+  val benchmarks = js.Array[Benchmark]()
+  val benchmarkApps = js.Array[BenchmarkApp]()
+
+  val global = [-js.Dynamic.global.asInstanceOf[js.Dictionary]-]{+js.Dynamic.glo
+  global("runScalaJSBenchmarks") = runBenchmarks _
+  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+
+
+
+
+
+
+[diff] a1dcf1aaa11470978db1d5d8bcf9e16201eb70ff - line 1 of 23              100%
+EOF
+
+assert_equals 'diff-u4.screen' <<EOF
+Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
+AuthorDate: Sat Mar 1 15:59:02 2014 -0500
+Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
+CommitDate: Sat Mar 1 15:59:02 2014 -0500
+
+    Add type parameter for js.Dynamic
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
+index 65f914a..3aa4320 100644
+--- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
++++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+@@ -14,9 +14,9 @@ import scala.scalajs.js
+object Benchmark {
+   val benchmarks = js.Array[Benchmark]()
+   val benchmarkApps = js.Array[BenchmarkApp]()
+
+   val global = [-js.Dynamic.global.asInstanceOf[js.Dictionary]-]{+js.Dynamic.glo
+   global("runScalaJSBenchmarks") = runBenchmarks _
+   global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+
+   def add(benchmark: Benchmark) {
+
+
+
+
+[diff] Changes to 'common/src/main/scala/org/scalajs/benchmark/Benchmark.sca100%
+EOF
+
+assert_equals 'diff-u5.screen' <<EOF
+AuthorDate: Sat Mar 1 15:59:02 2014 -0500
+Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
+CommitDate: Sat Mar 1 15:59:02 2014 -0500
+
+    Add type parameter for js.Dynamic
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
+index 65f914a..3aa4320 100644
+--- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
++++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+@@ -13,11 +13,11 @@ import scala.scalajs.js
+
+object Benchmark {
+  val benchmarks = js.Array[Benchmark]()
+  val benchmarkApps = js.Array[BenchmarkApp]()
+
+  val global = [-js.Dynamic.global.asInstanceOf[js.Dictionary]-]{+js.Dynamic.glo
+  global("runScalaJSBenchmarks") = runBenchmarks _
+  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+
+  def add(benchmark: Benchmark) {
+    benchmarks.push(benchmark)
+
+
+
+[diff] Changes to 'common/src/main/scala/org/scalajs/benchmark/Benchmark.sca100%
+EOF
+
+assert_equals 'diff-u10.screen' <<EOF
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
+index 65f914a..3aa4320 100644
+--- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
++++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+@@ -8,21 +8,21 @@
+
+package org.scalajs.benchmark
+
+import scala.compat.Platform
+import scala.scalajs.js
+
+object Benchmark {
+  val benchmarks = js.Array[Benchmark]()
+  val benchmarkApps = js.Array[BenchmarkApp]()
+
+  val global = [-js.Dynamic.global.asInstanceOf[js.Dictionary]-]{+js.Dynamic.glo
+  global("runScalaJSBenchmarks") = runBenchmarks _
+  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+
+  def add(benchmark: Benchmark) {
+    benchmarks.push(benchmark)
+    if (benchmark.isInstanceOf[BenchmarkApp]) {
+      benchmarkApps.push(benchmark.asInstanceOf[BenchmarkApp])
+    }
+[diff] Changes to 'common/src/main/scala/org/scalajs/benchmark/Benchmark.scal94%
+EOF
+
+assert_equals 'diff-u8.screen' <<EOF
+
+    Add type parameter for js.Dynamic
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala b/commo
+index 65f914a..3aa4320 100644
+--- a/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
++++ b/common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+@@ -10,17 +10,17 @@ package org.scalajs.benchmark
+
+import scala.compat.Platform
+import scala.scalajs.js
+
+object Benchmark {
+  val benchmarks = js.Array[Benchmark]()
+  val benchmarkApps = js.Array[BenchmarkApp]()
+
+  val global = [-js.Dynamic.global.asInstanceOf[js.Dictionary]-]{+js.Dynamic.glo
+  global("runScalaJSBenchmarks") = runBenchmarks _
+  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+
+  def add(benchmark: Benchmark) {
+    benchmarks.push(benchmark)
+    if (benchmark.isInstanceOf[BenchmarkApp]) {
+      benchmarkApps.push(benchmark.asInstanceOf[BenchmarkApp])
+    }
+[diff] Changes to 'common/src/main/scala/org/scalajs/benchmark/Benchmark.sca100%
+EOF
+
+for i in expected/*.screen; do
+	diff_file="$(basename -- "$i" | sed 's/[.]screen/-from-main.screen/')"
+	assert_equals "$diff_file" <<EOF
+$(cat < "$i")
+EOF
+done


### PR DESCRIPTION
Added ADD and DEL colors for {+added+} and [-removed-] blocks of git word-diff=plain

Since git does not escape delimiters in word-diff, this code may produce an incorrect color output on some code that actually contains these sequences including the first commit of this PR.

It's possible to bypass this by using git color escape sequences to determine additions and deletions, but it's likely to conflict with the rest of diff parser.

(Probably) fixes #221 
