### PR TITLE
Use id column for commit id only

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -17,6 +17,7 @@ Bug fixes:
  - Fix wrapping of lines with multibyte characters. (#988)
  - Improve highlighting of search with $ regex. (#1000)
  - Update tracking branch when refreshing status view. (#1015)
+ - Use id column for commit id only. (#1025)
 
 tig-2.5.1
 ---------

--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -195,7 +195,6 @@ struct view_column_data {
 	const unsigned long *line_number;
 	const mode_t *mode;
 	const struct ref *ref;
-	const char *reflog;
 	const struct ref *refs;
 	const char *status;
 	const char *text;

--- a/src/draw.c
+++ b/src/draw.c
@@ -495,7 +495,7 @@ view_column_draw(struct view *view, struct line *line, unsigned int lineno)
 			continue;
 
 		case VIEW_COLUMN_ID:
-			if (draw_id(view, column, column_data.reflog ? column_data.reflog : column_data.id))
+			if (draw_id(view, column, column_data.id))
 				return true;
 			continue;
 

--- a/src/main.c
+++ b/src/main.c
@@ -364,8 +364,6 @@ main_get_column_data(struct view *view, const struct line *line, struct view_col
 	column_data->author = commit->author;
 	column_data->date = &commit->time;
 	column_data->id = commit->id;
-	if (state->reflogs)
-		column_data->reflog = state->reflog[line->lineno - 1];
 
 	column_data->commit_title = commit->title;
 	if (state->with_graph) {
@@ -587,9 +585,16 @@ main_select(struct view *view, struct line *line)
 		string_ncopy(view->ref, commit->title, strlen(commit->title));
 		status_stage_info(view->env->status, line->type, NULL);
 	} else {
+		struct main_state *state = view->private;
 		const struct ref *ref = main_get_commit_refs(line, commit);
 
-		string_copy_rev(view->ref, commit->id);
+		if (state->reflogs) {
+			assert(state->reflogs >= line->lineno);
+			string_ncopy(view->ref, state->reflog[line->lineno - 1],
+				     strlen(state->reflog[line->lineno - 1]));
+		} else {
+			string_copy_rev(view->ref, commit->id);
+		}
 		if (ref)
 			ref_update_env(view->env, ref, true);
 	}

--- a/src/view.c
+++ b/src/view.c
@@ -893,8 +893,6 @@ compare_view_column(enum view_column_type column, bool use_file_mode,
 		return apply_comparator(timecmp, column_data1->date, column_data2->date);
 
 	case VIEW_COLUMN_ID:
-		if (column_data1->reflog && column_data2->reflog)
-			return apply_comparator(strcmp, column_data1->reflog, column_data2->reflog);
 		return apply_comparator(strcmp, column_data1->id, column_data2->id);
 
 	case VIEW_COLUMN_FILE_NAME:
@@ -1054,7 +1052,7 @@ view_column_text(struct view *view, struct view_column_data *column_data,
 
 	case VIEW_COLUMN_ID:
 		if (column->opt.id.display)
-			text = column_data->reflog ? column_data->reflog : column_data->id;
+			text = column_data->id;
 		break;
 
 	case VIEW_COLUMN_LINE_NUMBER:
@@ -1492,7 +1490,7 @@ view_column_info_update(struct view *view, struct line *line)
 			width = column->opt.id.width;
 			if (!width)
 				width = opt_id_width;
-			if (!column_data.reflog && !width)
+			if (!width)
 				width = 7;
 			break;
 

--- a/test/reflog/default-test
+++ b/test/reflog/default-test
@@ -21,16 +21,16 @@ in_work_dir create_repo_from_tgz "$base_dir/files/refs-repo.tgz"
 test_tig reflog
 
 assert_equals 'reflog-default.screen' <<EOF
-HEAD@{0} [r1.1.2] [r1.1.x] <v1.1> checkout: moving from r1.0 to r1.1.2
-HEAD@{1} [r1.0] <v1.0> checkout: moving from master to r1.0
-HEAD@{2} [master] {max-power/master} {origin/HEAD} {origin/master} reset: moving
-HEAD@{3} [master] {max-power/master} {origin/HEAD} {origin/master} clone: from /
+b45b570 [r1.1.2] [r1.1.x] <v1.1> checkout: moving from r1.0 to r1.1.2
+957f2b3 [r1.0] <v1.0> checkout: moving from master to r1.0
+5cb3412 [master] {max-power/master} {origin/HEAD} {origin/master} reset: moving
+5cb3412 [master] {max-power/master} {origin/HEAD} {origin/master} clone: from /o
 
 
 
 
 
-[reflog] b45b5704c34dbd4c5fd89d58d45238ad136ae166 - reference 1 of 4        100%
+[reflog] HEAD@{0} - reference 1 of 4                                        100%
 2009-12-26 01:11 +0000 作者                  * [r1.1.2] [r1.1.x] <v1.1> Commit 8
 2009-12-17 12:49 +0000 René Lévesque         * [r1.0] <v1.0> Commit 8 B
 2009-12-09 00:27 +0000 A. U. Thor            * Commit 8 A


### PR DESCRIPTION
That way, you can better figure out identical references when browsing
the reflog view. Show the reflog name in the title window instead. In
the stash view, the id column also shows the commit id instead of the
reference.

Closes #1025