### PR TITLE
Correctly report which version of libncurses was linked

### DIFF
--- a/src/tig.c
+++ b/src/tig.c
@@ -557,7 +557,7 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 				printf("tig version %s\n", TIG_VERSION);
 #ifdef NCURSES_VERSION
 				printf("%s version %s.%d\n",
-#ifdef NCURSES_WIDECHAR
+#if defined(HAVE_NCURSESW_CURSES_H) || defined(HAVE_NCURSESW_H)
 				       "ncursesw",
 #else
 				       "ncurses",


### PR DESCRIPTION
Later versions of ncurses (20111030 and up) support NCURSES_WIDECHAR even when compiling with libncurses instead of libncursesw.

Have tig correctly report whether it was linked against libncursesw or libncurses based off the same defines we set in the build script and use to determine which headers to include.

(See #1240 as an example of where `tig --version` incorrectly reports `ncursesw` instead of `ncurses`).