### PR TITLE
Make functions static, or declare them in a header

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -329,7 +329,7 @@ blame_read(struct view *view, struct buffer *buf, bool force_stop)
 	return true;
 }
 
-bool
+static bool
 blame_get_column_data(struct view *view, const struct line *line, struct view_column_data *column_data)
 {
 	struct blame *blame = line->data;

--- a/src/graph-v1.c
+++ b/src/graph-v1.c
@@ -125,7 +125,7 @@ graph_insert_column(struct graph_v1 *graph, struct graph_row *row, size_t pos, c
 	return column;
 }
 
-bool
+static bool
 graph_add_parent(struct graph *graph_, const char *parent)
 {
 	struct graph_v1 *graph = graph_->private;

--- a/src/graph-v2.c
+++ b/src/graph-v2.c
@@ -115,7 +115,7 @@ struct id_color {
 	size_t color;
 };
 
-struct id_color *
+static struct id_color *
 id_color_new(const char *id, size_t color)
 {
 	struct id_color *node = malloc(sizeof(struct id_color));

--- a/src/help.c
+++ b/src/help.c
@@ -79,7 +79,7 @@ help_draw(struct view *view, struct line *line, unsigned int lineno)
 	return true;
 }
 
-bool
+static bool
 help_grep(struct view *view, struct line *line)
 {
 	struct help *help = line->data;
@@ -216,7 +216,7 @@ help_request(struct view *view, enum request request, struct line *line)
 	}
 }
 
-void
+static void
 help_select(struct view *view, struct line *line)
 {
 }

--- a/src/io.c
+++ b/src/io.c
@@ -420,7 +420,7 @@ io_run(struct io *io, enum io_type type, const char *dir, char * const env[], co
 	return io_exec(io, type, dir, env, argv, 0);
 }
 
-bool
+static bool
 io_complete(enum io_type type, const char **argv, const char *dir, int fd)
 {
 	struct io io;

--- a/src/pager.c
+++ b/src/pager.c
@@ -12,6 +12,7 @@
  */
 
 #include "tig/tig.h"
+#include "tig/pager.h"
 #include "tig/options.h"
 #include "tig/request.h"
 #include "tig/line.h"

--- a/src/stage.c
+++ b/src/stage.c
@@ -366,7 +366,7 @@ stage_chunk_is_wrapped(struct view *view, struct line *line)
 	return false;
 }
 
-bool
+static bool
 find_deleted_line_in_head(struct view *view, struct line *line) {
 	struct io io;
 	struct buffer buffer;

--- a/src/stash.c
+++ b/src/stash.c
@@ -44,7 +44,7 @@ stash_select(struct view *view, struct line *line)
 	string_copy(view->ref, view->env->stash);
 }
 
-enum request
+static enum request
 stash_request(struct view *view, enum request request, struct line *line)
 {
 	enum open_flags flags = (view_is_displayed(view) && request != REQ_VIEW_DIFF)

--- a/src/tig.c
+++ b/src/tig.c
@@ -705,7 +705,7 @@ sigsegv_handler(int sig)
 }
 #endif
 
-void
+static void
 sighup_handler(int sig)
 {
 	if (die_callback)
@@ -748,7 +748,7 @@ key_combo_handler(struct input *input, struct key *key)
 	return INPUT_STOP;
 }
 
-enum request
+static enum request
 read_key_combo(struct keymap *keymap)
 {
 	struct key_combo combo = { REQ_NONE, keymap, 0 };
@@ -764,7 +764,7 @@ die_if_failed(enum status_code code, const char *msg)
 		die("%s: %s", msg, get_status_message(code));
 }
 
-void
+static void
 hangup_children(void)
 {
 	if (signal(SIGHUP, SIG_IGN) == SIG_ERR)

--- a/src/tree.c
+++ b/src/tree.c
@@ -11,6 +11,7 @@
  * GNU General Public License for more details.
  */
 
+#include "tig/tree.h"
 #include "tig/util.h"
 #include "tig/repo.h"
 #include "tig/io.h"


### PR DESCRIPTION
Found with -Wmissing-declarations. Most of these were effectively static;
make that explicit.

tree.c wants to include tree.h for the declaration of open_blob_editor().
pager.c wants to include pager.h for pager_get_column_data() and others.