### PR TITLE
support delta along with ANSI support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.tabSize": 8,
+  "editor.insertSpaces": false,
+  "files.associations": {
+    "*.h": "c"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.tabSize": 8,
-  "editor.insertSpaces": false,
-  "files.associations": {
-    "*.h": "c"
-  }
-}

--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,7 @@ TIG_OBJS = \
 	src/grep.o \
 	src/ui.o \
 	src/apps.o \
+	src/ansi.o \
 	$(GRAPH_OBJS) \
 	$(COMPAT_OBJS)
 

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -278,7 +278,7 @@ The following variables can be set:
 	to false. When set to true then 'diff-highlight' is used, else the option
 	value is used as the path. When this option is in effect, highlighted
 	regions are governed by `color diff-add-highlight` and
-	`color diff-del-highlight`.
+	`color diff-del-highlight`. git-delta is also supported.
 
 'ignore-space' (mixed) [no|all|some|at-eol|<bool>]::
 

--- a/include/tig/ansi.h
+++ b/include/tig/ansi.h
@@ -26,7 +26,7 @@ struct ansi_status {
 
 void split_ansi(const char *string, int *ansi_num, char **ansi_ptrs);
 void draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, size_t skip);
-void draw_ansi_line(struct view *view, char *ansi_end_ptr, int after_ansi_len, size_t *skip, int *cur_width, int *widths_of_display);
+void draw_ansi_line(struct view *view, char *ansi_end_ptr, int *after_ansi_len, size_t *skip, int *cur_width, int *widths_of_display);
 void wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status);
 
 #endif

--- a/include/tig/ansi.h
+++ b/include/tig/ansi.h
@@ -28,6 +28,7 @@ void split_ansi(const char *string, int *ansi_num, char **ansi_ptrs);
 void draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, size_t skip);
 void draw_ansi_line(struct view *view, char *ansi_end_ptr, int *after_ansi_len, size_t *skip, int *cur_width, int *widths_of_display);
 void wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status);
+short convert_ansi_into_256_color(char *save_ptr);
 
 #endif
 

--- a/include/tig/ansi.h
+++ b/include/tig/ansi.h
@@ -28,7 +28,7 @@ void split_ansi(const char *string, int *ansi_num, char **ansi_ptrs);
 void draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, size_t skip);
 void draw_ansi_line(struct view *view, char *ansi_end_ptr, int *after_ansi_len, size_t *skip, int *cur_width, int *widths_of_display);
 void wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status);
-short convert_ansi_into_256_color(char *save_ptr);
+short convert_ansi_into_256_color(char **save_ptr);
 
 #endif
 

--- a/include/tig/ansi.h
+++ b/include/tig/ansi.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2006-2015 Jonas Fonseca <jonas.fonseca@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef TIG_ANSI_H
+#define TIG_ANSI_H
+
+#include "tig/line.h"
+#include "tig/tig.h"
+#include "tig/view.h"
+
+struct ansi_status {
+	short fg;
+	short bg;
+	unsigned int attr;
+};
+
+void split_ansi(const char *string, int *ansi_num, char **ansi_ptrs);
+void draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs);
+void draw_ansi_line(struct view *view, char *text, int len);
+void wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status);
+
+#endif
+
+/* vim: set ts=8 sw=8 noexpandtab: */

--- a/include/tig/ansi.h
+++ b/include/tig/ansi.h
@@ -25,8 +25,8 @@ struct ansi_status {
 };
 
 void split_ansi(const char *string, int *ansi_num, char **ansi_ptrs);
-void draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs);
-void draw_ansi_line(struct view *view, char *text, int len);
+void draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, size_t skip);
+void draw_ansi_line(struct view *view, char *ansi_end_ptr, int after_ansi_len, size_t *skip, int *cur_width, int *widths_of_display);
 void wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status);
 
 #endif

--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -17,7 +17,7 @@
 #include "tig/tig.h"
 struct ref;
 
-extern short color_pairs_map[256][256];
+extern short color_pairs_map[257][257];
 
 /*
  * Line-oriented content detection.

--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -17,6 +17,8 @@
 #include "tig/tig.h"
 struct ref;
 
+extern short color_pairs_map[256][256];
+
 /*
  * Line-oriented content detection.
  */

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -82,7 +82,6 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, siz
 
 		if (view->curline->selected) {
 			draw_ansi_line(view, ansi_end_ptr, after_ansi_len, &skip, &cur_width, &widths_of_display);
-			cur_width += widths_of_display;
 			continue;
 		}
 
@@ -173,7 +172,6 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, siz
 		wattrset_by_ansi_status(view, &cur_ansi_status);
 
 		draw_ansi_line(view, ansi_end_ptr, after_ansi_len, &skip, &cur_width, &widths_of_display);
-		cur_width += widths_of_display;
 
 		free(ansi_code);
 		ansi_code = NULL;
@@ -204,6 +202,8 @@ draw_ansi_line(struct view *view, char *ansi_end_ptr, int after_ansi_len, size_t
 	} else {
 		waddnstr(view->win, ansi_end_ptr, after_ansi_len);
 	}
+
+	*cur_width += *widths_of_display;
 }
 
 void

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -85,92 +85,81 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, siz
 			continue;
 		}
 
+		// ncurses can't handle multiple attribute such as BOLD & UNDERLINE.
+		// If input-ansi has "\033[1;4" we'll give priority to the latter one.
+		char *saveptr;
 		char *ansi_code = malloc(sizeof(char) * (ansi_code_len + 1));
 		strncpy(ansi_code, text + 2, ansi_code_len);
 		ansi_code[ansi_code_len] = '\0';
