### PR TITLE
Use tab-size from EditorConfig

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,5 +28,8 @@ jobs:
           export LANG=en_US.utf8
           sudo apt update
           sudo DEBIAN_FRONTEND=noninteractive apt -yq install --no-install-recommends \
-            asciidoc valgrind xmlto
+            asciidoc \
+            libeditorconfig-dev \
+            valgrind \
+            xmlto
           CC=${{ matrix.compiler }} TIG_BUILD=${{ matrix.tig_build }} tools/travis.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,5 +45,13 @@ jobs:
       - name: Test Tig
         shell: 'script -q typescript sh {0}' # Workaround to get a TTY, see https://github.com/gfx/example-github-actions-with-tty
         run: |
-          brew install asciidoc autoconf automake coreutils gnu-sed ncurses xmlto
+          brew install \
+            asciidoc \
+            autoconf \
+            automake \
+            coreutils \
+            editorconfig \
+            gnu-sed \
+            ncurses \
+            xmlto
           TIG_BUILD=autoconf tools/travis.sh

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -206,6 +206,8 @@ configure script and building documentation:
 				 search and command prompts.
 |PCRE				|Adds support for Perl Compatible Regular
 				 Expressions in searches.
+|EditorConfig core library      |Adds support for setting tab-size based on
+                                 an .editorconfig file.
 |autoconf			|Contains autoreconf for generating configure
 				 from configure.ac.
 |asciidoc (>= 8.4)		|Generates HTML and (DocBook) XML from text.

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,6 +1,13 @@
 Release notes
 =============
 
+master
+------
+
+Improvements:
+
+- Honor tab width from EditorConfig by linking against the EditorConfig core library. (#1239)
+
 tig-2.5.8
 ---------
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,16 @@ AS_IF([test "x$with_pcre" != xno], [
 	])
 ])
 
+dnl Check for EditorConfig library
+AC_ARG_WITH(editorconfig, [AS_HELP_STRING([--without-editorconfig], [do not use the EditorConfig library])])
+AS_IF([test "x$with_editorconfig" != xno], [
+	AC_CHECK_HEADERS([editorconfig/editorconfig.h])
+	AS_IF([test "x$ac_cv_header_editorconfig_editorconfig_h" = xyes], [
+		AC_DEFINE([HAVE_EDITORCONFIG], [1], [Define if you have EditorConfig])
+		LIBS="$LIBS -leditorconfig"
+	])
+])
+
 dnl OS-specific
 case $(uname -s 2>/dev/null || echo unknown) in "OS400")
 	AC_CHECK_LIB(util, main, [LIBS="$LIBS -lutil"], AC_MSG_ERROR([Please install the libutil-devel package]))

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -269,6 +269,7 @@ The following variables can be set:
 'tab-size' (int)::
 
 	Number of spaces per tab. The default is 8 spaces.
+        This may be overridden by an EditorConfig file.
 
 'diff-context' (int)::
 

--- a/include/tig/diff.h
+++ b/include/tig/diff.h
@@ -16,7 +16,16 @@
 
 #include "tig/view.h"
 
