### PR TITLE
Fix parsing of three-way chunk headers with extra dashes

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -213,8 +213,9 @@ parse_chunk_header(struct chunk_header *header, const char *line)
 	if (!prefixcmp(line, "@@ -"))
 		line += STRING_SIZE("@@ -") - 1;
 	else if (!prefixcmp(line, "@@@") &&
-		 (line = strrchr(line, '-')))
-		/* Stay at that '-'. */ ;
+		 (line = strstr(line, " @@@")))
+		while (*line != '-')
+			line--;
 	else
 		return false;
 


### PR DESCRIPTION
This fixes a rare case of chunk line numbers not being computed
correctly.  It happens when a chunk marking a conflict contains a "-"
in its description:

	@@@ -45,7 -45,10 +45,14 @@@ void foo() { // -dash
