### PR TITLE
Refactor: break up nested ternaries into multiple lines

### DIFF
--- a/src/argv.c
+++ b/src/argv.c
@@ -337,8 +337,24 @@ format_append_arg(struct format_context *format, const char ***dst_argv, const c
 		const char *var = strstr(arg, "%(");
 		const char *esc = var > arg && *(var - 1) == '%' ? var - 1 : NULL;
 		const char *closing = var ? strchr(var, ')') : NULL;
-		const char *next = esc > arg ? esc : closing ? closing + 1 : NULL;
-		const int len = var && !esc ? var - arg : esc > arg ? esc - arg : next ? next - ++arg : strlen(arg);
+		const char *next;
+		int len;
+
+		if (esc > arg)
+			next = esc;
+		else if (closing)
+			next = closing + 1;
+		else
+			next = NULL;
+
+		if (var && !esc)
+			len = var - arg;
+		else if (esc > arg)
+			len = esc - arg;
+		else if (next)
+			len = next - ++arg;
+		else
+			len = strlen(arg);
 
 		if (var && !closing)
 			return false;

--- a/src/view.c
+++ b/src/view.c
@@ -1467,7 +1467,12 @@ get_view_column(struct view *view, enum view_column_type type)
 	return NULL;
 }
 
-#define MAXWIDTH(maxwidth)	(width == 0 ? maxwidth < 0 ? -maxwidth * view->width / 100 : maxwidth : 0)
+#define MAXWIDTH(maxwidth) \
+	(width == 0 \
+		? maxwidth < 0 \
+			? -maxwidth * view->width / 100 \
+			: maxwidth \
+		: 0)
 
 bool
 view_column_info_update(struct view *view, struct line *line)


### PR DESCRIPTION
We have some places where multiple ternary operators are nested on a
single line.  Break them up into multiple lines. I think this is much
easier to read because the indentation shows the nesting structure.
No functional change here.

Reading through format_append_arg(), I noticed that "echo %%(commit"
with the missing closing parenthesis is not supported. Probably
not worth spending too much time on that.
