### PR TITLE
Escape variables with %% in external commands

### DIFF
--- a/src/argv.c
+++ b/src/argv.c
@@ -335,9 +335,10 @@ format_append_arg(struct format_context *format, const char ***dst_argv, const c
 
 	while (arg) {
 		const char *var = strstr(arg, "%(");
+		const char *esc = var > arg && *(var - 1) == '%' ? var - 1 : NULL;
 		const char *closing = var ? strchr(var, ')') : NULL;
-		const char *next = closing ? closing + 1 : NULL;
-		const int len = var ? var - arg : strlen(arg);
+		const char *next = esc > arg ? esc : closing ? closing + 1 : NULL;
+		const int len = var && !esc ? var - arg : esc > arg ? esc - arg : next ? next - ++arg : strlen(arg);
 
 		if (var && !closing)
 			return false;
@@ -345,7 +346,7 @@ format_append_arg(struct format_context *format, const char ***dst_argv, const c
 		if (len && !string_format_from(format->buf, &format->bufpos, "%.*s", len, arg))
 			return false;
 
-		if (var && !format_expand_arg(format, var, next))
+		if (var && !esc && !format_expand_arg(format, var, next))
 			return false;
 
 		arg = next;

--- a/test/tigrc/escape-var-test
+++ b/test/tigrc/escape-var-test
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+tigrc <<EOF
+bind generic 1 @sh -c "echo '%%(refname)=%(refname)' > $HOME/shell-command.txt"
+EOF
+
+steps '
+	1
+'
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+test_tig
+
+assert_equals 'shell-command.txt' <<EOF
+%(refname)=master
+EOF


### PR DESCRIPTION
Example: %%(refname)

References #1091