### PR TITLE
Fix %(lineno) computation for hunk postimages that span only one line

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -222,7 +222,7 @@ parse_chunk_header(struct chunk_header *header, const char *line)
 	return  parse_ulong(&line, &header->old.position, '-', false) &&
 		parse_ulong(&line, &header->old.lines, ',', true) &&
 		parse_ulong(&line, &header->new.position, '+', false) &&
-		parse_ulong(&line, &header->new.lines, ',', false);
+		parse_ulong(&line, &header->new.lines, ',', true);
 }
 
 bool

--- a/test/diff/line-number-test
+++ b/test/diff/line-number-test
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export COLUMNS=40
+export LINES=3
+
+steps '
+	:view-diff
+	:move-last-line
+	:!echo %(lineno)
+	:save-display added-line-number.screen
+'
+
+
+git_init "$work_dir"
+
+test_setup_work_dir()
+{
+	git_commit --allow-empty-message
+	printf 'new line 1\n' > README.md
+	git add README.md
+}
+
+test_tig
+
+assert_equals 'added-line-number.screen' <<EOF
+1
+[pager] echo 1 - line 1 of 1 100%
+EOF


### PR DESCRIPTION
Usually diff hunk headers look like "@@ -a,b +c,d @@" where "a" is the
starting line number and "b" is the number of lines in the preimage of the
hunk. Same for "c" and "d" except they refer to lines in the postimage.

Git omits "b" and "d" if they are 1.  Tig already treated "b" as optional but
not "d". We can simply ignore a missing number because "header->new.lines"
is already initialized to 1 in parse_chunk_header().

	$ echo old line 1 >? old
	$ echo new line 1 >? new
	$ git diff --no-index old new | tail -n3
	@@ -1 +1 @@
	-old line 1
	+new line 1