### PR TITLE
Bugfix: smart-case does not work when search term contains a space

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -320,7 +320,7 @@ utf8_string_contains(const char *text, int category)
 			break;
 
 		property = utf8proc_get_property(unicode);
-		if (property->category & category)
+		if (property->category == category)
 			return true;
 
 		text += slen;


### PR DESCRIPTION
I found that `set ignore-case = smart-case` does not work when searching a term that includes the space character, e.g., searching 'foo bar' does not match 'Foo Bar'.

- This is because [the category for space](https://github.com/JuliaStrings/utf8proc/blob/93a88b43107eccf09eea399a3b7a6767092d4488/utf8proc.h#L304) is `UTF8PROC_CATEGORY_ZS`, which has the value 23, aka 0x17, or 0b10111, and the smart-case test, `utf8_string_contains_uppercase`, which calls `utf8_string_contains`, is [using bitwise AND to check the category](https://github.com/jonas/tig/blob/master/src/string.c#L323):

  ```
   if (property->category & category)
  ```

  So then the space character -- category 0x17 -- matches [the uppercase category](https://github.com/JuliaStrings/utf8proc/blob/93a88b43107eccf09eea399a3b7a6767092d4488/utf8proc.h#L282), `UTF8PROC_CATEGORY_LU  = 1`. I.e., `0x17 & 1` is true.

- My solution is to change the bitwise AND to the equality operator, `==`.

  This is based on my understanding that [the `utf8proc` categories](https://github.com/JuliaStrings/utf8proc/blob/93a88b43107eccf09eea399a3b7a6767092d4488/utf8proc.h#L279-L311) are not bitmask values (and that [`utf8proc_get_property`](https://github.com/JuliaStrings/utf8proc/blob/93a88b43107eccf09eea399a3b7a6767092d4488/utf8proc.c#L242) returns a single value, and not a bitmask), although I could be mistaken (this is my first time examining the `utf8proc` library).

- This regression occurred in [29524d0](https://github.com/jonas/tig/commit/29524d0).

Oh, and by the way, `tig` is such a delight to use! I discovered it when I got a MacBook for work and found out how slow `gitk` runs outside of Linux, and I haven't used `gitk` since -- `tig`'s gotta be one of my favorite developer tools. Great work!!
