### PR TITLE
Add direct repo URL to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,7 @@ Resources
  - Homepage:	https://jonas.github.io/tig/[]
  - Manual:	https://jonas.github.io/tig/doc/manual.html[]
  - Tarballs:	https://github.com/jonas/tig/releases[]
+ - Repository:	https://github.com/jonas/tig[]
  - Git URL:	git://github.com/jonas/tig.git
  - Gitter:	https://gitter.im/jonas/tig[]
  - Q&A:		https://stackoverflow.com/questions/tagged/tig[]


### PR DESCRIPTION
The most minor of contributions, but it seemed like a good idea, so that visitors don't have to go to the linked Releases or Issues pages and then click through to the repo homepage.