### PR TITLE
Fix potential crash when executing commands in bindings

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -21,6 +21,7 @@ Bug fixes:
  - Fix crash on adding a line to a view. (#523)
  - Fix memory leak in diff unit.
  - Fix loop after refresh or change in refs/main split view. (#991)
+ - Fix occasional crash on custom key bindings. (#1001)
 
 tig-2.5.0
 ---------

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -1096,6 +1096,7 @@ exec_run_request(struct view *view, struct run_request *req)
 	char cmd[SIZEOF_MED_STR];
 	const char *req_argv[SIZEOF_ARG];
 	int req_argc = 0;
+	struct run_request_flags req_flags = req->flags;
 
 	if (!argv_to_string(req->argv, cmd, sizeof(cmd), " ")
 	    || !argv_from_string_no_quotes(req_argv, &req_argc, cmd)
@@ -1132,13 +1133,13 @@ exec_run_request(struct view *view, struct run_request *req)
 	free(argv);
 
 	if (request == REQ_NONE) {
-		if (req->flags.confirm && !confirmed)
+		if (req_flags.confirm && !confirmed)
 			request = REQ_NONE;
 
-		else if (req->flags.exit)
+		else if (req_flags.exit)
 			request = REQ_QUIT;
 
-		else if (!req->flags.internal && watch_dirty(&view->watch))
+		else if (!req_flags.internal && watch_dirty(&view->watch))
 			request = REQ_REFRESH;
 
 	}


### PR DESCRIPTION
The function `run_prompt_command` may reallocate the array `run_request`,
invalidating the pointer to the current request if it was inside
`run_request`. The resulting use-after-free would cause occasional crashes.
    
Fixes #1001