### PR TITLE
Allow :back to work across separate blame views

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -393,7 +393,7 @@ push_view_history_state(struct view_history *history, struct position *position,
 
 	if (state && data && history->state_alloc &&
 	    !memcmp(state->data, data, history->state_alloc))
-		return NULL;
+		return state;
 
 	state = calloc(1, sizeof(*state) + history->state_alloc);
 	if (!state)


### PR DESCRIPTION
* stop clearing the history state when entering the blame view

* push a blame view history state before entering the diff view

* stop failing when trying to push an identical history state

Closes #1123