### PR TITLE
Enable jumping back in main view

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,8 @@
 
 DEFINE_ALLOCATOR(realloc_reflogs, char *, 32)
 
+static struct view_history main_view_history = { 0 };
+
 bool
 main_status_exists(struct view *view, enum line_type type)
 {
@@ -570,7 +572,19 @@ main_request(struct view *view, enum request request, struct line *line)
 		break;
 
 	case REQ_PARENT:
-		goto_id(view, "%(commit)^", true, false);
+		if (push_view_history_state(&main_view_history, &view->pos, NULL)) {
+			goto_id(view, "%(commit)^", true, false);
+		} else {
+			report("Failed to save current view state");
+		}
+		break;
+
+	case REQ_BACK:
+		if (pop_view_history_state(&main_view_history, &view->pos, NULL)) {
+			redraw_view(view);
+		} else {
+			report("Already at start of history");
+		}
 		break;
 
 	case REQ_MOVE_NEXT_MERGE:

--- a/test/main/goto-test
+++ b/test/main/goto-test
@@ -15,6 +15,10 @@ steps '
 	:save-display commit-1.screen
 	:parent
 	:save-display commit-2.screen
+	:back
+	:save-display commit-1-back.screen
+	:parent
+	:save-display commit-2-again.screen
 	:parent
 	:save-display commit-5.screen
 	:parent
@@ -42,7 +46,31 @@ assert_equals 'commit-1.screen' <<EOF
 [main] 9d2a1bbf0046ec6b5e7a6faebb9ba9374bdbdee7 - commit 1 of 5             100%
 EOF
 
+assert_equals 'commit-1-back.screen' <<EOF
+2009-03-28 13:22 +0000 Committer * [conflict-branch] Change: d'
+2009-03-20 01:00 +0000 Committer * Change: d
+2014-05-25 19:42 +0000 Unknown   | * Unstaged changes
+2009-03-11 12:38 +0000 Committer | * [conflict-master] Change: c'
+2009-03-03 00:15 +0000 Committer | * Change: c
+2009-02-22 11:53 +0000 Committer o-' [master] Change: b
+ 
+ 
+[main] 9d2a1bbf0046ec6b5e7a6faebb9ba9374bdbdee7 - commit 1 of 5             100%
+EOF
+
 assert_equals 'commit-2.screen' <<EOF
+2009-03-28 13:22 +0000 Committer * [conflict-branch] Change: d'
+2009-03-20 01:00 +0000 Committer * Change: d
+2014-05-25 19:42 +0000 Unknown   | * Unstaged changes
+2009-03-11 12:38 +0000 Committer | * [conflict-master] Change: c'
+2009-03-03 00:15 +0000 Committer | * Change: c
+2009-02-22 11:53 +0000 Committer o-' [master] Change: b
+ 
+ 
+[main] fa878e5e6d838243fa59025ef314395fbebc790f - commit 2 of 5             100%
+EOF
+
+assert_equals 'commit-2-again.screen' <<EOF
 2009-03-28 13:22 +0000 Committer * [conflict-branch] Change: d'
 2009-03-20 01:00 +0000 Committer * Change: d
 2014-05-25 19:42 +0000 Unknown   | * Unstaged changes


### PR DESCRIPTION
Hi there,

First, thank you for all the work on this awesome tool.

The one feature that I have been missing is the ability to go back to the previously selected commit after jumping to its parent.  I find that to be really useful for git repositories which are "heavily non-linear" (like the Linux kernel tree).

I see this idea has already been suggested in #628 and [also](https://github.com/jonas/tig/pull/506#issuecomment-240302791) in #506 (which implemented #388), so I took a stab at implementing it.

This PR looks almost too simple to be right, but it seems to work well for me :-)  I would be happy to work on it further if the approach I chose is not the preferred one.

Hope this helps!