-		if (strchr(ansi_code, ';') == NULL) {
-			if (strcmp(ansi_code, "0") == 0)
+		char *ansi_code_part = strtok_r(ansi_code, ";", &saveptr);
+		while (ansi_code_part != NULL) {
+			if (strcmp(ansi_code_part, "0") == 0) {
+				cur_ansi_status.fg = 256;
+				cur_ansi_status.bg = 256;
 				cur_ansi_status.attr = A_NORMAL;
-			if (strcmp(ansi_code, "1") == 0)
-				cur_ansi_status.attr = A_BOLD;
-			if (strcmp(ansi_code, "2") == 0)
-				cur_ansi_status.attr = A_DIM;
-			if (strcmp(ansi_code, "3") == 0)
-				cur_ansi_status.attr = A_ITALIC;
-			if (strcmp(ansi_code, "4") == 0)
-				cur_ansi_status.attr = A_UNDERLINE;
-			if (strcmp(ansi_code, "5") == 0)
-				cur_ansi_status.attr = A_BLINK;
-			if (strcmp(ansi_code, "6") == 0)
-				cur_ansi_status.attr = A_BLINK; // This is supposed to be faster than normal blink, but ncurses doesn't have any way to achieve.
-			if (strcmp(ansi_code, "7") == 0)
-				cur_ansi_status.attr = A_REVERSE;
-			if (strcmp(ansi_code, "8") == 0)
-				cur_ansi_status.attr = A_INVIS;
-			if (strcmp(ansi_code, "9") == 0)
-				// This is supposed to be strikethrough, but ncurses doesn't have any way to achieve.
-			if (strcmp(ansi_code, "30") == 0)
-				cur_ansi_status.fg = COLOR_BLACK;
-			if (strcmp(ansi_code, "31") == 0)
-				cur_ansi_status.fg = COLOR_RED;
-			if (strcmp(ansi_code, "32") == 0)
-				cur_ansi_status.fg = COLOR_GREEN;
-			if (strcmp(ansi_code, "33") == 0)
-				cur_ansi_status.fg = COLOR_YELLOW;
-			if (strcmp(ansi_code, "34") == 0)
-				cur_ansi_status.fg = COLOR_BLUE;
-			if (strcmp(ansi_code, "35") == 0)
-				cur_ansi_status.fg = COLOR_MAGENTA;
-			if (strcmp(ansi_code, "36") == 0)
-				cur_ansi_status.fg = COLOR_CYAN;
-			if (strcmp(ansi_code, "37") == 0)
-				cur_ansi_status.fg = COLOR_WHITE;
-			if (strcmp(ansi_code, "40") == 0)
-				cur_ansi_status.bg = COLOR_BLACK;
-			if (strcmp(ansi_code, "41") == 0)
-				cur_ansi_status.bg = COLOR_RED;
-			if (strcmp(ansi_code, "42") == 0)
-				cur_ansi_status.bg = COLOR_GREEN;
-			if (strcmp(ansi_code, "43") == 0)
-				cur_ansi_status.bg = COLOR_YELLOW;
-			if (strcmp(ansi_code, "44") == 0)
-				cur_ansi_status.bg = COLOR_BLUE;
-			if (strcmp(ansi_code, "45") == 0)
-				cur_ansi_status.bg = COLOR_MAGENTA;
-			if (strcmp(ansi_code, "46") == 0)
-				cur_ansi_status.bg = COLOR_CYAN;
-			if (strcmp(ansi_code, "47") == 0)
-				cur_ansi_status.bg = COLOR_WHITE;
-		} else {
-			char *token = malloc(sizeof(char) * (ansi_code_len + 1));
-			strcpy(token, ansi_code);
-			char *ansi_code_part = strtok(token, ";");
-
-			while (ansi_code_part != NULL) {
-				char *color_method_mark = strtok(NULL, ";");
-				if (strcmp(color_method_mark, "5") == 0) {
-					char *c256 = strtok(NULL, ";");
-					if (strcmp(ansi_code_part, "38") == 0)
-						cur_ansi_status.fg = atoi(c256);
-					if (strcmp(ansi_code_part, "48") == 0)
-						cur_ansi_status.bg = atoi(c256);
-				}
-				// WONTFIX: You can't init_color with numerous RGB code in ncurses.
-				// I decided to force delta users to use "true-color = never" when using tig,
-				// so the process never comes to this condition.
-				// I leave the code for someone who wants to implements in the future.
-				// if (strcmp(color_method_mark, "2") == 0) {
-					// char *r = strtok(NULL, ";");
-					// char *g = strtok(NULL, ";");
-					// char *b = strtok(NULL, ";");
-				// }
-				ansi_code_part = strtok(NULL, ";");
 			}
-			free(token);
-			token = NULL;
+			if (strcmp(ansi_code_part, "1") == 0)
+				cur_ansi_status.attr = A_BOLD;
+			if (strcmp(ansi_code_part, "2") == 0)
+				cur_ansi_status.attr = A_DIM;
+			if (strcmp(ansi_code_part, "3") == 0)
+				cur_ansi_status.attr = A_ITALIC;
+			if (strcmp(ansi_code_part, "4") == 0)
+				cur_ansi_status.attr = A_UNDERLINE;
+			if (strcmp(ansi_code_part, "5") == 0)
+				cur_ansi_status.attr = A_BLINK;
+			if (strcmp(ansi_code_part, "6") == 0)
+				cur_ansi_status.attr = A_BLINK; // This is supposed to be faster than normal blink, but ncurses doesn't have any way to achieve.
+			if (strcmp(ansi_code_part, "7") == 0)
+				cur_ansi_status.attr = A_REVERSE;
+			if (strcmp(ansi_code_part, "8") == 0)
+				cur_ansi_status.attr = A_INVIS;
+			if (strcmp(ansi_code_part, "9") == 0)
+				// This is supposed to be strikethrough, but ncurses doesn't have any way to achieve.
+			if (strcmp(ansi_code_part, "30") == 0)
+				cur_ansi_status.fg = COLOR_BLACK;
+			if (strcmp(ansi_code_part, "31") == 0)
+				cur_ansi_status.fg = COLOR_RED;
+			if (strcmp(ansi_code_part, "32") == 0)
+				cur_ansi_status.fg = COLOR_GREEN;
+			if (strcmp(ansi_code_part, "33") == 0)
+				cur_ansi_status.fg = COLOR_YELLOW;
+			if (strcmp(ansi_code_part, "34") == 0)
+				cur_ansi_status.fg = COLOR_BLUE;
+			if (strcmp(ansi_code_part, "35") == 0)
+				cur_ansi_status.fg = COLOR_MAGENTA;
+			if (strcmp(ansi_code_part, "36") == 0)
+				cur_ansi_status.fg = COLOR_CYAN;
+			if (strcmp(ansi_code_part, "37") == 0)
+				cur_ansi_status.fg = COLOR_WHITE;
+			if (strcmp(ansi_code_part, "38") == 0) {
+				short c256 = convert_ansi_into_256_color(saveptr);
+				if (c256 != -1)
+					cur_ansi_status.fg = c256;
+			}
+			if (strcmp(ansi_code_part, "40") == 0)
+				cur_ansi_status.bg = COLOR_BLACK;
+			if (strcmp(ansi_code_part, "41") == 0)
+				cur_ansi_status.bg = COLOR_RED;
+			if (strcmp(ansi_code_part, "42") == 0)
+				cur_ansi_status.bg = COLOR_GREEN;
+			if (strcmp(ansi_code_part, "43") == 0)
+				cur_ansi_status.bg = COLOR_YELLOW;
+			if (strcmp(ansi_code_part, "44") == 0)
+				cur_ansi_status.bg = COLOR_BLUE;
+			if (strcmp(ansi_code_part, "45") == 0)
+				cur_ansi_status.bg = COLOR_MAGENTA;
+			if (strcmp(ansi_code_part, "46") == 0)
+				cur_ansi_status.bg = COLOR_CYAN;
+			if (strcmp(ansi_code_part, "48") == 0) {
+				short c256 = convert_ansi_into_256_color(saveptr);
+				if (c256 != -1)
+					cur_ansi_status.bg = c256;
+			}
+
+			ansi_code_part = strtok_r(NULL, ";", &saveptr);
 		}
 		wattrset_by_ansi_status(view, &cur_ansi_status);
-
 		draw_ansi_line(view, ansi_end_ptr, &after_ansi_len, &skip, &cur_width, &widths_of_display);
 
 		free(ansi_code);
@@ -216,6 +205,29 @@ wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status) 
 		cur_ansi_status->bg -= 1;
 	short id = color_pairs_map[cur_ansi_status->fg][cur_ansi_status->bg];
 	wattr_set(view->win, cur_ansi_status->attr, id, NULL);
+}
+
+short
+convert_ansi_into_256_color(char *save_ptr) {
+	char *color_method_mark = strtok_r(NULL, ";", &save_ptr);
+	short c256 = -1;
+	if (strcmp(color_method_mark, "5") == 0) {
+		char *color_code = strtok_r(NULL, ";", &save_ptr);
+		c256 = atoi(color_code);
+	}
+
+	// WONTFIX: You can't init_color with numerous RGB code in ncurses.
+	// I decided to force delta users to use "true-color = never" when using tig,
+	// so the process never comes to this condition.
+	// I leave the code for someone who wants to implements in the future.
+	// if (strcmp(color_method_mark, "2") == 0) {
+		// char *r = strtok(NULL, ";");
+		// char *g = strtok(NULL, ";");
+		// char *b = strtok(NULL, ";");
+	// }
+	// Do some process to convert those color infos for ncurses.
+
+	return c256;
 }
 
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -176,6 +176,8 @@ draw_ansi_line(struct view *view, char *text, int len) {
 
 void
 wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status) {
+	// Because init_extended_pair can't accept more than 32768 pairs,
+	// we skip the colors with color codes odd numbered and greater than 15 currently.
 	if (cur_ansi_status->fg > 15 && cur_ansi_status->fg % 2 == 1)
 		cur_ansi_status->fg -= 1;
 	if (cur_ansi_status->bg > 15 && cur_ansi_status->bg % 2 == 1)

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -19,15 +19,15 @@
 
 void
 split_ansi(const char *string, int *ansi_num, char **ansi_ptrs) {
-	char *needle = "\033[";
+	char *head_of_ansi = "\033[";
 	int current_ansi_idx = 0;
-	char *next_ansi_ptr = strstr(string + current_ansi_idx, needle);
+	char *next_ansi_ptr = strstr(string + current_ansi_idx, head_of_ansi);
 
 	if (next_ansi_ptr == NULL)
 		return;
 	while (next_ansi_ptr != NULL) {
 		if (strcmp(string, next_ansi_ptr) == 0) {
-			next_ansi_ptr = strstr(string + current_ansi_idx + strlen(needle), needle);
+			next_ansi_ptr = strstr(string + current_ansi_idx + strlen(head_of_ansi), head_of_ansi);
 			continue;
 		}
 		int current_ansi_length = strlen(string + current_ansi_idx) - strlen(next_ansi_ptr);
@@ -35,7 +35,7 @@ split_ansi(const char *string, int *ansi_num, char **ansi_ptrs) {
 		ansi_ptrs[*ansi_num][current_ansi_length] = '\0';
 		*ansi_num += 1;
 		current_ansi_idx += current_ansi_length / sizeof(char);
-		next_ansi_ptr = strstr(string + current_ansi_idx + strlen(needle), needle);
+		next_ansi_ptr = strstr(string + current_ansi_idx + strlen(head_of_ansi), head_of_ansi);
 	}
 
 	strcpy(ansi_ptrs[*ansi_num], string + current_ansi_idx);
@@ -49,8 +49,7 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs) {
 	cur_ansi_status.bg = COLOR_BLACK;
 	cur_ansi_status.attr = A_NORMAL;
 
-	for (int i = 0; i < *ansi_num; i++)
-	{
+	for (int i = 0; i < *ansi_num; i++) {
 		int len = strlen(ansi_ptrs[i]);
 		char text[len + 1];
 		strcpy(text, ansi_ptrs[i]);
@@ -131,7 +130,7 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs) {
 			strcpy(token, ansi_code);
 			char *ansi_code_part = strtok(token, ";");
 
-			while(ansi_code_part != NULL) {
+			while (ansi_code_part != NULL) {
 				char *color_method_mark = strtok(NULL, ";");
 				if (strcmp(color_method_mark, "5") == 0) {
 					char *c256 = strtok(NULL, ";");

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -175,7 +175,7 @@ wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status) 
 	if (cur_ansi_status->bg > 15 && cur_ansi_status->bg % 2 == 1)
 		cur_ansi_status->bg -= 1;
 	short id = color_pairs_map[cur_ansi_status->fg][cur_ansi_status->bg];
-	wattrset(view->win, COLOR_PAIR(id)|cur_ansi_status->attr);
+	wattr_set(view->win, cur_ansi_status->attr, id, NULL);
 }
 
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -67,10 +67,16 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs) {
 		char *ansi_end_ptr = strchr(text, 'm');
 		int after_ansi_len = strlen(ansi_end_ptr);
 		int ansi_code_len = len - after_ansi_len - 2;
+		ansi_end_ptr += 1;
+
+		if (view->curline->selected) {
+			draw_ansi_line(view, ansi_end_ptr, after_ansi_len);
+			continue;
+		}
+
 		char *ansi_code = malloc(sizeof(char) * (ansi_code_len + 1));
 		strncpy(ansi_code, text + 2, ansi_code_len);
 		ansi_code[ansi_code_len] = '\0';
-		ansi_end_ptr += 1;
 
 		if (strchr(ansi_code, ';') == NULL) {
 			if (strcmp(ansi_code, "0") == 0)

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -46,8 +46,8 @@ split_ansi(const char *string, int *ansi_num, char **ansi_ptrs) {
 void
 draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, size_t skip) {
 	static struct ansi_status cur_ansi_status;
-	cur_ansi_status.fg = COLOR_WHITE;
-	cur_ansi_status.bg = COLOR_BLACK;
+	cur_ansi_status.fg = 256;
+	cur_ansi_status.bg = 256;
 	cur_ansi_status.attr = A_NORMAL;
 	int cur_width = 0;
 
@@ -210,9 +210,9 @@ void
 wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status) {
 	// Because init_extended_pair can't accept more than 32768 pairs,
 	// we skip the colors with color codes odd numbered and greater than 15 currently.
-	if (cur_ansi_status->fg > 15 && cur_ansi_status->fg % 2 == 1)
+	if (cur_ansi_status->fg < 256 && cur_ansi_status->fg > 15 && cur_ansi_status->fg % 2 == 1)
 		cur_ansi_status->fg -= 1;
-	if (cur_ansi_status->bg > 15 && cur_ansi_status->bg % 2 == 1)
+	if (cur_ansi_status->bg < 256 && cur_ansi_status->bg > 15 && cur_ansi_status->bg % 2 == 1)
 		cur_ansi_status->bg -= 1;
 	short id = color_pairs_map[cur_ansi_status->fg][cur_ansi_status->bg];
 	wattr_set(view->win, cur_ansi_status->attr, id, NULL);

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -190,7 +190,20 @@ draw_ansi_line(struct view *view, char *ansi_end_ptr, int after_ansi_len, size_t
 		*skip -= 1;
 		*widths_of_display -= 1;
 	}
-	waddnstr(view->win, ansi_end_ptr, after_ansi_len);
+
+	if (*cur_width + *widths_of_display > view->width) {
+		int left_widths = view->width - *cur_width;
+		while (left_widths > 0) {
+			utf8proc_int32_t unicode;
+			int bytes_to_display = utf8proc_iterate((const utf8proc_uint8_t *) ansi_end_ptr, strlen(ansi_end_ptr), &unicode);
+			waddnstr(view->win, ansi_end_ptr, bytes_to_display);
+			ansi_end_ptr += bytes_to_display;
+			after_ansi_len -= bytes_to_display;
+			left_widths -= 1;
+		}
+	} else {
+		waddnstr(view->win, ansi_end_ptr, after_ansi_len);
+	}
 }
 
 void

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -151,6 +151,8 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, siz
 				cur_ansi_status.bg = COLOR_MAGENTA;
 			if (strcmp(ansi_code_part, "46") == 0)
 				cur_ansi_status.bg = COLOR_CYAN;
+			if (strcmp(ansi_code_part, "47") == 0)
+				cur_ansi_status.bg = COLOR_WHITE;
 			if (strcmp(ansi_code_part, "48") == 0) {
 				short c256 = convert_ansi_into_256_color(&saveptr);
 				if (c256 != -1)

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -133,7 +133,7 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, siz
 			if (strcmp(ansi_code_part, "37") == 0)
 				cur_ansi_status.fg = COLOR_WHITE;
 			if (strcmp(ansi_code_part, "38") == 0) {
-				short c256 = convert_ansi_into_256_color(saveptr);
+				short c256 = convert_ansi_into_256_color(&saveptr);
 				if (c256 != -1)
 					cur_ansi_status.fg = c256;
 			}
@@ -152,7 +152,7 @@ draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs, int max_width, siz
 			if (strcmp(ansi_code_part, "46") == 0)
 				cur_ansi_status.bg = COLOR_CYAN;
 			if (strcmp(ansi_code_part, "48") == 0) {
-				short c256 = convert_ansi_into_256_color(saveptr);
+				short c256 = convert_ansi_into_256_color(&saveptr);
 				if (c256 != -1)
 					cur_ansi_status.bg = c256;
 			}
@@ -208,11 +208,11 @@ wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status) 
 }
 
 short
-convert_ansi_into_256_color(char *save_ptr) {
-	char *color_method_mark = strtok_r(NULL, ";", &save_ptr);
+convert_ansi_into_256_color(char **save_ptr) {
+	char *color_method_mark = strtok_r(NULL, ";", save_ptr);
 	short c256 = -1;
 	if (strcmp(color_method_mark, "5") == 0) {
-		char *color_code = strtok_r(NULL, ";", &save_ptr);
+		char *color_code = strtok_r(NULL, ";", save_ptr);
 		c256 = atoi(color_code);
 	}
 

--- a/src/ansi.c
+++ b/src/ansi.c
@@ -1,0 +1,182 @@
+/* Copyright (c) 2006-2015 Jonas Fonseca <jonas.fonseca@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ */
+
+#include "tig/ansi.h"
+#include "tig/draw.h"
+#include "tig/line.h"
+#include "tig/tig.h"
+#include "tig/view.h"
+
+void
+split_ansi(const char *string, int *ansi_num, char **ansi_ptrs) {
+	char *needle = "\033[";
+	int current_ansi_idx = 0;
+	char *next_ansi_ptr = strstr(string + current_ansi_idx, needle);
+
+	if (next_ansi_ptr == NULL)
+		return;
+	while (next_ansi_ptr != NULL) {
+		if (strcmp(string, next_ansi_ptr) == 0) {
+			next_ansi_ptr = strstr(string + current_ansi_idx + strlen(needle), needle);
+			continue;
+		}
+		int current_ansi_length = strlen(string + current_ansi_idx) - strlen(next_ansi_ptr);
+		strncpy(ansi_ptrs[*ansi_num], string + current_ansi_idx, current_ansi_length);
+		ansi_ptrs[*ansi_num][current_ansi_length] = '\0';
+		*ansi_num += 1;
+		current_ansi_idx += current_ansi_length / sizeof(char);
+		next_ansi_ptr = strstr(string + current_ansi_idx + strlen(needle), needle);
+	}
+
+	strcpy(ansi_ptrs[*ansi_num], string + current_ansi_idx);
+	*ansi_num += 1;
+}
+
+void
+draw_ansi(struct view *view, int *ansi_num, char **ansi_ptrs) {
+	static struct ansi_status cur_ansi_status;
+	cur_ansi_status.fg = COLOR_WHITE;
+	cur_ansi_status.bg = COLOR_BLACK;
+	cur_ansi_status.attr = A_NORMAL;
+
+	for (int i = 0; i < *ansi_num; i++)
+	{
+		int len = strlen(ansi_ptrs[i]);
+		char text[len + 1];
+		strcpy(text, ansi_ptrs[i]);
+
+		if (i == 0 && text[0] != '\033') {
+			waddnstr(view->win, text, len);
+			continue;
+		}
+		// delta won't add moving ansi codes which are
+		// A, B, C, D, E, F, G, H, f, S, T.
+		// J, K exists for filling lines with a color, but ncurses can't do.
+		if ((text[3] == 'J') || (text[3] == 'K'))
+			continue;
+
+		char *ansi_end_ptr = strchr(text, 'm');
+		int after_ansi_len = strlen(ansi_end_ptr);
+		int ansi_code_len = len - after_ansi_len - 2;
+		char *ansi_code = malloc(sizeof(char) * (ansi_code_len + 1));
+		strncpy(ansi_code, text + 2, ansi_code_len);
+		ansi_code[ansi_code_len] = '\0';
+		ansi_end_ptr += 1;
+
+		if (strchr(ansi_code, ';') == NULL) {
+			if (strcmp(ansi_code, "0") == 0)
+				cur_ansi_status.attr = A_NORMAL;
+			if (strcmp(ansi_code, "1") == 0)
+				cur_ansi_status.attr = A_BOLD;
+			if (strcmp(ansi_code, "2") == 0)
+				cur_ansi_status.attr = A_DIM;
+			if (strcmp(ansi_code, "3") == 0)
+				cur_ansi_status.attr = A_ITALIC;
+			if (strcmp(ansi_code, "4") == 0)
+				cur_ansi_status.attr = A_UNDERLINE;
+			if (strcmp(ansi_code, "5") == 0)
+				cur_ansi_status.attr = A_BLINK;
+			if (strcmp(ansi_code, "6") == 0)
+				cur_ansi_status.attr = A_BLINK; // This is supposed to be faster than normal blink, but ncurses doesn't have any way to achieve.
+			if (strcmp(ansi_code, "7") == 0)
+				cur_ansi_status.attr = A_REVERSE;
+			if (strcmp(ansi_code, "8") == 0)
+				cur_ansi_status.attr = A_INVIS;
+			if (strcmp(ansi_code, "9") == 0)
+				// This is supposed to be strikethrough, but ncurses doesn't have any way to achieve.
+			if (strcmp(ansi_code, "30") == 0)
+				cur_ansi_status.fg = COLOR_BLACK;
+			if (strcmp(ansi_code, "31") == 0)
+				cur_ansi_status.fg = COLOR_RED;
+			if (strcmp(ansi_code, "32") == 0)
+				cur_ansi_status.fg = COLOR_GREEN;
+			if (strcmp(ansi_code, "33") == 0)
+				cur_ansi_status.fg = COLOR_YELLOW;
+			if (strcmp(ansi_code, "34") == 0)
+				cur_ansi_status.fg = COLOR_BLUE;
+			if (strcmp(ansi_code, "35") == 0)
+				cur_ansi_status.fg = COLOR_MAGENTA;
+			if (strcmp(ansi_code, "36") == 0)
+				cur_ansi_status.fg = COLOR_CYAN;
+			if (strcmp(ansi_code, "37") == 0)
+				cur_ansi_status.fg = COLOR_WHITE;
+			if (strcmp(ansi_code, "40") == 0)
+				cur_ansi_status.bg = COLOR_BLACK;
+			if (strcmp(ansi_code, "41") == 0)
+				cur_ansi_status.bg = COLOR_RED;
+			if (strcmp(ansi_code, "42") == 0)
+				cur_ansi_status.bg = COLOR_GREEN;
+			if (strcmp(ansi_code, "43") == 0)
+				cur_ansi_status.bg = COLOR_YELLOW;
+			if (strcmp(ansi_code, "44") == 0)
+				cur_ansi_status.bg = COLOR_BLUE;
+			if (strcmp(ansi_code, "45") == 0)
+				cur_ansi_status.bg = COLOR_MAGENTA;
+			if (strcmp(ansi_code, "46") == 0)
+				cur_ansi_status.bg = COLOR_CYAN;
+			if (strcmp(ansi_code, "47") == 0)
+				cur_ansi_status.bg = COLOR_WHITE;
+		} else {
+			char *token = malloc(sizeof(char) * (ansi_code_len + 1));
+			strcpy(token, ansi_code);
+			char *ansi_code_part = strtok(token, ";");
+
+			while(ansi_code_part != NULL) {
+				char *color_method_mark = strtok(NULL, ";");
+				if (strcmp(color_method_mark, "5") == 0) {
+					char *c256 = strtok(NULL, ";");
+					if (strcmp(ansi_code_part, "38") == 0)
+						cur_ansi_status.fg = atoi(c256);
+					if (strcmp(ansi_code_part, "48") == 0)
+						cur_ansi_status.bg = atoi(c256);
+				}
+				// WONTFIX: You can't init_color with numerous RGB code in ncurses.
+				// I decided to force delta users to use "true-color = never" when using tig,
+				// so the process never comes to this condition.
+				// I leave the code for someone who wants to implements in the future.
+				// if (strcmp(color_method_mark, "2") == 0) {
+					// char *r = strtok(NULL, ";");
+					// char *g = strtok(NULL, ";");
+					// char *b = strtok(NULL, ";");
+				// }
+				ansi_code_part = strtok(NULL, ";");
+			}
+
+			free(token);
+			token = NULL;
+		}
+
+		wattrset_by_ansi_status(view, &cur_ansi_status);
+		draw_ansi_line(view, ansi_end_ptr, after_ansi_len);
+		free(ansi_code);
+		ansi_code = NULL;
+	}
+}
+
+void
+draw_ansi_line(struct view *view, char *text, int len) {
+	if (len > 1)
+		waddnstr(view->win, text, len);
+}
+
+void
+wattrset_by_ansi_status(struct view *view, struct ansi_status* cur_ansi_status) {
+	if (cur_ansi_status->fg > 15 && cur_ansi_status->fg % 2 == 1)
+		cur_ansi_status->fg -= 1;
+	if (cur_ansi_status->bg > 15 && cur_ansi_status->bg % 2 == 1)
+		cur_ansi_status->bg -= 1;
+	short id = color_pairs_map[cur_ansi_status->fg][cur_ansi_status->bg];
+	wattrset(view->win, COLOR_PAIR(id)|cur_ansi_status->attr);
+}
+
+/* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/apps.c
+++ b/src/apps.c
@@ -107,8 +107,14 @@ struct app_external
 	    && app_diff_highlight_path_search(dhlt_path, sizeof(dhlt_path), query)
 	    && *dhlt_path) {
 		if (suffixcmp(dhlt_path, strlen(dhlt_path), "/diff-highlight.perl")) {
-			dhlt_app.argv[0] = dhlt_path;
-			dhlt_app.argv[1] = NULL;
+			if (strcmp(strrchr(dhlt_path, '/'), "/delta") == 0) {
+				dhlt_app.argv[0] = dhlt_path;
+				dhlt_app.argv[1] = "--true-color=never";
+				dhlt_app.argv[2] = NULL;
+			} else {
+				dhlt_app.argv[0] = dhlt_path;
+				dhlt_app.argv[1] = NULL;
+			}
 		} else if (path_search(perl_path, sizeof(perl_path), "perl", getenv("PATH"), X_OK)) {
 			/* if the package manager failed to "make install" within the contrib dir, rescue via */
 			/* perl -MDiffHighlight -I/path/containing /path/containing/diff-highlight.perl */

--- a/src/draw.c
+++ b/src/draw.c
@@ -75,25 +75,59 @@ draw_chars(struct view *view, enum line_type type, const char *string, int lengt
 	}
 
 	set_view_attr(view, type);
-	if (len > 0) {
-		int ansi_num = 0;
-		int len_with_ansi = strlen(string);
-		int max_num = (len_with_ansi / 4) + 1;
-		int max_len = (len_with_ansi - 4) + 1;
-		char **ansi_ptrs = (char **)malloc(sizeof(char *) * max_num);
-		char *ansi_ptrs_for_free = (char *)malloc(sizeof(char) * max_num * max_len);
-		for (int i = 0; i < max_num; i++)
-			ansi_ptrs[i] = ansi_ptrs_for_free + i * max_len;
-		split_ansi(string, &ansi_num, ansi_ptrs);
+	if (len > 0)
+		waddnstr(view->win, string, len);
 
-		if (ansi_num > 0)
-			draw_ansi(view, &ansi_num, ansi_ptrs);
-		else
-			waddnstr(view->win, string, len);
-
-		free(ansi_ptrs_for_free);
-		free(ansi_ptrs);
+	if (trimmed && use_tilde) {
+		set_view_attr(view, LINE_DELIMITER);
+		waddstr(view->win, opt_truncation_delimiter ? opt_truncation_delimiter : "~");
+		col++;
 	}
+
+	view->col += col;
+	return VIEW_MAX_LEN(view) <= 0;
+}
+
+static bool
+draw_chars_with_ansi(struct view *view, enum line_type type, const char *string, int length,
+	   int max_width, bool use_tilde)
+{
+	int len = 0;
+	int col = 0;
+	int trimmed = false;
+	size_t skip = view->pos.col > view->col ? view->pos.col - view->col : 0;
+
+	if (max_width <= 0)
+		return VIEW_MAX_LEN(view) <= 0;
+
+	if (opt_iconv_out != ICONV_NONE) {
+		string = encoding_iconv(opt_iconv_out, string, len);
+		if (!string)
+			return VIEW_MAX_LEN(view) <= 0;
+	}
+
+	set_view_attr(view, type);
+
+	int ansi_num = 0;
+	int len_with_ansi = strlen(string);
+	int max_num = (len_with_ansi / 4) + 1;
+	int max_len = (len_with_ansi - 4) + 1;
+	char **ansi_ptrs = (char **)malloc(sizeof(char *) * max_num);
+	char *ansi_ptrs_for_free = (char *)malloc(sizeof(char) * max_num * max_len);
+	for (int i = 0; i < max_num; i++)
+		ansi_ptrs[i] = ansi_ptrs_for_free + i * max_len;
+	split_ansi(string, &ansi_num, ansi_ptrs);
+
+	if (ansi_num > 0)
+		draw_ansi(view, &ansi_num, ansi_ptrs, max_width, skip);
+	else {
+		len = utf8_length(&string, length, skip, &col, view->width, &trimmed, use_tilde, opt_tab_size);
+		waddnstr(view->win, string, len);
+	}
+
+	free(ansi_ptrs_for_free);
+	free(ansi_ptrs);
+
 	if (trimmed && use_tilde) {
 		set_view_attr(view, LINE_DELIMITER);
 		waddstr(view->win, opt_truncation_delimiter ? opt_truncation_delimiter : "~");
@@ -134,8 +168,14 @@ draw_text_expanded(struct view *view, enum line_type type, const char *string, i
 		size_t pos = string_expand(text, sizeof(text), string, length, opt_tab_size);
 		size_t col = view->col;
 
-		if (draw_chars(view, type, text, -1, max_width, use_tilde))
-			return true;
+		if (opt_diff_highlight && *opt_diff_highlight && strcmp(opt_diff_highlight, "delta") == 0) {
+			if (draw_chars_with_ansi(view, type, text, -1, max_width, use_tilde))
+				return true;
+		} else {
+			if (draw_chars(view, type, text, -1, max_width, use_tilde))
+				return true;
+		}
+
 		string += pos;
 		length -= pos;
 		max_width -= view->col - col;

--- a/src/draw.c
+++ b/src/draw.c
@@ -121,7 +121,7 @@ draw_chars_with_ansi(struct view *view, enum line_type type, const char *string,
 	if (ansi_num > 0)
 		draw_ansi(view, &ansi_num, ansi_ptrs, max_width, skip);
 	else {
-		len = utf8_length(&string, length, skip, &col, view->width, &trimmed, use_tilde, opt_tab_size);
+		len = utf8_length(&string, length, skip, &col, max_width, &trimmed, use_tilde, opt_tab_size);
 		waddnstr(view->win, string, len);
 	}
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -13,6 +13,7 @@
 
 #include "tig/tig.h"
 #include "tig/graph.h"
+#include "tig/ansi.h"
 #include "tig/draw.h"
 #include "tig/options.h"
 #include "compat/hashtab.h"
@@ -74,9 +75,25 @@ draw_chars(struct view *view, enum line_type type, const char *string, int lengt
 	}
 
 	set_view_attr(view, type);
-	if (len > 0)
-		waddnstr(view->win, string, len);
+	if (len > 0) {
+		int ansi_num = 0;
+		int len_with_ansi = strlen(string);
+		int max_num = (len_with_ansi / 4) + 1;
+		int max_len = (len_with_ansi - 4) + 1;
+		char **ansi_ptrs = (char **)malloc(sizeof(char *) * max_num);
+		char *ansi_ptrs_for_free = (char *)malloc(sizeof(char) * max_num * max_len);
+		for (int i = 0; i < max_num; i++)
+			ansi_ptrs[i] = ansi_ptrs_for_free + i * max_len;
+		split_ansi(string, &ansi_num, ansi_ptrs);
 
+		if (ansi_num > 0)
+			draw_ansi(view, &ansi_num, ansi_ptrs);
+		else
+			waddnstr(view->win, string, len);
+
+		free(ansi_ptrs_for_free);
+		free(ansi_ptrs);
+	}
 	if (trimmed && use_tilde) {
 		set_view_attr(view, LINE_DELIMITER);
 		waddstr(view->win, opt_truncation_delimiter ? opt_truncation_delimiter : "~");

--- a/src/draw.c
+++ b/src/draw.c
@@ -168,7 +168,7 @@ draw_text_expanded(struct view *view, enum line_type type, const char *string, i
 		size_t pos = string_expand(text, sizeof(text), string, length, opt_tab_size);
 		size_t col = view->col;
 
-		if (opt_diff_highlight && *opt_diff_highlight && strcmp(opt_diff_highlight, "delta") == 0) {
+		if (opt_diff_highlight && *opt_diff_highlight && strcmp(opt_diff_highlight, "delta") == 0 && strstr(string, "\033[") != NULL) {
 			if (draw_chars_with_ansi(view, type, text, -1, max_width, use_tilde))
 				return true;
 		} else {

--- a/src/line.c
+++ b/src/line.c
@@ -246,6 +246,14 @@ init_colors(void)
 		color_pairs_map[fg][bg] = cnt;
 	}
 	}
+	for (short bg = 0; bg < 256; bg++) {
+		init_extended_pair(++cnt, COLOR_DEFAULT, bg);
+		color_pairs_map[256][bg] = cnt;
+	}
+	for (short fg = 0; fg < 256; fg++) {
+		init_extended_pair(++cnt, fg, COLOR_DEFAULT);
+		color_pairs_map[fg][256] = cnt;
+	}
 }
 
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/line.c
+++ b/src/line.c
@@ -23,6 +23,8 @@ static size_t line_rules;
 static struct line_info **color_pair;
 static size_t color_pairs;
 
+short color_pairs_map[256][256];
+
 DEFINE_ALLOCATOR(realloc_line_rule, struct line_rule, 8)
 DEFINE_ALLOCATOR(realloc_color_pair, struct line_info *, 8)
 
@@ -231,6 +233,20 @@ init_colors(void)
 		for (info = &rule->info; info; info = info->next) {
 			init_line_info_color_pair(info, type, default_bg, default_fg);
 		}
+	}
+
+	// TODO: init_extended_pair must be able to accept more than 256 here
+	// if we compiled with --ext-colors, but it doesn't work.
+	// https://github.com/mirror/ncurses/blob/56a81c7e79f73d397cc8074401d039f59c34cad5/ncurses/base/lib_color.c#L382-L391
+	// Currently we skip the odd number upper than 15.
+	short cnt = COLOR_ID(LINE_NONE);
+	for (short bg = 0; bg < 256; bg++) {
+	for (short fg = 0; fg < 256; fg++) {
+		if ((fg > 15 && fg % 2 == 1) || (bg > 15 && bg % 2 == 1))
+			continue;
+		init_extended_pair(cnt++, fg, bg);
+		color_pairs_map[fg][bg] = cnt;
+	}
 	}
 }
 

--- a/src/line.c
+++ b/src/line.c
@@ -239,12 +239,12 @@ init_colors(void)
 	// if we compiled with --ext-colors, but it doesn't work.
 	// https://github.com/mirror/ncurses/blob/56a81c7e79f73d397cc8074401d039f59c34cad5/ncurses/base/lib_color.c#L382-L391
 	// Currently we skip the odd number upper than 15.
-	short cnt = COLOR_ID(LINE_NONE);
+	short cnt = COLOR_ID(LINE_NONE) + 1;
 	for (short bg = 0; bg < 256; bg++) {
 	for (short fg = 0; fg < 256; fg++) {
 		if ((fg > 15 && fg % 2 == 1) || (bg > 15 && bg % 2 == 1))
 			continue;
-		init_extended_pair(cnt++, fg, bg);
+		init_extended_pair(++cnt, fg, bg);
 		color_pairs_map[fg][bg] = cnt;
 	}
 	}

--- a/src/line.c
+++ b/src/line.c
@@ -23,7 +23,7 @@ static size_t line_rules;
 static struct line_info **color_pair;
 static size_t color_pairs;
 
-short color_pairs_map[256][256];
+short color_pairs_map[257][257];
 
 DEFINE_ALLOCATOR(realloc_line_rule, struct line_rule, 8)
 DEFINE_ALLOCATOR(realloc_color_pair, struct line_info *, 8)
@@ -254,6 +254,8 @@ init_colors(void)
 		init_extended_pair(++cnt, fg, COLOR_DEFAULT);
 		color_pairs_map[fg][256] = cnt;
 	}
+	init_extended_pair(++cnt, COLOR_DEFAULT, COLOR_DEFAULT);
+	color_pairs_map[256][256] = cnt;
 }
 
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/line.c
+++ b/src/line.c
@@ -235,10 +235,8 @@ init_colors(void)
 		}
 	}
 
-	// TODO: init_extended_pair must be able to accept more than 256 here
-	// if we compiled with --ext-colors, but it doesn't work.
-	// https://github.com/mirror/ncurses/blob/56a81c7e79f73d397cc8074401d039f59c34cad5/ncurses/base/lib_color.c#L382-L391
-	// Currently we skip the odd number upper than 15.
+	// Because init_extended_pair can't accept more than 32768 pairs,
+	// we skip the colors with color codes odd numbered and greater than 15 currently.
 	short cnt = COLOR_ID(LINE_NONE) + 1;
 	for (short bg = 0; bg < 256; bg++) {
 	for (short fg = 0; fg < 256; fg++) {

--- a/src/string.c
+++ b/src/string.c
@@ -103,7 +103,7 @@ string_expand(char *dst, size_t dstlen, const char *src, int srclen, int tabsize
 				expanded = dstlen - size - 1;
 			memcpy(dst + size, "        ", expanded);
 			size += expanded;
-		} else if (isspace(c) || iscntrl(c)) {
+		} else if ((isspace(c) || iscntrl(c)) && !(c == '\033' && src[pos+1] == '[')) {
 			dst[size++] = ' ';
 		} else {
 			dst[size++] = src[pos];

--- a/test/diff/diff-highlight-with-delta-test
+++ b/test/diff/diff-highlight-with-delta-test
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+test_require delta
+
+export PATH="$(dirname -- "$delta_path"):$PATH"
+
+tigrc <<EOF
+set diff-highlight = "delta"
+EOF
+
+steps '
+	:save-display diff-highlight-with-delta.screen
+'
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+test_tig show master^
+
+assert_equals 'diff-highlight-with-delta.screen' <<EOF
+commit a1dcf1aaa11470978db1d5d8bcf9e16201eb70ff
+Author:     Jonas Fonseca <jonas.fonseca@gmail.com>
+AuthorDate: Sat Mar 1 15:59:02 2014 -0500
+Commit:     Jonas Fonseca <jonas.fonseca@gmail.com>
+CommitDate: Sat Mar 1 15:59:02 2014 -0500
+ 
+    Add type parameter for js.Dynamic
+---
+ common/src/main/scala/org/scalajs/benchmark/Benchmark.scala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+ 
+ 
+common/src/main/scala/org/scalajs/benchmark/Benchmark.scala
+────────────────────────────────────────────────────────────────────────────────
+ 
+───────────────────────┐
+15: object Benchmark { │
+───────────────────────┘
+  val benchmarks = js.Array[Benchmark]()
+  val benchmarkApps = js.Array[BenchmarkApp]()
+ 
+  val global = js.Dynamic.global.asInstanceOf[js.Dictionary]
+  val global = js.Dynamic.global.asInstanceOf[js.Dictionary[js.Any]]
+  global("runScalaJSBenchmarks") = runBenchmarks _
+  global("initScalaJSBenchmarkApps") = initBenchmarkApps _
+ 
+ 
+ 
+[diff] a1dcf1aaa11470978db1d5d8bcf9e16201eb70ff - line 1 of 26              100%
+EOF

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -440,11 +440,11 @@ show_test_results()
 		fi
 
 		# Replace CR used by Git progress messages
-	  kernel="$(uname -s 2>/dev/null || printf 'unknown\n')"
-	  case "$kernel" in
-	  	Darwin)	LC_ALL=C tr '\r' '\n' < .test-result ;;
-	  	*)	tr '\r' '\n' < .test-result ;;
-	  esac
+		kernel="$(uname -s 2>/dev/null || printf 'unknown\n')"
+		case "$kernel" in
+			Darwin)	LC_ALL=C tr '\r' '\n' < .test-result ;;
+			*)	tr '\r' '\n' < .test-result ;;
+		esac
 
 	elif [ -n "$verbose" ]; then
 		count="$(grep -c '^ *\[OK\]' < .test-result || true)"

--- a/test/tools/libtest.sh
+++ b/test/tools/libtest.sh
@@ -440,7 +440,12 @@ show_test_results()
 		fi
 
 		# Replace CR used by Git progress messages
-		tr '\r' '\n' < .test-result
+	  kernel="$(uname -s 2>/dev/null || printf 'unknown\n')"
+	  case "$kernel" in
+	  	Darwin)	LC_ALL=C tr '\r' '\n' < .test-result ;;
+	  	*)	tr '\r' '\n' < .test-result ;;
+	  esac
+
 	elif [ -n "$verbose" ]; then
 		count="$(grep -c '^ *\[OK\]' < .test-result || true)"
 		printf 'Passed %d assertions\n' "$count"
@@ -546,6 +551,12 @@ test_require()
 			fi
 			if [ ! -e "$diff_highlight_path" ]; then
 				test_skip "The test requires diff-highlight, usually found in share/git-core-contrib"
+			fi
+			;;
+		delta)
+			delta_path="/usr/local/bin/delta"
+			if [ ! -e "$delta_path" ]; then
+				test_skip "The test requires git-delta, https://dandavison.github.io/delta/installation.html"
 			fi
 			;;
 		readline)


### PR DESCRIPTION
https://github.com/jonas/tig/issues/542#issuecomment-899094741

- All test passes.
- I haven't seen segmentation faults with newest versions of MacOS Big Sur, iTerm2, and delta. ncurses version is 6.2.
- It looks like no performance issues.
- I've only tested it with Terminal.app and iTerm on MacOS.

![ss 0003-08-17 at 19 11 58](https://user-images.githubusercontent.com/41639488/129708738-311c1604-e53b-4c2f-98c8-1d908cb801b3.png)
![ss 0003-08-17 at 19 12 36](https://user-images.githubusercontent.com/41639488/129708762-eafd62bc-b6aa-4922-baee-64b6b4b0a308.png)

### how to use delta in tig

It requires ncurse 6.1 or higher.

```bash
# if you don't have ncurses
curl -O ftp://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz
tar -xzvf ncurses-6.2.tar.gz
cd ncurses-6.2
./configure --prefix=${where you like} --enable-pc-files --with-pkg-config-libdir=/usr/local/bin/pkgconfig --enable-sigwinch --enable-symlinks --enable-widec --with-shared --with-gpm=no --without-ada --enable-ext-colors # i set the path as /usr/local which is default
sudo make
sudo make install

cd ${path to tig of the branch of above PR}
make configure
./configure LDFLAGS=-L${where you download ncurses}/lib CPPFLAGS=-I{where you installed ncurses}/include  # i set the path as /usr/local/opt/ncurses which is installed by ncurses
make

echo "set diff-highlight = \"delta\"" >> ~/.tigrc

./src/tig
```