### PR TITLE
Fix tests not working with bash 5.0+ as /bin/sh

### DIFF
--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -17,6 +17,8 @@
 set -eu
 if [ -n "${BASH_VERSION:-}" ]; then
 	set -o pipefail
+	# Prevent bash from changing LINES and COLUMNS variables
+	shopt -u checkwinsize || true
 fi
 IFS='
 	'


### PR DESCRIPTION
Bash checkwinsize automatically sets LINES and COLUMNS preventing tig tests from setting these variables manually.

This option has been enabled by default since bash-5.0-beta2.