### PR TITLE
Zsh completion fixes

### DIFF
--- a/contrib/tig-completion.bash
+++ b/contrib/tig-completion.bash
@@ -86,13 +86,6 @@ _tig() {
 	esac
 }
 
-# Detect if current shell is ZSH, and if so, load this file in bash
-# compatibility mode.
-if [ -n "$ZSH_VERSION" ]; then
-	autoload bashcompinit
-	bashcompinit
-fi
-
 # we use internal git-completion functions, so wrap _tig for all necessary
 # variables (like cword and prev) to be defined
 __git_complete tig _tig 

--- a/contrib/tig-completion.bash
+++ b/contrib/tig-completion.bash
@@ -33,8 +33,6 @@ __tig_options="
 	-v --version
 	-h --help
 	-C
-	--
-	+
 "
 __tig_commands="
 	blame
@@ -47,38 +45,31 @@ __tig_commands="
 	show
 "
 
-_tig() {
+__tig_main () {
 	# parse already existing parameters
 	local i c=1 command
 	while [ $c -lt $cword ]; do
 		i="${words[c]}"
 		case "$i" in
 		--)	command="log"; break;;
+		-C)	return;;
 		-*)	;;
 		*)	command="$i"; break ;;
 		esac
 		c=$((++c))
 	done
 
-	# options -- only before command
-	case "$command$cur" in
-		-C*)
-			COMPREPLY=( $(compgen -d -P '-C' -- ${cur##-C}) )
-			return
-			;;
-	esac
-
 	# commands
 	case "$command" in
 		refs|status|stash)
-			COMPREPLY=( $(compgen -W "$__tig_options" -- "$cur") )
+			__gitcomp "$__tig_options"
 			;;
 		reflog)
 			__git_complete_command log
 			;;
 		"")
 			__git_complete_command log
-			__gitcompappend "$(compgen -W "$__tig_options $__tig_commands" -- "$cur")"
+			__gitcomp "$__tig_options $__tig_commands"
 			;;
 		*)
 			__git_complete_command $command
@@ -88,11 +79,11 @@ _tig() {
 
 # we use internal git-completion functions, so wrap _tig for all necessary
 # variables (like cword and prev) to be defined
-__git_complete tig _tig 
+__git_complete tig __tig_main
 
 # The following are necessary only for Cygwin, and only are needed
 # when the user has tab-completed the executable name and consequently
 # included the '.exe' suffix.
 if [ Cygwin = "$(uname -o 2>/dev/null)" ]; then
-	__git_complete tig.exe _tig
+	__git_complete tig.exe __tig_main
 fi

--- a/contrib/tig-completion.zsh
+++ b/contrib/tig-completion.zsh
@@ -10,17 +10,23 @@
 # then add following to your ~/.zshrc file:
 #
 #  fpath=(~/.zsh $fpath)
+#
+# You also need Git's Zsh completion installed:
+#
+# https://github.com/felipec/git-completion/blob/master/git-completion.zsh
 
 
 _tig () {
   local e
-  autoload -U bashcompinit && bashcompinit
-  e=$(dirname ${funcsourcetrace[1]%:*})/git-completion.bash
-  if [ -f $e ]; then
-    GIT_SOURCING_ZSH_COMPLETION=y . $e
-  fi
+
+  compdef _git tig
+
   e=$(dirname ${funcsourcetrace[1]%:*})/tig-completion.bash
   if [ -f $e ]; then
+    # Temporarily override __git_complete so the bash script doesn't complain
+    local old="$functions[__git_complete]"
+    functions[__git_complete]=:
     . $e
+    functions[__git_complete]="$old"
   fi
 }

--- a/contrib/tig-completion.zsh
+++ b/contrib/tig-completion.zsh
@@ -14,6 +14,7 @@
 
 _tig () {
   local e
+  autoload -U bashcompinit && bashcompinit
   e=$(dirname ${funcsourcetrace[1]%:*})/git-completion.bash
   if [ -f $e ]; then
     GIT_SOURCING_ZSH_COMPLETION=y . $e


### PR DESCRIPTION
There's a bunch of issues regarding the zsh completion:

* The Zsh bash completion emulation was loaded at the wrong time
* The Git bash completion helpers were not used correctly
* The Zsh bash completion emulation can't be relied upon

These changes should fix the issues mentioned in pull #960 and #940.