### PR TITLE
Revert terminal hacks and workarounds

### DIFF
--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -145,7 +145,6 @@ struct view {
 	struct line *curline;	/* Line currently being drawn. */
 	enum line_type curtype;	/* Attribute currently used for drawing. */
 	unsigned long col;	/* Column when drawing. */
-	bool has_scrolled;	/* View was scrolled. */
 	bool force_redraw;	/* Whether to force a redraw after reading. */
 
 	/* Loading */

--- a/src/display.c
+++ b/src/display.c
@@ -463,10 +463,6 @@ save_view(struct view *view, const char *path)
 /* Whether or not the curses interface has been initialized. */
 static bool cursed = false;
 
-/* Terminal hacks and workarounds. */
-static bool use_scroll_redrawwin;
-static bool use_scroll_status_wclear;
-
 /* The status window is used for polling keystrokes. */
 WINDOW *status_win;
 
@@ -484,8 +480,6 @@ update_status_window(struct view *view, const char *context, const char *msg, va
 
 	if (!status_empty || *msg) {
 		wmove(status_win, 0, 0);
-		if (view && view->has_scrolled && use_scroll_status_wclear)
-			wclear(status_win);
 		if (*msg) {
 			vw_printw(status_win, msg, args);
 			status_empty = false;
@@ -637,7 +631,6 @@ void
 init_display(void)
 {
 	bool no_display = !!getenv("TIG_NO_DISPLAY");
-	const char *term;
 	int x, y;
 	int code;
 
@@ -691,36 +684,6 @@ init_display(void)
 #else
 	TABSIZE = opt_tab_size;
 #endif
-
-	term = getenv("XTERM_VERSION")
-		   ? NULL
-		   : (getenv("TERM_PROGRAM") ? getenv("TERM_PROGRAM") : getenv("COLORTERM"));
-	if (term && !strcmp(term, "gnome-terminal")) {
-		/* In the gnome-terminal-emulator, the warning message
-		 * shown when scrolling up one line while the cursor is
-		 * on the first line followed by scrolling down one line
-		 * corrupts the status line. This is fixed by calling
-		 * wclear. */
-		use_scroll_status_wclear = true;
-		use_scroll_redrawwin = false;
-
-	} else if (term &&
-			   (!strcmp(term, "xrvt-xpm") || !strcmp(term, "Apple_Terminal") ||
-				!strcmp(term, "iTerm.app"))) {
-		/* No problems with full optimizations in
-		 * xrvt-(unicode)
-		 * aterm
-		 * Terminal.app
-		 * iTerm2 */
-		use_scroll_status_wclear = use_scroll_redrawwin = false;
-
-	} else {
-		/* When scrolling in (u)xterm the last line in the
-		 * scrolling direction will update slowly.  This is
-		 * the conservative default. */
-		use_scroll_redrawwin = true;
-		use_scroll_status_wclear = false;
-	}
 }
 
 static bool
@@ -785,10 +748,6 @@ update_views(void)
 
 	foreach_view (view, i) {
 		update_view(view);
-		if (view_is_displayed(view) && view->has_scrolled &&
-		    use_scroll_redrawwin)
-			redrawwin(view->win);
-		view->has_scrolled = false;
 		if (view->pipe)
 			is_loading = true;
 	}

--- a/src/view.c
+++ b/src/view.c
@@ -92,7 +92,6 @@ do_scroll_view(struct view *view, int lines)
 		wnoutrefresh(view->win);
 	}
 
-	view->has_scrolled = true;
 	report_clear();
 }
 


### PR DESCRIPTION
The extra redrawwin() added by b445baeb8e9c67d1d3cf943e350cbd4fd0cbd174
to fix a scrolling bug in (u)xterm is causing flickering when paging
in XTerm(370).

As the original issues with xterm and gnome-terminal cannot be
reproduced anymore even on a now antique distro, revert the
associated workarounds.

Fixes #1180