### PR TITLE
Allow to generate a compilation database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /node_modules/
 aclocal.m4
 autom4te.cache
+/compile_commands/
+/compile_commands.json
 config.h
 config.h.in
 config.log


### PR DESCRIPTION
This is useful for some Clang-based tools, in particular language servers like clangd or ccls.

I mostly took this mostly from Git's Makefile.  The awkward if-statement
is because the "missing_compdb_dir" trick that Git uses didn't work for
some reason.

Keep in mind that not all compilers support the -MJ option. Clang does, so this
command should give you a fresh compile_commands.json

	make CC=clang GENERATE_COMPILATION_DATABASE=yes clean all-debug