### PR TITLE
Don't error if git tab completion is not available. Fixes #1011

### DIFF
--- a/contrib/tig-completion.bash
+++ b/contrib/tig-completion.bash
@@ -98,7 +98,7 @@ fi
 
 # we use internal git-completion functions (if available), so wrap _tig for all necessary
 # variables (like cword and prev) to be defined
-if type '__git_complete' 2>/dev/null | grep -q 'function'; then
+if [ "$(type -t __git_complete)" = function ]; then
 	__git_complete tig _tig
 
 	# The following are necessary only for Cygwin, and only are needed

--- a/contrib/tig-completion.bash
+++ b/contrib/tig-completion.bash
@@ -28,6 +28,9 @@
 #       is performed while the script loads.  If git isn't found
 #       at source time then all lookups will be done on demand,
 #       which may be slightly slower.
+#
+#    4) This completion file depends on git completion already being
+#       loaded. Make sure git-completion.bash happens first.
 
 __tig_options="
 	-v --version
@@ -93,13 +96,15 @@ if [ -n "$ZSH_VERSION" ]; then
 	bashcompinit
 fi
 
-# we use internal git-completion functions, so wrap _tig for all necessary
+# we use internal git-completion functions (if available), so wrap _tig for all necessary
 # variables (like cword and prev) to be defined
-__git_complete tig _tig 
+if type '__git_complete' 2>/dev/null | grep -q 'function'; then
+	__git_complete tig _tig
 
-# The following are necessary only for Cygwin, and only are needed
-# when the user has tab-completed the executable name and consequently
-# included the '.exe' suffix.
-if [ Cygwin = "$(uname -o 2>/dev/null)" ]; then
-	__git_complete tig.exe _tig
+	# The following are necessary only for Cygwin, and only are needed
+	# when the user has tab-completed the executable name and consequently
+	# included the '.exe' suffix.
+	if [ Cygwin = "$(uname -o 2>/dev/null)" ]; then
+		__git_complete tig.exe _tig
+	fi
 fi


### PR DESCRIPTION
Seems like tab completion should always be a nice-to have, so made it just exit silently if git tab completions were not available. If you want I can make it print a friendly error message.

As is, users get a pretty mysterious:

```
-bash: __git_complete: command not found
$
```

And it is a little hard to know where it came from.

Fixes #1011 