### PR TITLE
Allow to change directory from the next argument

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -488,8 +488,10 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 	for (i = 1; i < argc; i++) {
 		const char *opt = argv[i];
 		if (!strncmp(opt, "-C", 2)) {
-			if (chdir(opt + 2))
-				die("Failed to change directory to %s", opt + 2);
+			const char *dir = strlen(opt) == 2 && i + 1 < argc ? \
+					  argv[++i] : opt + 2;
+			if (chdir(dir))
+				die("Failed to change directory to %s", dir);
 			continue;
 		} else {
 			break;


### PR DESCRIPTION
The -C change directory option only accepts dir within the same argv argument. The git tool allows this value to be in the next argument. This PR allows providing the change directory as the next argument after -C.