### PR TITLE
Mention again that 'generic' keymap can be overridden

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -607,8 +607,9 @@ Keymaps::
 
 Valid keymaps are: *main*, *diff*, *log*, *reflog*, *help*, *pager*, *status*,
 *stage*, *tree*, *blob*, *blame*, *refs*, *stash*, *grep* and *generic*. Use
-*generic* to set key mapping in all keymaps. Use *search* to define keys for
-navigating search results during search.
+*generic* to set key mapping in all keymaps (which may still be overridden by a
+specific view keybinding). Use *search* to define keys for navigating search
+results during search.
 
 Key values::
 


### PR DESCRIPTION
There is a paragraph above to explain it in detail. However, redundancy
is not a bad thing in documentation IMO. In other words, I missed it
before.

Signed-off-by: Wolfram Sang <wsa@kernel.org>