### PR TITLE
Fix parsing of -L argument

### DIFF
--- a/src/argv.c
+++ b/src/argv.c
@@ -576,6 +576,7 @@ argv_parse_rev_flag(const char *arg, struct rev_flags *rev_flags)
 		"--grep=",
 		"-G",
 		"-S",
+		"-L",
 	};
 	size_t arglen = strlen(arg);
 	bool graph = true;


### PR DESCRIPTION
This makes it possible to use tig -L:argv_parse_rev_flag:src/argv.c
to browse all commits updating argv_parse_rev_flag() in argv.c.