### PR TITLE
Add TIGRC_EXTRA

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -264,6 +264,9 @@ TIGRC_USER::
 TIGRC_SYSTEM::
 	Path of the system wide configuration file.
 
+TIGRC_EXTRA::
+	Path of the additional configuration file.
+
 [[history-files]]
 History Files
 ~~~~~~~~~~~~~

--- a/doc/tig.1.adoc
+++ b/doc/tig.1.adoc
@@ -206,6 +206,9 @@ TIGRC_SYSTEM::
 	`{sysconfdir}/tigrc`). Define to empty string to use built-in
 	configuration.
 
+TIGRC_EXTRA::
+	Path of the additional configuration file.
+
 TIG_LS_REMOTE::
 	Command for retrieving all repository references. The command
 	should output data in the same format as git-ls-remote(1).

--- a/src/options.c
+++ b/src/options.c
@@ -1013,6 +1013,7 @@ enum status_code
 load_options(void)
 {
 	const char *tigrc_user = getenv("TIGRC_USER");
+	const char *tigrc_extra = getenv("TIGRC_EXTRA");
 	const char *tigrc_system = getenv("TIGRC_SYSTEM");
 	const char *tig_diff_opts = getenv("TIG_DIFF_OPTS");
 	const bool diff_opts_from_args = !!opt_diff_options;
@@ -1051,6 +1052,10 @@ load_options(void)
 
 		if (load_option_file(tigrc_user) == ERROR_FILE_DOES_NOT_EXIST)
 			load_option_file(TIG_USER_CONFIG);
+	}
+
+	if (tigrc_extra) {
+		load_option_file(tigrc_extra);
 	}
 
 	if (!diff_opts_from_args && tig_diff_opts && *tig_diff_opts) {


### PR DESCRIPTION
I'm thinking about creating a plugin for Zsh, but also possibly for Bash, that would supply e.g.: a bindings that would display a fzf-backed list of Makefile targets and run a selected target. To supply such additional functionality in a pluggable fashion such variable would serve very well.

The patch is very simple. It loads the extra configuration after the 2 other ones.