### PR TITLE
Fix for PR 1041 - add check for key_value != KEY_ESC

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -898,7 +898,7 @@ get_input(int prompt_position, struct key *key)
 			 * ASCII value.
 			 */
 			if (KEY_CTL('@') <= key_value && key_value <= KEY_CTL('_') &&
-			    key_value != KEY_RETURN && key_value != KEY_TAB) {
+			    key_value != KEY_RETURN && key_value != KEY_TAB && key_value != KEY_ESC) {
 				key->modifiers.control = 1;
 				key_value = key_value | 0x40;
 			}


### PR DESCRIPTION
This is a fix required since the PR of: https://github.com/jonas/tig/pull/1041
We need to also skip when key_value is KEY_ESC so it is not set to a control key.