### PR TITLE
Use comparison instead of destructive assignment

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -373,10 +373,7 @@ diff_common_read(struct view *view, const char *data, struct diff_state *state)
 
 	} else if (opt_word_diff && state->reading_diff_chunk &&
 		   /* combined diff format is not using word diff */
-		   !state->combined_diff &&
-		   (type = LINE_DEFAULT ||
-		    /* ADD and DEL are only valid in regular diff hunks */
-		    type == LINE_DIFF_ADD || type == LINE_DIFF_DEL)) {
+		   !state->combined_diff) {
 		return diff_common_read_diff_wdiff(view, data);
 	}
 


### PR DESCRIPTION
I found this when working on the CI, running, see
https://builds.sr.ht/~krobelus/job/388884 which runs

	CC=clang TIG_BUILD=config.make tools/travis.sh

The warning from clang was:

	src/diff.c:377:27: error: converting the enum constant to a boolean [-Werror,-Wint-in-bool-context]
	                   (type = LINE_DEFAULT ||