### PR TITLE
Expose %(file_old), the filename before a rename or deletion

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,6 +1,14 @@
 Release notes
 =============
 
+master
+------
+
+Improvements:
+ - Expose `%(file_old)`, useful for deleted and renamed files. 
+
+Bug fixes:
+
 tig-2.5.4
 ---------
 

--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -174,6 +174,7 @@ following variables.
 |%(directory)		|The current directory path in the tree view or
 			 "." if undefined.
 |%(file)		|The currently selected file.
+|%(file_old)		|The old filename of the currently selected file.
 |%(lineno)		|The currently selected line number. Defaults to 0.
 |%(lineno_old)		|The currently selected line number, before the diff
 			 was applied. Defaults to 0.

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -722,6 +722,7 @@ following variable names, which are substituted before commands are run:
 |%(directory)		|The current directory path in the tree view or
 			 "." if undefined.
 |%(file)		|The currently selected file.
+|%(file_old)		|The old filename of the currently selected file.
 |%(lineno)		|The currently selected line number. Defaults to 0.
 |%(lineno_old)		|The currently selected line number, before the diff
 			 was applied. Defaults to 0.

--- a/include/tig/argv.h
+++ b/include/tig/argv.h
@@ -45,6 +45,7 @@ typedef unsigned long argv_number;
 	_(argv_string,	 branch,	"",		"") \
 	_(argv_string,	 directory,	".",		"") \
 	_(argv_string,	 file,		"",		"") \
+	_(argv_string,	 file_old,	"",		"") \
 	_(argv_string,	 head,		"",		"HEAD") \
 	_(argv_number,	 lineno,	"",		0) \
 	_(argv_number,	 lineno_old,	"",		0) \

--- a/include/tig/diff.h
+++ b/include/tig/diff.h
@@ -41,7 +41,7 @@ enum status_code diff_init_highlight(struct view *view, struct diff_state *state
 bool diff_done_highlight(struct diff_state *state);
 
 unsigned int diff_get_lineno(struct view *view, struct line *line, bool old);
-const char *diff_get_pathname(struct view *view, struct line *line);
+const char *diff_get_pathname(struct view *view, struct line *line, bool old);
 
 extern struct view diff_view;
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -639,7 +639,7 @@ stage_request(struct view *view, enum request request, struct line *line)
 		if (stage_status.new.name[0]) {
 			string_copy(view->env->file, stage_status.new.name);
 		} else {
-			const char *file = diff_get_pathname(view, line);
+			const char *file = diff_get_pathname(view, line, false);
 
 			if (file)
 				string_ncopy(view->env->file, file, strlen(file));


### PR DESCRIPTION
This improves interaction with external tools that require file names.

Implemented by extending diff_get_pathname.
We don't handle prefixes like "diff --cc" when computing %(file_old),
because we can't tell yet if such a line is "old" or "new".
Git only uses these combined headers for binary files, and other edge
cases, see: PAGER='less +1206' git show 75ae10b:combine-diff.c
Anyway, this is not really important because %(file) already has the
correct name.

An alternative (partial) solution would be to change %(file) to the
old filename but only for deleted files. I decided against this;
while it would be convenient for some basic scenarios, it hides
information which makes scripting more difficult.

Another, more general solution for these kinds of problems would be
to allow to pipe the raw diff to user scripts.