### PR TITLE
Add reference types stash and other

### DIFF
--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -185,12 +185,14 @@ The following variables can be set:
 	Prefix with `hide:` to not show that reference type, e.g. `hide:remote`.
 	Supported reference types are:
 	 - head			: The current HEAD.
-	 - tag			: A signed tag.
-	 - local-tag		: An unsigned tag.
+	 - tag			: An annotated tag.
+	 - local-tag		: A lightweight tag.
 	 - remote		: A remote.
 	 - tracked-remote	: The remote tracked by current HEAD.
 	 - replace		: A replaced reference.
-	 - branch		: Any other reference.
+	 - branch		: A branch.
+	 - stash		: The stash.
+	 - other		: Any other reference.
 
 'line-graphics' (mixed) [ascii|default|utf-8|auto|<bool>]::
 

--- a/include/tig/types.h
+++ b/include/tig/types.h
@@ -143,7 +143,9 @@ bool map_enum_do(const struct enum_map_entry *map, size_t map_size, int *value, 
 
 #define REFERENCE_ENUM(_) \
 	_(REFERENCE, HEAD), \
+	_(REFERENCE, STASH), \
 	_(REFERENCE, BRANCH), \
+	_(REFERENCE, OTHER), \
 	_(REFERENCE, TRACKED_REMOTE), \
 	_(REFERENCE, REMOTE), \
 	_(REFERENCE, TAG), \

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -230,6 +230,12 @@ add_to_refs(const char *id, size_t idlen, char *name, size_t namelen, struct ref
 		if (*opt->head)
 			return SUCCESS;
 		type = REFERENCE_HEAD;
+
+	} else if (!strcmp(name, "refs/stash")) {
+		type = REFERENCE_STASH;
+
+	} else if (!prefixcmp(name, "refs/")) {
+		type = REFERENCE_OTHER;
 	}
 
 	/* If we are reloading or it's an annotated tag, replace the

--- a/tigrc
+++ b/tigrc
@@ -93,12 +93,14 @@ set truncation-delimiter	= ~		# Character drawn for truncations, or "utf-8"
 
 # Format reference names based on type.
 #  - head		: The current HEAD.
-#  - tag		: A signed tag.
-#  - local-tag		: An unsigned tag.
+#  - tag		: An annotated tag.
+#  - local-tag		: A lightweight tag.
 #  - remote		: A remote.
 #  - tracked-remote	: The remote tracked by current HEAD.
 #  - replace		: A replaced reference.
-#  - branch		: Any other reference.
+#  - branch		: A branch.
+#  - stash		: The stash.
+#  - other		: Any other reference.
 # If no format is defined for `local-tag` then the one for `tag` is used.
 # Similarly, `remote` is used if no `tracked-remote` format exists.
 # Prefix with `hide:` to not show that reference type, e.g. `hide:remote`.


### PR DESCRIPTION
This makes it possible to filter refs created by tools such as git-branchless
with `set reference-format = hide:other`.

Closes #1160