+#if defined HAVE_EDITORCONFIG
+struct diff_common_state {
+		uint8_t tab_size;
+};
+#endif
+
 struct diff_state {
+#if defined HAVE_EDITORCONFIG
+	struct diff_common_state common;
+#endif
 	bool after_commit_title;
 	bool after_diff;
 	bool reading_diff_chunk;

--- a/include/tig/draw.h
+++ b/include/tig/draw.h
@@ -25,7 +25,7 @@ enum align {
 	ALIGN_RIGHT
 };
 
-bool draw_text(struct view *view, enum line_type type, const char *string);
+bool draw_text(struct view *view, enum line_type type, const char *string, int tab_size);
 bool PRINTF_LIKE(3, 4) draw_formatted(struct view *view, enum line_type type, const char *format, ...);
 bool draw_graphic(struct view *view, enum line_type type, const chtype graphic[], size_t size, bool separator);
 bool draw_field(struct view *view, enum line_type type, const char *text, int width, enum align align, bool trim);

--- a/include/tig/pager.h
+++ b/include/tig/pager.h
@@ -17,9 +17,11 @@
 #include "tig/view.h"
 
 bool pager_get_column_data(struct view *view, const struct line *line, struct view_column_data *column_data);
-bool pager_common_read(struct view *view, const char *data, enum line_type type, struct line **line);
+bool pager_common_read(struct view *view, const char *data, enum line_type type, bool is_diff, struct line **line);
 enum request pager_request(struct view *view, enum request request, struct line *line);
 void pager_select(struct view *view, struct line *line);
+
+uint8_t editorconfig_tab_size(const char file[]);
 
 extern struct view pager_view;
 

--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -39,6 +39,9 @@ struct box {
 struct line {
 	enum line_type type;
 	unsigned int lineno:24;
+#if defined HAVE_EDITORCONFIG
+	unsigned int tab_size:8;
+#endif
 
 	/* State flags */
 	unsigned int selected:1;

--- a/src/blob.c
+++ b/src/blob.c
@@ -14,6 +14,7 @@
 #include "tig/refdb.h"
 #include "tig/parse.h"
 #include "tig/repo.h"
+#include "tig/diff.h"
 #include "tig/display.h"
 #include "tig/draw.h"
 #include "tig/ui.h"
@@ -22,6 +23,9 @@
 #include "tig/blob.h"
 
 struct blob_state {
+#if defined HAVE_EDITORCONFIG
+	struct diff_common_state common;
+#endif
 	char commit[SIZEOF_REF];
 	const char *file;
 };
@@ -90,6 +94,10 @@ blob_open(struct view *view, enum open_flags flags)
 	else
 		string_copy_rev(view->ref, view->ops->id);
 
+#if defined HAVE_EDITORCONFIG
+	state->common.tab_size = editorconfig_tab_size(view->env->file);
+#endif
+
 	return begin_update(view, NULL, argv, flags);
 }
 
@@ -104,7 +112,7 @@ blob_read(struct view *view, struct buffer *buf, bool force_stop)
 		return true;
 	}
 
-	return pager_common_read(view, buf->data, LINE_DEFAULT, NULL);
+	return pager_common_read(view, buf->data, LINE_DEFAULT, false, NULL);
 }
 
 static void

--- a/src/display.c
+++ b/src/display.c
@@ -678,12 +678,6 @@ init_display(void)
 		keyok(code, false);
 	}
 #endif
-
-#if defined(NCURSES_VERSION_PATCH) && (NCURSES_VERSION_PATCH >= 20080119)
-	set_tabsize(opt_tab_size);
-#else
-	TABSIZE = opt_tab_size;
-#endif
 }
 
 static bool

--- a/src/draw.c
+++ b/src/draw.c
@@ -471,6 +471,12 @@ view_column_draw(struct view *view, struct line *line, unsigned int lineno)
 {
 	struct view_column *column = view->columns;
 	struct view_column_data column_data = {0};
+	int tab_size;
+#if defined HAVE_EDITORCONFIG
+	tab_size = line->tab_size ? line->tab_size : opt_tab_size;
+#else
+	tab_size = opt_tab_size;
+#endif
 
 	if (!view->ops->get_column_data(view, line, &column_data))
 		return true;
@@ -582,13 +588,13 @@ view_column_draw(struct view *view, struct line *line, unsigned int lineno)
 						indent = 0;
 					}
 
-					if (draw_textn(view, cell->type, text, length, opt_tab_size))
+					if (draw_textn(view, cell->type, text, length, tab_size))
 						return true;
 
 					text += length;
 				}
 
-			} else if (draw_text(view, type, text, opt_tab_size)) {
+			} else if (draw_text(view, type, text, tab_size)) {
 				return true;
 			}
 		}

