### PR TITLE
Remove quotes from TIG_LS_REMOTE to allow inline shell commands

### DIFF
--- a/src/refdb.c
+++ b/src/refdb.c
@@ -325,7 +325,7 @@ reload_refs(bool force)
 		int argc = 0;
 
 		string_ncopy(ls_remote_cmd, env, strlen(env));
-		if (!argv_from_string(ls_remote_argv, &argc, ls_remote_cmd))
+		if (!argv_from_string_no_quotes(ls_remote_argv, &argc, ls_remote_cmd))
 			return error("Failed to parse TIG_LS_REMOTE: %s", env);
 	}
 

--- a/test/refs/filter-test
+++ b/test/refs/filter-test
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Test ref filtering (GitHub issue #1160)
+
+. libtest.sh
+. libgit.sh
+
+export LINES=9
+export COLUMNS=120
+
+git_init
+
+test_setup_work_dir() {
+	git_commit --allow-empty -m Initial\ commit
+	git branch my-branch1 HEAD
+	git branch my-branch2 HEAD
+	git update-ref refs/remotes/origin/my-branch1 HEAD
+	git update-ref refs/remotes/origin/my-branch2 HEAD
+	git tag my-tag1 HEAD
+	git tag my-tag2 HEAD
+	git update-ref refs/my-raw-ref1 HEAD
+	git update-ref refs/my-raw-ref2 HEAD
+}
+
+export TIG_LS_REMOTE='sh -c "git show-ref --head --dereference | grep -v refs/.\\*1"'
+
+steps '
+	:save-display main.screen
+	:view-refs
+	:save-display refs.screen
+'
+
+test_tig
+
+assert_equals 'main.screen' <<EOF
+2009-02-13 23:31 +0000 Committer I [master] [my-branch2] [refs/my-raw-ref2] {origin/my-branch2} <my-tag2> Initial commit
+
+
+
+
+
+
+[main] 174877369ea7af366da2ebcedd63d7a00d8046ea - commit 1 of 1  100%
+EOF
+
+assert_equals 'refs.screen' <<EOF
+  All references
+  master
+  my-branch2
+  refs/my-raw-ref2
+  origin/my-branch2
+  my-tag2
+
+[refs] All references  100%
+EOF


### PR DESCRIPTION
The environment variable TIG_LS_REMOTE can be used to select the
references that Tig will display.

When using a command like TIG_LS_REMOTE='sh -c "a | b"' tig, we pass an
argv-array with 3 elements to execvpe.  The third argument is passed
with quotes, which means that the shell tries to run a command that
is literally called 'a | b'.

Fix this by removing quotes. We already split arguments with a
shell-like syntax, so this only improves compatibility.

This makes it easier filter away unwanted refs (#1160) without creating
a script TIG_LS_REMOTE.
