### PR TITLE
Autoscroll in pager

### DIFF
--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -88,6 +88,7 @@ typedef struct view_column *view_settings;
 	_(vertical_split,		enum vertical_split,	VIEW_RESET_DISPLAY | VIEW_DIFF_LIKE) \
 	_(wrap_lines,			bool,			VIEW_DIFF_LIKE) \
 	_(wrap_search,			bool,			VIEW_NO_FLAGS) \
+        _(pager_autoscroll,		bool,		        VIEW_NO_FLAGS) \
 
 #define DEFINE_OPTION_EXTERNS(name, type, flags) extern type opt_##name;
 OPTION_INFO(DEFINE_OPTION_EXTERNS)

--- a/src/view.c
+++ b/src/view.c
@@ -621,6 +621,7 @@ begin_update(struct view *view, const char *dir, const char **argv, enum open_fl
 bool
 update_view(struct view *view)
 {
+        bool should_autoscroll = false;
 	/* Clear the view and redraw everything since the tree sorting
 	 * might have rearranged things. */
 	bool redraw = view->lines == 0;
@@ -652,11 +653,19 @@ update_view(struct view *view)
 			return false;
 		}
 
+		if ((view->pos.offset + view->height + 1) == view->lines)
+		    should_autoscroll = true;
+
 		if (!view->ops->read(view, &line, false)) {
 			report("Allocation failure");
 			end_update(view, true);
 			return false;
 		}
+
+		/* Autoscroll is available only in pager */
+		if (should_autoscroll && opt_pager_autoscroll &&
+                    !strcmp(view->name, "pager"))
+		        do_scroll_view(view, 2);
 	}
 
 	if (io_error(view->pipe)) {

--- a/tigrc
+++ b/tigrc
@@ -143,6 +143,7 @@ set mouse			= no		# Enable mouse support?
 set mouse-scroll		= 3		# Number of lines to scroll via the mouse
 set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?
 set pgrp			= no		# Make tig process-group leader
+set pager-autoscroll            = no
 
 # User-defined commands
 # ---------------------


### PR DESCRIPTION
A second attempt (after #1139) to add two features:
- autoscroll in pager,
- regex matching lines colorization in pager.

In this attempt I've did what has been recommended to me previously:
- autoscroll is off by default so that `tig`  resembles `less` (`set pager-autoscroll = off`),,
- the regex used by the line colorization can be also customized via an option `color-pager-regex`.

I think that running `make` in pager is a good use case and it could be better supported.