### PR TITLE
Can edit in Pager

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -155,6 +155,9 @@ pager_request(struct view *view, enum request request, struct line *line)
 	enum open_flags flags = view_is_displayed(view) ? OPEN_SPLIT : OPEN_DEFAULT;
 	int split = 0;
 
+	if (request == REQ_EDIT)
+		return diff_common_edit(view, request, line);
+
 	if (request != REQ_ENTER)
 		return request;
 


### PR DESCRIPTION
When working with pull requests, before merging to `master` it is nice to get the total diff of all of the commits of the PR, as in the `Files changed` tab on github. This is possible with `tig`, i.e. `git diff master | tig` or `:!git diff master`, but currently, this view does not support editing.

This PR makes editing in the pager view possible.