### PR TITLE
Pass stash args through

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -10,6 +10,7 @@ Improvements:
  - Start blame of an uncommitted deleted line from HEAD so the line's origin can be traced. (#1008)
  - Add line-graphics = auto. (#834)
  - Allow maxwidth to be expressed in % of the view width.
+ - Pass stash args through. (#1022)
 
 Bug fixes:
 

--- a/doc/tig.1.adoc
+++ b/doc/tig.1.adoc
@@ -18,7 +18,7 @@ tig reflog [options] [revisions]
 tig blame  [options] [rev] [--] path
 tig grep   [options] [pattern]
 tig refs   [options]
-tig stash
+tig stash  [options]
 tig status
 tig <      [Git command output]
 _______________________________________________________________________

--- a/src/stash.c
+++ b/src/stash.c
@@ -20,7 +20,7 @@ static enum status_code
 stash_open(struct view *view, enum open_flags flags)
 {
 	static const char *stash_argv[] = { "git", "stash", "list",
-		encoding_arg, "--no-color", "--pretty=raw", NULL };
+		encoding_arg, "--no-color", "--pretty=raw", "%(revargs)", NULL };
 	struct main_state *state = view->private;
 
 	state->with_graph = false;
@@ -31,8 +31,12 @@ stash_open(struct view *view, enum open_flags flags)
 static void
 stash_select(struct view *view, struct line *line)
 {
+	struct main_state *state = view->private;
+
 	main_select(view, line);
-	string_format(view->env->stash, "stash@{%d}", line->lineno - 1);
+	assert(state->reflogs >= line->lineno);
+	string_ncopy(view->env->stash, state->reflog[line->lineno - 1] + STRING_SIZE("refs/"),
+		     strlen(state->reflog[line->lineno - 1]) - STRING_SIZE("refs/"));
 	string_copy(view->ref, view->env->stash);
 }
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -378,7 +378,7 @@ static const char usage_string[] =
 "   or: tig blame  [options] [rev] [--] path\n"
 "   or: tig grep   [options] [pattern]\n"
 "   or: tig refs   [options]\n"
-"   or: tig stash\n"
+"   or: tig stash  [options]\n"
 "   or: tig status\n"
 "   or: tig <      [git command output]\n"
 "\n"


### PR DESCRIPTION
As the stash reference does not necessarily match the line number anymore,
take it from the output of git stash list.

Closes #1022