### PR TITLE
Fix vertical lines in Putty with UTF-8 graphics

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -187,11 +187,24 @@ static void
 redraw_display_separator(bool clear)
 {
 	if (display_sep) {
-		chtype separator = opt_line_graphics ? ACS_VLINE : '|';
+		int lineno = 0;
 
 		if (clear)
 			wclear(display_sep);
-		wbkgd(display_sep, separator + get_line_attr(NULL, LINE_TITLE_BLUR));
+		wbkgdset(display_sep, get_line_attr(NULL, LINE_TITLE_BLUR));
+
+		switch (opt_line_graphics) {
+		case GRAPHIC_ASCII:
+			while (mvwaddch(display_sep, lineno++, 0, '|') == OK);
+			break;
+		case GRAPHIC_DEFAULT:
+			while (mvwaddch(display_sep, lineno++, 0, ACS_VLINE) == OK);
+			break;
+		case GRAPHIC_UTF_8:
+			while (mvwaddstr(display_sep, lineno++, 0, "│") == OK);
+			break;
+		}
+
 		wnoutrefresh(display_sep);
 	}
 }

--- a/src/draw.c
+++ b/src/draw.c
@@ -314,7 +314,7 @@ draw_lineno_custom(struct view *view, struct view_column *column, unsigned int l
 	unsigned long digits3 = MIN(9,MAX(3,column->width));
 	int max = MIN(VIEW_MAX_LEN(view), digits3);
 	char *text = NULL;
-	chtype separator = opt_line_graphics ? ACS_VLINE : '|';
+	chtype separator = ACS_VLINE;
 	struct line_number_options *opts = &column->opt.line_number;
 	int interval = opts->interval > 0 ? opts->interval : 5;
 
@@ -332,7 +332,17 @@ draw_lineno_custom(struct view *view, struct view_column *column, unsigned int l
 		draw_chars(view, LINE_LINE_NUMBER, text, -1, max, true);
 	else
 		draw_space(view, LINE_LINE_NUMBER, max, digits3);
-	return draw_graphic(view, LINE_DEFAULT, &separator, 1, true);
+
+	switch (opt_line_graphics) {
+	case GRAPHIC_ASCII:
+		return draw_chars(view, LINE_DEFAULT, "| ", -1, 2, false);
+	case GRAPHIC_DEFAULT:
+		return draw_graphic(view, LINE_DEFAULT, &separator, 1, true);
+	case GRAPHIC_UTF_8:
+		return draw_chars(view, LINE_DEFAULT, "│ ", -1, 2, false);
+	}
+
+	return false;
 }
 
 bool

--- a/test/main/vertical-lines-test
+++ b/test/main/vertical-lines-test
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export WIDTH=40
+export LINES=18
+
+tigrc <<EOF
+set vertical-split = auto
+EOF
+
+steps '
+	:set main-view-line-number-display = yes
+	:set diff-view-line-number-display = yes
+	:enter
+
+	:set line-graphics = ascii
+	:save-display main-verticals-ascii.screen
+
+	:set line-graphics = default
+	:save-display main-verticals-default.screen
+
+	:set line-graphics = utf-8
+	:save-display main-verticals-utf8.screen
+'
+
+git_clone 'repo-one'
+
+test_tig
+
+assert_equals 'main-verticals-ascii.screen' <<EOF
+  1| 2010-04-07 05:37 +0000 Max Power   |  1| commit 5cb3412a5e06e506840495b91ac
+   | 2010-03-29 17:15 +0000 Jørgen Thy~ |   | Refs: [master], {origin/master}, {
+   | 2010-03-21 04:53 +0000 作者        |   | Author:     Max Power <power123@ex
+   | 2010-03-12 16:31 +0000 René Léves~ |   | AuthorDate: Wed Apr 7 05:37:40 201
+  5| 2010-03-04 04:09 +0000 A. U. Thor  |  5| Commit:     Committer <c.ommitter@
+   | 2010-02-23 15:46 +0000 Max Power   |   | CommitDate: Wed Apr 7 05:37:40 201
+   | 2010-02-15 03:24 +0000 Jørgen Thy~ |   |
+   | 2010-02-06 15:02 +0000 作者        |   |     Commit 10 E
+   | 2010-01-29 02:40 +0000 René Léves~ |
+ 10| 2010-01-20 14:18 +0000 A. U. Thor  |
+   | 2010-01-12 01:56 +0000 Max Power   |
+   | 2010-01-03 13:33 +0000 Jørgen Thy~ |
+   | 2009-12-26 01:11 +0000 作者        |
+   | 2009-12-17 12:49 +0000 René Léves~ |
+ 15| 2009-12-09 00:27 +0000 A. U. Thor  |
+   | 2009-11-30 12:05 +0000 Max Power   |
+[main] 5cb3412a5e06e506840495b91acc8832%|[diff] 5cb3412a5e06e506840495b91acc100%
+EOF
+
+assert_equals 'main-verticals-default.screen' <<EOF
+  1x 2010-04-07 05:37 +0000 Max Power   |  1x commit 5cb3412a5e06e506840495b91ac
+   x 2010-03-29 17:15 +0000 Jørgen Thy~ |   x Refs: [master], {origin/master}, {
+   x 2010-03-21 04:53 +0000 作者        |   x Author:     Max Power <power123@ex
+   x 2010-03-12 16:31 +0000 René Léves~ |   x AuthorDate: Wed Apr 7 05:37:40 201
+  5x 2010-03-04 04:09 +0000 A. U. Thor  |  5x Commit:     Committer <c.ommitter@
+   x 2010-02-23 15:46 +0000 Max Power   |   x CommitDate: Wed Apr 7 05:37:40 201
+   x 2010-02-15 03:24 +0000 Jørgen Thy~ |   x
+   x 2010-02-06 15:02 +0000 作者        |   x     Commit 10 E
+   x 2010-01-29 02:40 +0000 René Léves~ |
+ 10x 2010-01-20 14:18 +0000 A. U. Thor  |
+   x 2010-01-12 01:56 +0000 Max Power   |
+   x 2010-01-03 13:33 +0000 Jørgen Thy~ |
+   x 2009-12-26 01:11 +0000 作者        |
+   x 2009-12-17 12:49 +0000 René Léves~ |
+ 15x 2009-12-09 00:27 +0000 A. U. Thor  |
+   x 2009-11-30 12:05 +0000 Max Power   |
+[main] 5cb3412a5e06e506840495b91acc8832%|[diff] 5cb3412a5e06e506840495b91acc100%
+EOF
+
+assert_equals 'main-verticals-utf8.screen' <<EOF
+  1│ 2010-04-07 05:37 +0000 Max Power   |  1│ commit 5cb3412a5e06e506840495b91ac
+   │ 2010-03-29 17:15 +0000 Jørgen Thy~ |   │ Refs: [master], {origin/master}, {
+   │ 2010-03-21 04:53 +0000 作者        |   │ Author:     Max Power <power123@ex
+   │ 2010-03-12 16:31 +0000 René Léves~ |   │ AuthorDate: Wed Apr 7 05:37:40 201
+  5│ 2010-03-04 04:09 +0000 A. U. Thor  |  5│ Commit:     Committer <c.ommitter@
+   │ 2010-02-23 15:46 +0000 Max Power   |   │ CommitDate: Wed Apr 7 05:37:40 201
+   │ 2010-02-15 03:24 +0000 Jørgen Thy~ |   │
+   │ 2010-02-06 15:02 +0000 作者        |   │     Commit 10 E
+   │ 2010-01-29 02:40 +0000 René Léves~ |
+ 10│ 2010-01-20 14:18 +0000 A. U. Thor  |
+   │ 2010-01-12 01:56 +0000 Max Power   |
+   │ 2010-01-03 13:33 +0000 Jørgen Thy~ |
+   │ 2009-12-26 01:11 +0000 作者        |
+   │ 2009-12-17 12:49 +0000 René Léves~ |
+ 15│ 2009-12-09 00:27 +0000 A. U. Thor  |
+   │ 2009-11-30 12:05 +0000 Max Power   |
+[main] 5cb3412a5e06e506840495b91acc8832%|[diff] 5cb3412a5e06e506840495b91acc100%
+EOF


### PR DESCRIPTION
   Putty doesn't show VT100 line drawing characters in the UTF-8 mode by
   default. Putty 0.70 and older doesn't even have that option.
   
   For the vertical display separator, use '|' as background, then output
   the vertical line character on every line.
   
   For the line number separator, use draw_graphic() in the default mode
   only. Use draw_chars() in the ASCII and UTF-8 modes.
   
   Add a test for vertical lines. The display separator is always captured
   as a line of '|' characters. The line number separators are captured
   correctly. 'x' corresponds to ACS_VLINE.

   Closes #981
