### PR TITLE
Improve graph rendering in the default graphic mode

### DIFF
--- a/src/graph-v1.c
+++ b/src/graph-v1.c
@@ -396,11 +396,11 @@ graph_symbol_to_chtype(const struct graph_symbol *symbol)
 		if (symbol->boundary)
 			graphics[1] = 'o';
 		else if (symbol->initial)
-			graphics[1] = 'I';
+			graphics[1] = '@';
 		else if (symbol->merge)
-			graphics[1] = 'M';
+			graphics[1] = ACS_DIAMOND;
 		else
-			graphics[1] = 'o'; //ACS_DIAMOND; //'*';
+			graphics[1] = ACS_BULLET;
 		return graphics;
 	}
 

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -1096,11 +1096,11 @@ graph_symbol_to_chtype(const struct graph_symbol *symbol)
 		if (symbol->boundary)
 			graphics[1] = 'o';
 		else if (symbol->initial)
-			graphics[1] = 'I';
+			graphics[1] = '@';
 		else if (symbol->merge)
-			graphics[1] = 'M';
+			graphics[1] = ACS_DIAMOND;
 		else
-			graphics[1] = 'o'; //ACS_DIAMOND; //'*';
+			graphics[1] = ACS_BULLET;
 		return graphics;
 
 	} else if (graph_symbol_cross_merge(symbol)) {

--- a/test/main/author-name-change-test
+++ b/test/main/author-name-change-test
@@ -20,8 +20,8 @@ in_work_dir create_repo_from_tgz "$base_dir/files/repo-authornamechange.tgz"
 test_tig
 
 assert_equals 'main-default.screen' <<EOF
-2016-11-28 23:13 -0500 Mr. Hyde   o [master] Commit 2
-2016-11-28 23:13 -0500 Dr. Jekyll I Commit 1
+2016-11-28 23:13 -0500 Mr. Hyde   ~ [master] Commit 2
+2016-11-28 23:13 -0500 Dr. Jekyll @ Commit 1
  
 [main] 15c9cec4c9a64c560391c7e0bfb0913b908f9287 - commit 1 of 2             100%
 EOF

--- a/test/main/default-test
+++ b/test/main/default-test
@@ -36,74 +36,74 @@ git_clone 'repo-one'
 test_tig
 
 assert_equals 'main-default.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             28%
 EOF
 
 assert_equals 'main-ref-format.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o (master) @origin/master @origin/H
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o [v1.0] Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ (master) @origin/master @origin/H
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ [v1.0] Commit 8 B
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             28%
 EOF
 
 assert_equals 'main-remotes-hidden.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o (master) Commit 10 E
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o [v1.0] Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ (master) Commit 10 E
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ [v1.0] Commit 8 B
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             28%
 EOF
 
 assert_equals 'main-no-refs.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o Commit 10 E
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ Commit 10 E
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ Commit 8 B
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             28%
 EOF
 

--- a/test/main/emoji-test
+++ b/test/main/emoji-test
@@ -29,13 +29,13 @@ git_init
 test_case emoji-commit-titles-col-46 \
 	--subshell='export COLUMNS=46' \
 	<<EOF
-2009-04-06 01:44 +0000 Committer o [master] 🌏
-2009-03-28 13:22 +0000 Committer o 💄 Polish t
-2009-03-20 01:00 +0000 Committer o 📚 Document
-2009-03-11 12:38 +0000 Committer o 🎨 Reformat
-2009-03-03 00:15 +0000 Committer o ✨ Add new
-2009-02-22 11:53 +0000 Committer o 🐧 Fix Linu
-2009-02-13 23:31 +0000 Committer I 🚑 Fix bug
+2009-04-06 01:44 +0000 Committer ~ [master] 🌏
+2009-03-28 13:22 +0000 Committer ~ 💄 Polish t
+2009-03-20 01:00 +0000 Committer ~ 📚 Document
+2009-03-11 12:38 +0000 Committer ~ 🎨 Reformat
+2009-03-03 00:15 +0000 Committer ~ ✨ Add new
+2009-02-22 11:53 +0000 Committer ~ 🐧 Fix Linu
+2009-02-13 23:31 +0000 Committer @ 🚑 Fix bug
 
 [main] 50a10e108b44c34548b9ba9e318416b3027100%
 EOF
@@ -43,13 +43,13 @@ EOF
 test_case emoji-commit-titles-col-unset \
 	--subshell='unset COLUMNS' \
 	<<EOF
-2009-04-06 01:44 +0000 Committer o [master] 🌏💧✋🕋🗡🚀🏜☀️🌡🌶💯🚱⏳🌅🌑😡💉😱😈💀
-2009-03-28 13:22 +0000 Committer o 💄 Polish the UI
-2009-03-20 01:00 +0000 Committer o 📚 Document new feature
-2009-03-11 12:38 +0000 Committer o 🎨 Reformat the code
-2009-03-03 00:15 +0000 Committer o ✨ Add new feature
-2009-02-22 11:53 +0000 Committer o 🐧 Fix Linux issue
-2009-02-13 23:31 +0000 Committer I 🚑 Fix bug
+2009-04-06 01:44 +0000 Committer ~ [master] 🌏💧✋🕋🗡🚀🏜☀️🌡🌶💯🚱⏳🌅🌑😡💉😱😈💀
+2009-03-28 13:22 +0000 Committer ~ 💄 Polish the UI
+2009-03-20 01:00 +0000 Committer ~ 📚 Document new feature
+2009-03-11 12:38 +0000 Committer ~ 🎨 Reformat the code
+2009-03-03 00:15 +0000 Committer ~ ✨ Add new feature
+2009-02-22 11:53 +0000 Committer ~ 🐧 Fix Linux issue
+2009-02-13 23:31 +0000 Committer @ 🚑 Fix bug
 
 [main] 50a10e108b44c34548b9ba9e318416b3027a0627 - commit 1 of 7             100%
 EOF
@@ -57,13 +57,13 @@ EOF
 test_case emoji-commit-titles-col-300 \
 	--subshell='export COLUMNS=300' \
 	<<EOF
-2009-04-06 01:44 +0000 Committer o [master] 🌏💧✋🕋🗡🚀🏜☀️🌡🌶💯🚱⏳🌅🌑😡💉😱😈💀💥🌛🌙🐭💥🚶🏻〰🐛️⌛️👳🙏💥😴🛌😳💥🐛💥👊⚔👑
-2009-03-28 13:22 +0000 Committer o 💄 Polish the UI
-2009-03-20 01:00 +0000 Committer o 📚 Document new feature
-2009-03-11 12:38 +0000 Committer o 🎨 Reformat the code
-2009-03-03 00:15 +0000 Committer o ✨ Add new feature
-2009-02-22 11:53 +0000 Committer o 🐧 Fix Linux issue
-2009-02-13 23:31 +0000 Committer I 🚑 Fix bug
+2009-04-06 01:44 +0000 Committer ~ [master] 🌏💧✋🕋🗡🚀🏜☀️🌡🌶💯🚱⏳🌅🌑😡💉😱😈💀💥🌛🌙🐭💥🚶🏻〰🐛️⌛️👳🙏💥😴🛌😳💥🐛💥👊⚔👑
+2009-03-28 13:22 +0000 Committer ~ 💄 Polish the UI
+2009-03-20 01:00 +0000 Committer ~ 📚 Document new feature
+2009-03-11 12:38 +0000 Committer ~ 🎨 Reformat the code
+2009-03-03 00:15 +0000 Committer ~ ✨ Add new feature
+2009-02-22 11:53 +0000 Committer ~ 🐧 Fix Linux issue
+2009-02-13 23:31 +0000 Committer @ 🚑 Fix bug
 
 [main] 50a10e108b44c34548b9ba9e318416b3027a0627 - commit 1 of 7                                                                                                                                                                                                                                         100%
 EOF

--- a/test/main/filter-args-test
+++ b/test/main/filter-args-test
@@ -42,31 +42,31 @@ git log --encoding=UTF-8 --topo-order --exclude=refs/remotes/origin/* --exclude=
 EOF
 
 assert_equals 'filtered.screen' <<EOF
-2017-02-06 17:54 +0000 Committer          o [feature/x] Feature X
-2014-03-01 15:59 -0500 Jonas Fonseca      o Add type parameter for js.Dynamic
-2014-01-16 22:51 -0500 Jonas Fonseca      o Move classes under org.scalajs.bench
-2014-01-16 17:39 -0500 Jonas Fonseca      o Integrate app code into the benchmar
-2013-11-26 23:39 -0500 Jonas Fonseca      o Extract the benchmark list variable
-2013-11-26 23:22 -0500 Jonas Fonseca      o Disable phantomjs by default
-2013-11-26 22:52 -0500 Jonas Fonseca      o Fix reference setup to work for node
-2013-11-26 22:03 -0500 Jonas Fonseca      o Move benchmark registration to Scala
-2013-11-05 23:20 -0500 Jonas Fonseca      o Reformat code using Scala IDE
-2013-11-05 20:41 -0500 Jonas Fonseca      o Update exports.js files to use new S
-2013-11-03 23:48 -0500 Jonas Fonseca      o Add support for PhantomJS
-2013-11-03 23:11 -0500 Jonas Fonseca      o Make the engine stubs file optional
-2013-11-03 22:44 -0500 Jonas Fonseca      o Refactor the benchmark shell code
-2013-10-29 18:48 +0100 Sébastien Doeraene o Remove workaround to support Node.js
-2013-10-29 18:46 +0100 Sébastien Doeraene o Update for new groupId and package s
-2013-10-27 23:05 -0400 Jonas Fonseca      o Add JavaScript benchmark reference c
-2013-10-27 18:12 -0400 Jonas Fonseca      o Add check sum calculation for verify
-2013-10-26 12:54 -0400 Jonas Fonseca      o Add Scala.js LICENSE file and a cool
-2013-10-25 20:29 -0400 Jonas Fonseca      o Support node as a JavaScript engine
-2013-10-25 00:34 -0400 Jonas Fonseca      o Run benchmarks for a fixed number of
-2013-10-24 23:44 -0400 Jonas Fonseca      o Rework the benchmark runner and add
-2013-10-18 11:39 +0200 Sébastien Doeraene o Fix the "./run.sh opt" invocation.
-2013-10-17 20:29 -0400 Jonas Fonseca      o Simplify render scene loop by using
-2013-10-17 20:27 -0400 Jonas Fonseca      o Make the run shell script infrastruc
-2013-10-14 13:15 -0400 Jonas Fonseca      I Initial import of Tracer benchmark
+2017-02-06 17:54 +0000 Committer          ~ [feature/x] Feature X
+2014-03-01 15:59 -0500 Jonas Fonseca      ~ Add type parameter for js.Dynamic
+2014-01-16 22:51 -0500 Jonas Fonseca      ~ Move classes under org.scalajs.bench
+2014-01-16 17:39 -0500 Jonas Fonseca      ~ Integrate app code into the benchmar
+2013-11-26 23:39 -0500 Jonas Fonseca      ~ Extract the benchmark list variable
+2013-11-26 23:22 -0500 Jonas Fonseca      ~ Disable phantomjs by default
+2013-11-26 22:52 -0500 Jonas Fonseca      ~ Fix reference setup to work for node
+2013-11-26 22:03 -0500 Jonas Fonseca      ~ Move benchmark registration to Scala
+2013-11-05 23:20 -0500 Jonas Fonseca      ~ Reformat code using Scala IDE
+2013-11-05 20:41 -0500 Jonas Fonseca      ~ Update exports.js files to use new S
+2013-11-03 23:48 -0500 Jonas Fonseca      ~ Add support for PhantomJS
+2013-11-03 23:11 -0500 Jonas Fonseca      ~ Make the engine stubs file optional
+2013-11-03 22:44 -0500 Jonas Fonseca      ~ Refactor the benchmark shell code
+2013-10-29 18:48 +0100 Sébastien Doeraene ~ Remove workaround to support Node.js
+2013-10-29 18:46 +0100 Sébastien Doeraene ~ Update for new groupId and package s
+2013-10-27 23:05 -0400 Jonas Fonseca      ~ Add JavaScript benchmark reference c
+2013-10-27 18:12 -0400 Jonas Fonseca      ~ Add check sum calculation for verify
+2013-10-26 12:54 -0400 Jonas Fonseca      ~ Add Scala.js LICENSE file and a cool
+2013-10-25 20:29 -0400 Jonas Fonseca      ~ Support node as a JavaScript engine
+2013-10-25 00:34 -0400 Jonas Fonseca      ~ Run benchmarks for a fixed number of
+2013-10-24 23:44 -0400 Jonas Fonseca      ~ Rework the benchmark runner and add
+2013-10-18 11:39 +0200 Sébastien Doeraene ~ Fix the "./run.sh opt" invocation.
+2013-10-17 20:29 -0400 Jonas Fonseca      ~ Simplify render scene loop by using
+2013-10-17 20:27 -0400 Jonas Fonseca      ~ Make the run shell script infrastruc
+2013-10-14 13:15 -0400 Jonas Fonseca      @ Initial import of Tracer benchmark
  
  
  

--- a/test/main/jump-ends-test
+++ b/test/main/jump-ends-test
@@ -6,14 +6,14 @@
 export LINES=5
 
 first_line_content=\
-'2014-03-01 17:26 -0500 Jonas Fonseca      o [master] WIP: Upgrade to 0.4-SNAPSHO
-2014-03-01 15:59 -0500 Jonas Fonseca      o Add type parameter for js.Dynamic
-2014-01-16 22:51 -0500 Jonas Fonseca      o Move classes under org.scalajs.bench
+'2014-03-01 17:26 -0500 Jonas Fonseca      ~ [master] WIP: Upgrade to 0.4-SNAPSHO
+2014-03-01 15:59 -0500 Jonas Fonseca      ~ Add type parameter for js.Dynamic
+2014-01-16 22:51 -0500 Jonas Fonseca      ~ Move classes under org.scalajs.bench
 [main] ee912870202200a0b9cf4fd86ba57243212d341e - commit 1 of 48              6%'
 
 last_line_content=\
-'2013-10-14 16:09 -0400 Jonas Fonseca      o Move description of the optimizeJS w
-2013-10-14 13:15 -0400 Jonas Fonseca      I Initial import of Tracer benchmark
+'2013-10-14 16:09 -0400 Jonas Fonseca      ~ Move description of the optimizeJS w
+2013-10-14 13:15 -0400 Jonas Fonseca      @ Initial import of Tracer benchmark
  
 [main] 90286e0752016a6bca30dfa7ca236d1f99345eb8 - commit 48 of 48           100%'
 

--- a/test/main/mailmap-test
+++ b/test/main/mailmap-test
@@ -32,19 +32,19 @@ steps '
 test_tig
 
 assert_equals 'mailmapped.screen' <<EOF
-2010-04-07 05:37 +0000 Full Throttle o [master] {origin/master} {origin/HEAD} Co
-2010-03-29 17:15 +0000 Stargazer     o Commit 10 D
-2010-03-21 04:53 +0000 龙            o Commit 10 C
-2010-03-12 16:31 +0000 Ti-Poil       o Commit 10 B
-2010-03-04 04:09 +0000 Thoreau       o Commit 10 A
-2010-02-23 15:46 +0000 Full Throttle o Commit 9 E
-2010-02-15 03:24 +0000 Stargazer     o Commit 9 D
-2010-02-06 15:02 +0000 龙            o Commit 9 C
-2010-01-29 02:40 +0000 Ti-Poil       o Commit 9 B
-2010-01-20 14:18 +0000 Thoreau       o Commit 9 A
-2010-01-12 01:56 +0000 Full Throttle o Commit 8 E
-2010-01-03 13:33 +0000 Stargazer     o Commit 8 D
-2009-12-26 01:11 +0000 龙            o Commit 8 C
+2010-04-07 05:37 +0000 Full Throttle ~ [master] {origin/master} {origin/HEAD} Co
+2010-03-29 17:15 +0000 Stargazer     ~ Commit 10 D
+2010-03-21 04:53 +0000 龙            ~ Commit 10 C
+2010-03-12 16:31 +0000 Ti-Poil       ~ Commit 10 B
+2010-03-04 04:09 +0000 Thoreau       ~ Commit 10 A
+2010-02-23 15:46 +0000 Full Throttle ~ Commit 9 E
+2010-02-15 03:24 +0000 Stargazer     ~ Commit 9 D
+2010-02-06 15:02 +0000 龙            ~ Commit 9 C
+2010-01-29 02:40 +0000 Ti-Poil       ~ Commit 9 B
+2010-01-20 14:18 +0000 Thoreau       ~ Commit 9 A
+2010-01-12 01:56 +0000 Full Throttle ~ Commit 8 E
+2010-01-03 13:33 +0000 Stargazer     ~ Commit 8 D
+2009-12-26 01:11 +0000 龙            ~ Commit 8 C
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             26%
 EOF
 

--- a/test/main/main-options-test
+++ b/test/main/main-options-test
@@ -20,16 +20,16 @@ git_clone 'repo-one'
 test_tig
 
 assert_equals 'with-10-lines.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
  
  
  

--- a/test/main/refresh-periodic-test
+++ b/test/main/refresh-periodic-test
@@ -41,36 +41,36 @@ test_timeout 30
 test_tig
 
 assert_equals 'main-with-unstaged.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
  
 [main] Unstaged changes                                                     100%
 EOF
 
 assert_equals 'main-after-add-a.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 [main] Unstaged changes                                                     100%
 EOF
 
 assert_equals 'main-after-commit.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-22 11:53 +0000 Committer  o [master] Commit changes
-2009-02-13 23:31 +0000 A. U. Thor I Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-22 11:53 +0000 Committer  ~ [master] Commit changes
+2009-02-13 23:31 +0000 A. U. Thor @ Initial commit
 [main] Unstaged changes                                                     100%
 EOF
 
 assert_equals 'main-after-commiting-change-and-sleeping-hello.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-22 11:53 +0000 Committer  o [master] Another change: hello
-2009-02-22 11:53 +0000 Committer  o Commit changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-22 11:53 +0000 Committer  ~ [master] Another change: hello
+2009-02-22 11:53 +0000 Committer  ~ Commit changes
 [main] Unstaged changes                                                      75%
 EOF
 
 assert_equals 'main-after-commiting-change-and-sleeping-world.screen' <<EOF
-2009-02-22 11:53 +0000 Committer  o [master] Another change: world
-2009-02-22 11:53 +0000 Committer  o Another change: hello
-2009-02-22 11:53 +0000 Committer  o Commit changes
+2009-02-22 11:53 +0000 Committer  ~ [master] Another change: world
+2009-02-22 11:53 +0000 Committer  ~ Another change: hello
+2009-02-22 11:53 +0000 Committer  ~ Commit changes
 [main] 70bab5b220d2fd9bf61c125d52d59e10e93ec341 - commit 1 of 4              75%
 EOF

--- a/test/main/refresh-test
+++ b/test/main/refresh-test
@@ -40,49 +40,49 @@ export GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
 test_tig
 
 assert_equals 'main-with-unstaged.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 [main] Unstaged changes                                                     100%
 EOF
 
 assert_equals 'main-after-add-a.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 [main] Unstaged changes                                                     100%
 EOF
 
 assert_equals 'main-after-add-all.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 [main] Staged changes                                                       100%
 EOF
 
 assert_equals 'main-after-commit.screen' <<EOF
-2009-02-22 11:53 +0000 Committer  o [master] Commit changes
-2009-02-13 23:31 +0000 A. U. Thor I Initial commit
+2009-02-22 11:53 +0000 Committer  ~ [master] Commit changes
+2009-02-13 23:31 +0000 A. U. Thor @ Initial commit
 
 [main] 559565d219fd061c3cec4f2071025374533bdfc6 - commit 1 of 2             100%
 EOF
 
 assert_equals 'main-after-reset-soft.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 [main] Staged changes                                                       100%
 EOF
 
 assert_equals 'main-after-reset-a-and-bc.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 [main] Unstaged changes                                                     100%
 EOF
 
 assert_equals 'main-after-reset-hard.screen' <<EOF
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 [main] ca34b8bb5a0034fc5b5ab9840f74cae1fab2c3a9 - commit 1 of 1             100%

--- a/test/main/search-test
+++ b/test/main/search-test
@@ -37,145 +37,145 @@ git_clone 'repo-one'
 test_tig
 
 assert_equals 'main-search-author.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 8d53d6a41f8540749c0db5d0b53e48d2f178dce4 - commit 3 of 50             28%
 EOF
 
 assert_equals 'main-search-author-empty.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 711615619913109be8fd85f2c378839acaa6db11 - commit 8 of 50             28%
 EOF
 
 assert_equals 'main-search-author-find-next.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] b45b5704c34dbd4c5fd89d58d45238ad136ae166 - commit 13 of 50            28%
 EOF
 
 assert_equals 'main-search-title.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 99278700109ac9fe4a80bbc1e5b26769e3614f1b - commit 9 of 50             28%
 EOF
 
 assert_equals 'main-search-title-no-match.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 99278700109ac9fe4a80bbc1e5b26769e3614f1b - commit 9 of 50             28%
 EOF
 
 assert_equals 'main-search-refs.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 957f2b368e6fa5c0757f36b1441e32729ee5e9c7 - commit 14 of 50            28%
 EOF
 
 assert_equals 'main-search-time.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 545eb1fa92b902b6799e2a1691419c3158254a0a - commit 12 of 50            28%
 EOF
 
 assert_equals 'main-search-smart-case.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D
-2009-12-26 01:11 +0000 作者                  o Commit 8 C
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B
 [main] 19455fa3642af6a6a7d527dd043caf5a70eaad2d - commit 5 of 50             28%
 EOF

--- a/test/main/show-changes-after-rename-test
+++ b/test/main/show-changes-after-rename-test
@@ -26,7 +26,7 @@ test_setup_work_dir() {
 test_tig
 
 assert_equals 'default.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown   o Staged changes
-2009-02-13 23:31 +0000 Committer I [master] commit1
+$YYY_MM_DD_HH_MM +0000 Unknown   ~ Staged changes
+2009-02-13 23:31 +0000 Committer @ [master] commit1
 [main] Staged changes                                                       100%
 EOF

--- a/test/main/show-changes-test
+++ b/test/main/show-changes-test
@@ -56,8 +56,8 @@ in_work_dir create_dirty_workdir
 test_tig
 
 assert_equals 'main-with-unstaged.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 
@@ -74,8 +74,8 @@ $YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
 EOF
 
 assert_equals 'main-with-unstaged-split.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 [main] Unstaged changes                                                     100%
@@ -92,9 +92,9 @@ index e697dfd..9d8ef3d 100644
 EOF
 
 assert_equals 'main-with-unstaged-and-staged-split.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 [main] Unstaged changes                                                     100%
  .j  | 6 ++----
@@ -110,8 +110,8 @@ index e697dfd..9d8ef3d 100644
 EOF
 
 assert_equals 'main-with-staged.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 
@@ -128,8 +128,8 @@ $YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
 EOF
 
 assert_equals 'main-with-staged-split.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 [main] Staged changes                                                       100%
@@ -146,9 +146,9 @@ index e697dfd..9d8ef3d 100644
 EOF
 
 assert_equals 'main-with-staged-and-unstaged.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 
@@ -164,8 +164,8 @@ $YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
 EOF
 
 assert_equals 'main-with-renamed.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 
@@ -182,12 +182,12 @@ $YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
 EOF
 
 assert_equals 'main-with-conflict.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-03-11 12:38 +0000 Committer  o [conflict-master] Change: c'
-2009-03-03 00:15 +0000 Committer  o Change: c
-2009-02-22 11:53 +0000 Committer  o [master] Change: b
-2009-02-13 23:31 +0000 Committer  o Change: a
-2009-02-13 23:31 +0000 A. U. Thor I Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-03-11 12:38 +0000 Committer  ~ [conflict-master] Change: c'
+2009-03-03 00:15 +0000 Committer  ~ Change: c
+2009-02-22 11:53 +0000 Committer  ~ [master] Change: b
+2009-02-13 23:31 +0000 Committer  ~ Change: a
+2009-02-13 23:31 +0000 A. U. Thor @ Initial commit
 
 
 

--- a/test/main/untracked-test
+++ b/test/main/untracked-test
@@ -23,10 +23,10 @@ in_work_dir touch z
 test_tig
 
 assert_equals 'start.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Untracked changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Untracked changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 
@@ -45,10 +45,10 @@ $YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
 EOF
 
 assert_equals 'result.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Untracked changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-$YYY_MM_DD_HH_MM +0000 Unknown    o Staged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Untracked changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Staged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 
 [main] Untracked changes                                                    100%

--- a/test/main/update-unstaged-changes-test
+++ b/test/main/update-unstaged-changes-test
@@ -26,8 +26,8 @@ in_work_dir create_dirty_workdir
 test_tig
 
 assert_equals 'start.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
 
 [main] Unstaged changes                                                     100%
 EOF

--- a/test/main/view-split-test
+++ b/test/main/view-split-test
@@ -69,11 +69,11 @@ assert_equals 'main-vsplit-25-75.screen' <<EOF
 EOF
 
 assert_equals 'main-hsplit-default.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             10%
 commit 5cb3412a5e06e506840495b91acc885037a48b72
 Refs: [master], {origin/master}, {origin/HEAD}
@@ -89,14 +89,14 @@ CommitDate: Wed Apr 7 05:37:40 2010 +0000
 EOF
 
 assert_equals 'main-hsplit-50-50.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             16%
 commit 5cb3412a5e06e506840495b91acc885037a48b72
 Refs: [master], {origin/master}, {origin/HEAD}

--- a/test/refs/replace-test
+++ b/test/refs/replace-test
@@ -59,21 +59,21 @@ d9a8c8b 2009-10-18 22:14 +0000 Max Power     not-replace    Commit 6 E
 EOF
 
 assert_equals 'main.screen' <<EOF
-5cb3412 2010-04-07 05:37 +0000 Max Power             o [master] {origin/master}
-2843bfd 2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-8d53d6a 2010-03-21 04:53 +0000 作者                  o Commit 10 C
-51b7580 2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-19455fa 2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-276c3a4 2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-5633519 2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-7116156 2010-02-06 15:02 +0000 作者                  o Commit 9 C
-9927870 2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
-a3f25ca 2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A
-d9a8c8b 2009-10-18 22:14 +0000 Max Power             o ~not-replace~ Commit 6 E
-02e1e72 2009-10-10 09:52 +0000 Jørgen Thygesen Brahe o Commit 6 D
-5d9d565 2009-09-23 09:07 +0000 René Lévesque         o ~replaced~ Commit 6 B
-2ba9ed5 2009-09-14 20:45 +0000 A. U. Thor            o Commit 6 A
-2053940 2009-07-25 18:32 +0000 Max Power             o ~replaced~ Commit 4 E
-ceac6c2 2009-07-17 06:10 +0000 Jørgen Thygesen Brahe o Commit 4 D
+5cb3412 2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master}
+2843bfd 2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+8d53d6a 2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+51b7580 2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+19455fa 2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+276c3a4 2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+5633519 2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+7116156 2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+9927870 2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
+a3f25ca 2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A
+d9a8c8b 2009-10-18 22:14 +0000 Max Power             ~ ~not-replace~ Commit 6 E
+02e1e72 2009-10-10 09:52 +0000 Jørgen Thygesen Brahe ~ Commit 6 D
+5d9d565 2009-09-23 09:07 +0000 René Lévesque         ~ ~replaced~ Commit 6 B
+2ba9ed5 2009-09-14 20:45 +0000 A. U. Thor            ~ Commit 6 A
+2053940 2009-07-25 18:32 +0000 Max Power             ~ ~replaced~ Commit 4 E
+ceac6c2 2009-07-17 06:10 +0000 Jørgen Thygesen Brahe ~ Commit 4 D
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 34             47%
 EOF

--- a/test/regressions/github-390-test
+++ b/test/regressions/github-390-test
@@ -31,11 +31,11 @@ test_setup_work_dir() {
 test_tig
 
 assert_equals 'initial.screen' <<EOF
-2009-02-13 23:31 +0000 Committer I [master] {origin/master} {origin/HEAD} committed
+2009-02-13 23:31 +0000 Committer @ [master] {origin/master} {origin/HEAD} committed
 [main] 6b55d08be93000f4bdf67f74177ab14f590910d4 - commit 1 of 1                       100%
 EOF
 
 assert_equals 'tagged.screen' <<EOF
-2009-02-13 23:31 +0000 Committer I [master] {origin/master} {origin/HEAD} <Marke> committe
+2009-02-13 23:31 +0000 Committer @ [master] {origin/master} {origin/HEAD} <Marke> committe
 [main] 6b55d08be93000f4bdf67f74177ab14f590910d4 - commit 1 of 1                       100%
 EOF

--- a/test/regressions/github-434-test
+++ b/test/regressions/github-434-test
@@ -27,47 +27,47 @@ git_clone 'repo-one'
 test_tig
 
 assert_equals 'vsplit-auto.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/|commit 5cb3412a5e06e506840495b91acc885037a48b72
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D                      |Refs: [master], {origin/master}, {origin/HEAD}
-2010-03-21 04:53 +0000 作者                  o Commit 10 C                      |Author:     Max Power <power123@example.org>
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B                      |AuthorDate: Wed Apr 7 05:37:40 2010 +0000
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A                      |Commit:     Committer <c.ommitter@example.net>
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E                       |CommitDate: Wed Apr 7 05:37:40 2010 +0000
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D                       |
-2010-02-06 15:02 +0000 作者                  o Commit 9 C                       |    Commit 10 E
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B                       |
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A                       |
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E                       |
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D                       |
-2009-12-26 01:11 +0000 作者                  o Commit 8 C                       |
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B                |
-2009-12-09 00:27 +0000 A. U. Thor            o Commit 8 A                       |
-2009-11-30 12:05 +0000 Max Power             o Commit 7 E                       |
-2009-11-21 23:43 +0000 Jørgen Thygesen Brahe o Commit 7 D                       |
-2009-11-13 11:20 +0000 作者                  o Commit 7 C                       |
-2009-11-04 22:58 +0000 René Lévesque         o Commit 7 B                       |
-2009-10-27 10:36 +0000 A. U. Thor            o Commit 7 A                       |
-2009-10-18 22:14 +0000 Max Power             o Commit 6 E                       |
-2009-10-10 09:52 +0000 Jørgen Thygesen Brahe o Commit 6 D                       |
-2009-10-01 21:30 +0000 作者                  o Commit 6 C                       |
-2009-09-23 09:07 +0000 René Lévesque         o Commit 6 B                       |
-2009-09-14 20:45 +0000 A. U. Thor            o Commit 6 A                       |
-2009-09-06 08:23 +0000 Max Power             o Commit 5 E                       |
-2009-08-28 20:01 +0000 Jørgen Thygesen Brahe o Commit 5 D                       |
-2009-08-20 07:39 +0000 作者                  o Commit 5 C                       |
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/|commit 5cb3412a5e06e506840495b91acc885037a48b72
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D                      |Refs: [master], {origin/master}, {origin/HEAD}
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C                      |Author:     Max Power <power123@example.org>
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B                      |AuthorDate: Wed Apr 7 05:37:40 2010 +0000
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A                      |Commit:     Committer <c.ommitter@example.net>
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E                       |CommitDate: Wed Apr 7 05:37:40 2010 +0000
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D                       |
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C                       |    Commit 10 E
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B                       |
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A                       |
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E                       |
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D                       |
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C                       |
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B                |
+2009-12-09 00:27 +0000 A. U. Thor            ~ Commit 8 A                       |
+2009-11-30 12:05 +0000 Max Power             ~ Commit 7 E                       |
+2009-11-21 23:43 +0000 Jørgen Thygesen Brahe ~ Commit 7 D                       |
+2009-11-13 11:20 +0000 作者                  ~ Commit 7 C                       |
+2009-11-04 22:58 +0000 René Lévesque         ~ Commit 7 B                       |
+2009-10-27 10:36 +0000 A. U. Thor            ~ Commit 7 A                       |
+2009-10-18 22:14 +0000 Max Power             ~ Commit 6 E                       |
+2009-10-10 09:52 +0000 Jørgen Thygesen Brahe ~ Commit 6 D                       |
+2009-10-01 21:30 +0000 作者                  ~ Commit 6 C                       |
+2009-09-23 09:07 +0000 René Lévesque         ~ Commit 6 B                       |
+2009-09-14 20:45 +0000 A. U. Thor            ~ Commit 6 A                       |
+2009-09-06 08:23 +0000 Max Power             ~ Commit 5 E                       |
+2009-08-28 20:01 +0000 Jørgen Thygesen Brahe ~ Commit 5 D                       |
+2009-08-20 07:39 +0000 作者                  ~ Commit 5 C                       |
 [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             56%|[diff] 5cb3412a5e06e506840495b91acc885037a48b72 - line 1 of 8              100%
 EOF
 
 assert_equals 'hsplit.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/HEAD} Commit 10 E
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D
-2010-03-21 04:53 +0000 作者                  o Commit 10 C
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/HEAD} Commit 10 E
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B
 [main] 2843bfd58b98c7e23ab91e51ffa4db4f8e27c9a4 - commit 2 of 50                                                                                             18%
 commit 2843bfd58b98c7e23ab91e51ffa4db4f8e27c9a4
 Author:     Jørgen Thygesen Brahe <brache@example.dk>
@@ -91,33 +91,33 @@ CommitDate: Mon Mar 29 17:15:30 2010 +0000
 EOF
 
 assert_equals 'vsplit.screen' <<EOF
-2010-04-07 05:37 +0000 Max Power             o [master] {origin/master} {origin/|commit 2843bfd58b98c7e23ab91e51ffa4db4f8e27c9a4
-2010-03-29 17:15 +0000 Jørgen Thygesen Brahe o Commit 10 D                      |Author:     Jørgen Thygesen Brahe <brache@example.dk>
-2010-03-21 04:53 +0000 作者                  o Commit 10 C                      |AuthorDate: Mon Mar 29 17:15:30 2010 +0000
-2010-03-12 16:31 +0000 René Lévesque         o Commit 10 B                      |Commit:     Committer <c.ommitter@example.net>
-2010-03-04 04:09 +0000 A. U. Thor            o Commit 10 A                      |CommitDate: Mon Mar 29 17:15:30 2010 +0000
-2010-02-23 15:46 +0000 Max Power             o Commit 9 E                       |
-2010-02-15 03:24 +0000 Jørgen Thygesen Brahe o Commit 9 D                       |    Commit 10 D
-2010-02-06 15:02 +0000 作者                  o Commit 9 C                       |
-2010-01-29 02:40 +0000 René Lévesque         o Commit 9 B                       |
-2010-01-20 14:18 +0000 A. U. Thor            o Commit 9 A                       |
-2010-01-12 01:56 +0000 Max Power             o Commit 8 E                       |
-2010-01-03 13:33 +0000 Jørgen Thygesen Brahe o Commit 8 D                       |
-2009-12-26 01:11 +0000 作者                  o Commit 8 C                       |
-2009-12-17 12:49 +0000 René Lévesque         o <v1.0> Commit 8 B                |
-2009-12-09 00:27 +0000 A. U. Thor            o Commit 8 A                       |
-2009-11-30 12:05 +0000 Max Power             o Commit 7 E                       |
-2009-11-21 23:43 +0000 Jørgen Thygesen Brahe o Commit 7 D                       |
-2009-11-13 11:20 +0000 作者                  o Commit 7 C                       |
-2009-11-04 22:58 +0000 René Lévesque         o Commit 7 B                       |
-2009-10-27 10:36 +0000 A. U. Thor            o Commit 7 A                       |
-2009-10-18 22:14 +0000 Max Power             o Commit 6 E                       |
-2009-10-10 09:52 +0000 Jørgen Thygesen Brahe o Commit 6 D                       |
-2009-10-01 21:30 +0000 作者                  o Commit 6 C                       |
-2009-09-23 09:07 +0000 René Lévesque         o Commit 6 B                       |
-2009-09-14 20:45 +0000 A. U. Thor            o Commit 6 A                       |
-2009-09-06 08:23 +0000 Max Power             o Commit 5 E                       |
-2009-08-28 20:01 +0000 Jørgen Thygesen Brahe o Commit 5 D                       |
-2009-08-20 07:39 +0000 作者                  o Commit 5 C                       |
+2010-04-07 05:37 +0000 Max Power             ~ [master] {origin/master} {origin/|commit 2843bfd58b98c7e23ab91e51ffa4db4f8e27c9a4
+2010-03-29 17:15 +0000 Jørgen Thygesen Brahe ~ Commit 10 D                      |Author:     Jørgen Thygesen Brahe <brache@example.dk>
+2010-03-21 04:53 +0000 作者                  ~ Commit 10 C                      |AuthorDate: Mon Mar 29 17:15:30 2010 +0000
+2010-03-12 16:31 +0000 René Lévesque         ~ Commit 10 B                      |Commit:     Committer <c.ommitter@example.net>
+2010-03-04 04:09 +0000 A. U. Thor            ~ Commit 10 A                      |CommitDate: Mon Mar 29 17:15:30 2010 +0000
+2010-02-23 15:46 +0000 Max Power             ~ Commit 9 E                       |
+2010-02-15 03:24 +0000 Jørgen Thygesen Brahe ~ Commit 9 D                       |    Commit 10 D
+2010-02-06 15:02 +0000 作者                  ~ Commit 9 C                       |
+2010-01-29 02:40 +0000 René Lévesque         ~ Commit 9 B                       |
+2010-01-20 14:18 +0000 A. U. Thor            ~ Commit 9 A                       |
+2010-01-12 01:56 +0000 Max Power             ~ Commit 8 E                       |
+2010-01-03 13:33 +0000 Jørgen Thygesen Brahe ~ Commit 8 D                       |
+2009-12-26 01:11 +0000 作者                  ~ Commit 8 C                       |
+2009-12-17 12:49 +0000 René Lévesque         ~ <v1.0> Commit 8 B                |
+2009-12-09 00:27 +0000 A. U. Thor            ~ Commit 8 A                       |
+2009-11-30 12:05 +0000 Max Power             ~ Commit 7 E                       |
+2009-11-21 23:43 +0000 Jørgen Thygesen Brahe ~ Commit 7 D                       |
+2009-11-13 11:20 +0000 作者                  ~ Commit 7 C                       |
+2009-11-04 22:58 +0000 René Lévesque         ~ Commit 7 B                       |
+2009-10-27 10:36 +0000 A. U. Thor            ~ Commit 7 A                       |
+2009-10-18 22:14 +0000 Max Power             ~ Commit 6 E                       |
+2009-10-10 09:52 +0000 Jørgen Thygesen Brahe ~ Commit 6 D                       |
+2009-10-01 21:30 +0000 作者                  ~ Commit 6 C                       |
+2009-09-23 09:07 +0000 René Lévesque         ~ Commit 6 B                       |
+2009-09-14 20:45 +0000 A. U. Thor            ~ Commit 6 A                       |
+2009-09-06 08:23 +0000 Max Power             ~ Commit 5 E                       |
+2009-08-28 20:01 +0000 Jørgen Thygesen Brahe ~ Commit 5 D                       |
+2009-08-20 07:39 +0000 作者                  ~ Commit 5 C                       |
 [main] 2843bfd58b98c7e23ab91e51ffa4db4f8e27c9a4 - commit 2 of 50             56%|[diff] 2843bfd58b98c7e23ab91e51ffa4db4f8e27c9a4 - line 1 of 7              100%
 EOF

--- a/test/stage/maximized-unstaged-changes-test
+++ b/test/stage/maximized-unstaged-changes-test
@@ -30,8 +30,8 @@ in_work_dir create_dirty_workdir
 test_tig
 
 assert_equals 'split.screen' <<EOF
-$YYY_MM_DD_HH_MM +0000 Unknown    o Unstaged changes
-2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+$YYY_MM_DD_HH_MM +0000 Unknown    ~ Unstaged changes
+2009-02-13 23:31 +0000 A. U. Thor @ [master] Initial commit
  
 [main] Unstaged changes                                                     100%
  .j  | 6 ++----


### PR DESCRIPTION
```
*  Improve graph rendering in the default graphic mode
   
   Using the same symbol for ordinary and boundary commits is misleading.
   Keep 'o' for boundary commits only, it's similar to other graphic modes.
   
   Use ACS_BULLET for ordinary commits, ACS_DIAMOND for merges and '@' for
   the initial commit, which is similar to the symbols used in the UTF-8
   graphic mode.
   
   Update tests for the new graph symbols. ACS_BULLET corresponds to '~' in
   the alternative charset.
```