### PR TITLE
Disable ncurses extended key values so that esc-codes can be used in …

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -708,6 +708,17 @@ init_display(void)
 		use_scroll_redrawwin = true;
 		use_scroll_status_wclear = false;
 	}
+
+#if defined(NCURSES_EXT_FUNCS)
+    // Disable extended keys so that esc-codes will be received
+    // instead of extended key values (> KEY_MAX).
+    // Then these keys can be mapped in .tigrc etc.
+    int i;
+    for (i=KEY_MAX; i<2000; i++) {
+        keyok(i, false);
+    }
+#endif
+
 }
 
 static bool


### PR DESCRIPTION
…mappings for Shift/Ctrl/Alt Up/Dn/Lt/Rt/Hm/En/In/De/PgUp/PgDn

This is the other way to go, as compared to PR https://github.com/jonas/tig/pull/1048

thx,
-m