### PR TITLE
Fix null dereferences on unset format strings

### DIFF
--- a/src/argv.c
+++ b/src/argv.c
@@ -361,7 +361,7 @@ format_append_argv(struct format_context *format, const char ***dst_argv, const 
 	int argc;
 
 	if (!src_argv)
-		return true;
+		return argv_append(dst_argv, "");
 
 	for (argc = 0; src_argv[argc]; argc++)
 		if (!format_append_arg(format, dst_argv, src_argv[argc]))

--- a/src/argv.c
+++ b/src/argv.c
@@ -367,7 +367,7 @@ format_append_argv(struct format_context *format, const char ***dst_argv, const 
 		if (!format_append_arg(format, dst_argv, src_argv[argc]))
 			return false;
 
-	return src_argv[argc] == NULL;
+	return true;
 }
 
 static bool

--- a/test/regressions/github-1136-test
+++ b/test/regressions/github-1136-test
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+LINES=10
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+# This runs an empty command, hence the empty pager.
+test_case bang-cmdlineargs-doesnt-crash \
+	--args='status' \
+	--script='
+	:!%(cmdlineargs)
+	' <<EOF
+
+
+
+
+
+
+
+
+[pager]                                                                       0%
+EOF
+
+test_case echo-cmdlineargs-doesnt-crash \
+	--args='status' \
+	--script='
+	:echo %(cmdlineargs)
+	' <<EOF
+On branch master
+Changes to be committed:
+  (no files)
+Changes not staged for commit:
+  (no files)
+Untracked files:
+  (no files)
+
+[status] Nothing to update                                                  100%
+EOF
+
+run_test_cases


### PR DESCRIPTION
Our argv_format() reports success but leaves the output at null
when the input is "%(cmdlineargs)" and the corresponding option
("opt_cmdline_args") is null.
Other callers already check if the output is null, do the same.

Fixes two null dereferences in prompt.c:

	:!%(cmdlineargs)
	:echo %(cmdlineargs)

I don't know if there is a reproducer for the change in argv.c but
this seems better.