--- a/src/help.c
+++ b/src/help.c
@@ -46,7 +46,7 @@ help_draw(struct view *view, struct line *line, unsigned int lineno)
 			       keymap->hidden ? '+' : '-', keymap->name);
 
 	} else if (line->type == LINE_HELP_GROUP || !keymap) {
-		draw_text(view, line->type, help->data.text);
+		draw_text(view, line->type, help->data.text, opt_tab_size);
 
 	} else if (help->request > REQ_RUN_REQUESTS) {
 		struct run_request *req = get_run_request(help->request);
@@ -73,7 +73,7 @@ help_draw(struct view *view, struct line *line, unsigned int lineno)
 		if (draw_field(view, LINE_HELP_ACTION, enum_name(req_info->name), state->name_width, ALIGN_LEFT, false))
 			return true;
 
-		draw_text(view, LINE_DEFAULT, req_info->help);
+		draw_text(view, LINE_DEFAULT, req_info->help, opt_tab_size);
 	}
 
 	return true;

--- a/src/log.c
+++ b/src/log.c
@@ -19,6 +19,9 @@
 #include "tig/pager.h"
 
 struct log_state {
+#if defined HAVE_EDITORCONFIG
+	struct diff_common_state common;
+#endif
 	/* Used for tracking when we need to recalculate the previous
 	 * commit, for example when the user scrolls up or uses the page
 	 * up/down in the log view. */
@@ -145,7 +148,7 @@ log_read(struct view *view, struct buffer *buf, bool force_stop)
 		state->reading_diff_stat = false;
 	}
 
-	if (!pager_common_read(view, data, type, &line))
+	if (!pager_common_read(view, data, type, true, &line))
 		return false;
 	if (line && state->graph_indent)
 		line->graph_indent = 1;

--- a/src/stage.c
+++ b/src/stage.c
@@ -767,6 +767,11 @@ stage_open(struct view *view, enum open_flags flags)
 	if (stage_line_type != LINE_STAT_UNTRACKED)
 		diff_save_line(view, &state->diff, flags);
 
+#if defined HAVE_EDITORCONFIG
+	if (stage_line_type == LINE_STAT_UNTRACKED)
+		state->diff.common.tab_size = editorconfig_tab_size(stage_status.new.name);
+#endif
+
 	view->vid[0] = 0;
 	code = begin_update(view, repo.exec_dir, argv, flags);
 	if (code == SUCCESS && stage_line_type != LINE_STAT_UNTRACKED) {
@@ -787,7 +792,7 @@ stage_read(struct view *view, struct buffer *buf, bool force_stop)
 		return true;
 
 	if (stage_line_type == LINE_STAT_UNTRACKED)
-		return pager_common_read(view, buf ? buf->data : NULL, LINE_DEFAULT, NULL);
+		return pager_common_read(view, buf ? buf->data : NULL, LINE_DEFAULT, false, NULL);
 
 	if (!buf) {
 		if (!diff_done_highlight(&state->diff)) {

--- a/src/tig.c
+++ b/src/tig.c
@@ -60,6 +60,10 @@
 #include <pcre.h>
 #endif
 
+#if defined HAVE_EDITORCONFIG
+#include <editorconfig/editorconfig.h>
+#endif
+
 /*
  * Option management
  */
@@ -543,6 +547,14 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 				printf("PCRE2 version %s\n", pcre2_version);
 #elif defined HAVE_PCRE
 				printf("PCRE version %s\n", pcre_version());
+#endif
+#if defined HAVE_EDITORCONFIG
+				{
+					int major, minor, patch;
+					const char *suffix = editorconfig_get_version_suffix();
+					editorconfig_get_version(&major, &minor, &patch);
+					printf("EditorConfig version %d.%d.%d%s\n", major, minor, patch, suffix);
+				}
 #endif
 				exit(EXIT_SUCCESS);
 


### PR DESCRIPTION
For projects that use tab width != 8, we need to set the "tab-size"
config option.  Many projects these days state their preference in a
".editorconfig" file.

Add an optional dependency to the EditorConfig library to read such
files. Prefer the tab-size from EditorConfig, over the "tab-size"
config option. Not being able to override the EditorConfig tab-size
seems counterintuitive but I don't see why someone would want that, so
I'd wait until someone complains. If we want that we could implement a
"tab-size-from-editorconfig" option that defaults to true.

Closes #840
