### PR TITLE
Enable mailmap by default to match git log's behaviour

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -65,8 +65,8 @@ log_open(struct view *view, enum open_flags flags)
 {
 	const char *log_argv[] = {
 		"git", "log", encoding_arg, commit_order_arg(), "--cc",
-			"--stat", "%(logargs)", "%(cmdlineargs)", "%(revargs)",
-			"--no-color", "--", "%(fileargs)", NULL
+			"--stat", use_mailmap_arg(), "%(logargs)", "%(cmdlineargs)",
+			"%(revargs)", "--no-color", "--", "%(fileargs)", NULL
 	};
 
 	return begin_update(view, NULL, log_argv, flags);

--- a/src/options.c
+++ b/src/options.c
@@ -144,7 +144,7 @@ diff_context_arg()
 const char *
 use_mailmap_arg()
 {
-	return opt_mailmap ? "--use-mailmap" : "";
+	return opt_mailmap ? "--use-mailmap" : "--no-use-mailmap";
 }
 
 const char *

--- a/test/main/filter-args-test
+++ b/test/main/filter-args-test
@@ -38,7 +38,7 @@ git rev-parse --git-dir --is-inside-work-tree --show-cdup --show-prefix HEAD --s
 EOF
 
 assert_equals 'log.trace' <<EOF
-git log --encoding=UTF-8 --topo-order --exclude=refs/remotes/origin/* --exclude=refs/heads/master --all --date=raw --parents --no-color --show-notes --pretty=format:commit %m %H %P%x00%an <%ae> %ad%x00%s%x00%N -- common tracer
+git log --encoding=UTF-8 --topo-order --exclude=refs/remotes/origin/* --exclude=refs/heads/master --all --date=raw --parents --no-color --show-notes --pretty=format:commit %m %H %P%x00%aN <%aE> %ad%x00%s%x00%N -- common tracer
 EOF
 
 assert_equals 'filtered.screen' <<EOF

--- a/tigrc
+++ b/tigrc
@@ -118,7 +118,7 @@ set show-notes			= yes		# When non-bool passed as `--show-notes=...` (diff)
 #set blame-options		= -C -C -C	# User-defined options for `tig blame` (git-blame)
 #set log-options		= --pretty=raw	# User-defined options for `tig log` (git-log)
 #set main-options		= -n 1000	# User-defined options for `tig` (git-log)
-#set mailmap			= yes		# Use .mailmap to show canonical name and email address
+set mailmap			= yes		# Use .mailmap to show canonical name and email address
 
 # Misc
 set start-on-head		= no		# Start with cursor on HEAD commit


### PR DESCRIPTION
Also improve consistency when mailmap is disabled.

Closes #1104