### PR TITLE
Update %(text) when navigating diff contents

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -830,9 +830,9 @@ diff_common_select(struct view *view, struct line *line, const char *changes_msg
 			view->env->blob[0] = 0;
 		} else {
 			string_ncopy(view->ref, view->ops->id, strlen(view->ops->id));
-			pager_select(view, line);
 		}
 	}
+	pager_select(view, line);
 }
 
 static void


### PR DESCRIPTION
Previously we'd only update %(text) in the header of the diff view.  Also
update %(text) when inside the diff contents. This allows to determine if
the current line is added, deleted or context, which allows to give precise
location information when talking to the GitLab API for example.