### PR TITLE
Autoscroll colorify compiler output

### DIFF
--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -22,6 +22,7 @@ struct ref;
  */
 
 #define LINE_INFO(_) \
+        _(COMPILER_MSG,     ""), \
 	_(DIFF_HEADER,		"diff --"), \
 	_(DIFF_DEL_FILE,	"--- "), \
 	_(DIFF_ADD_FILE,	"+++ "), \

--- a/src/view.c
+++ b/src/view.c
@@ -641,8 +641,10 @@ update_view(struct view *view)
 			return false;
 		}
 
-		if (should_autoscroll)
-		    do_scroll_view(view, 1);
+		/* Autoscroll is available only in pager */
+		if (should_autoscroll && !strcmp(view->name, "pager"))
+
+		        do_scroll_view(view, 1);
 	}
 
 	if (io_error(view->pipe)) {

--- a/src/view.c
+++ b/src/view.c
@@ -600,6 +600,7 @@ begin_update(struct view *view, const char *dir, const char **argv, enum open_fl
 bool
 update_view(struct view *view)
 {
+        bool should_autoscroll = false;
 	/* Clear the view and redraw everything since the tree sorting
 	 * might have rearranged things. */
 	bool redraw = view->lines == 0;
@@ -630,12 +631,18 @@ update_view(struct view *view)
 			end_update(view, true);
 			return false;
 		}
-
+		
+		if ((view->pos.offset + view->height + 1) == view->lines)
+		    should_autoscroll = true;
+		
 		if (!view->ops->read(view, &line, false)) {
 			report("Allocation failure");
 			end_update(view, true);
 			return false;
 		}
+
+		if (should_autoscroll)
+		    do_scroll_view(view, 1);
 	}
 
 	if (io_error(view->pipe)) {


### PR DESCRIPTION
Hi,
I think that this PR implements quite a valuable features, which all converge to a very useful use case (explained at the end). The features are:

## The patches
 
1. **Autoscroll** of the pager view – quite a missed feature, with a protection against overactivity – the view has to be placed at the bottom for the autoscroll to occur – i.e.: it's safe to scroll up and have a stable view of what's going on.

2. **Colorizing** of the compiler's errors and warnings (and notes) in pager view. <br/>The errors are to be browsed in the use case explained below, so they are being colorized first here by this patch.

## The use case

The two patches open a way for a configuring of TIG as a **comfortable IDE-like errors round-trip fixing tool**, by:

1. Configuring the `'n'` key in pager to search for lines with "error:|warning:|note:" regex, via.:
    ```
    bind pager n :/warning:|error:|note:
    ```
2. Configuring Return in pager to open the editor on the line number extracted from the current error/warning/note, via:
    ```
    bind pager <Enter> !sh -c "~/github/tig/contrib/make-line-open.zsh '%(text)'"
    ```

3. Optionally, configuring `'E'` to run `:!make`, via:
    ```
    bind generic E :!make
    ```

4. Setting the `compiler-msg` color (the only thing that's problematic - I don't know how to make a default value for it), via:
    ```
    color compiler-msg yellow default bold
    ```

Then what's possible is the following use case: [![asciicast](https://asciinema.org/a/430460.svg)](https://asciinema.org/a/430460).

## Helper script body

The `make-line-open` script is as follows:

```zsh
#!/usr/bin/env zsh

emulate zsh -o extended_glob

if [[ $1 == (#b)([^:]##):([0-9]##):* ]]; then
    [[ -z $EDITOR ]] && EDITOR=mcedit

    $EDITOR +$match[2] **/$match[1]
fi
```

## Summary

The patches are quite simple, only 9 and 21 lines and follow the coding style. I think that the patches are useful also without/outside the use case – having pager view autoscrolled, for example, is an useful thing.
