### PR TITLE
Expose the line number before a diff as %(lineno_old)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -11,6 +11,7 @@ Improvements:
  - Add line-graphics = auto. (#834)
  - Allow maxwidth to be expressed in % of the view width.
  - Pass stash args through. (#1022)
+ - The line number before a diff was applied is exposed as `%(lineno_old)` (#1081)
 
 Bug fixes:
 

--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -175,6 +175,8 @@ following variables.
 			 "." if undefined.
 |%(file)		|The currently selected file.
 |%(lineno)		|The currently selected line number. Defaults to 0.
+|%(lineno_old)		|The currently selected line number, before the diff
+			 was applied. Defaults to 0.
 |%(ref)			|The reference given to blame or HEAD if undefined.
 |%(revargs)		|The revision arguments passed on the command line.
 |%(fileargs)		|The file arguments passed on the command line.

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -722,6 +722,8 @@ following variable names, which are substituted before commands are run:
 			 "." if undefined.
 |%(file)		|The currently selected file.
 |%(lineno)		|The currently selected line number. Defaults to 0.
+|%(lineno_old)		|The currently selected line number, before the diff
+			 was applied. Defaults to 0.
 |%(ref)			|The reference given to blame or HEAD if undefined.
 |%(revargs)		|The revision arguments passed on the command line.
 |%(fileargs)		|The file arguments passed on the command line.

--- a/include/tig/argv.h
+++ b/include/tig/argv.h
@@ -47,6 +47,7 @@ typedef unsigned long argv_number;
 	_(argv_string,	 file,		"",		"") \
 	_(argv_string,	 head,		"",		"HEAD") \
 	_(argv_number,	 lineno,	"",		0) \
+	_(argv_number,	 lineno_old,	"",		0) \
 	_(argv_string,	 ref,		"HEAD",		"") \
 	_(argv_string,	 remote,	"origin",	"") \
 	_(argv_string,	 stash,		"",		"") \

--- a/src/diff.c
+++ b/src/diff.c
@@ -827,6 +827,7 @@ diff_common_select(struct view *view, struct line *line, const char *changes_msg
 			view->env->lineno = view->env->goto_lineno = diff_get_lineno(view, line, false);
 			if (view->env->goto_lineno > 0)
 				view->env->goto_lineno--;
+			view->env->lineno_old = diff_get_lineno(view, line, true);
 			view->env->blob[0] = 0;
 		} else {
 			string_ncopy(view->ref, view->ops->id, strlen(view->ops->id));


### PR DESCRIPTION
I use Tig to write review comments on GitLab (hopefully soon GitHub as well).
To comment on specific lines of a diff, the GitLab API requires both the
line number _before_ the diff, and _after_ the diff.  Additionally, it needs
the line type (added, deleted / context line). This patch exposes %(lineno_old)
which is the dual to %(linenno). It could also be useful when viewing
"reverse" diffs.