### PR TITLE
Highlight matching regex pattern in pager, via option color-pager-regex

### DIFF
--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -22,6 +22,7 @@ struct ref;
  */
 
 #define LINE_INFO(_) \
+        _(COLOR_MATCH,     ""), \
 	_(DIFF_HEADER,		"diff --"), \
 	_(DIFF_DEL_FILE,	"--- "), \
 	_(DIFF_ADD_FILE,	"+++ "), \

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -88,6 +88,7 @@ typedef struct view_column *view_settings;
 	_(vertical_split,		enum vertical_split,	VIEW_RESET_DISPLAY | VIEW_DIFF_LIKE) \
 	_(wrap_lines,			bool,			VIEW_DIFF_LIKE) \
 	_(wrap_search,			bool,			VIEW_NO_FLAGS) \
+	_(color_pager_regex,		const char *,		VIEW_NO_FLAGS) \
 
 #define DEFINE_OPTION_EXTERNS(name, type, flags) extern type opt_##name;
 OPTION_INFO(DEFINE_OPTION_EXTERNS)

--- a/src/diff.c
+++ b/src/diff.c
@@ -302,12 +302,28 @@ diff_common_highlight(struct view *view, const char *text, enum line_type type)
 bool
 diff_common_read(struct view *view, const char *data, struct diff_state *state)
 {
+        const char *regex_txt;
+        regex_t regex;
+        regmatch_t pmatch[10];
+	int regex_flags = REG_EXTENDED, regex_err;
 	enum line_type type = get_line_type(data);
 
 	/* ADD2 and DEL2 are only valid in combined diff hunks */
 	if (!state->combined_diff && (type == LINE_DIFF_ADD2 || type == LINE_DIFF_DEL2))
 		type = LINE_DEFAULT;
 
+
+        if (type == LINE_DEFAULT && opt_color_pager_regex != NULL && *opt_color_pager_regex)
+        {
+            regex_err = regcomp(&regex, opt_color_pager_regex, regex_flags);
+
+            if (!regex_err)
+                regex_err = regexec(&regex, data, 8, pmatch, 0);
+
+            if (!regex_err) 
+                type = LINE_COLOR_MATCH;
+            regfree(&regex);
+        }
 	/* DEL_FILE, ADD_FILE and START are only valid outside diff chunks */
 	if (state->reading_diff_chunk) {
 		if (type == LINE_DIFF_DEL_FILE || type == LINE_DIFF_START)

--- a/tigrc
+++ b/tigrc
@@ -143,6 +143,7 @@ set mouse			= no		# Enable mouse support?
 set mouse-scroll		= 3		# Number of lines to scroll via the mouse
 set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?
 set pgrp			= no		# Make tig process-group leader
+set color-pager-regex           = ""
 
 # User-defined commands
 # ---------------------
@@ -447,6 +448,7 @@ color palette-12		white	default	bold
 color palette-13		red	default	bold
 color graph-commit		blue	default
 color search-result		black	yellow
+color color-match               magenta  default bold
 
 # Mappings for colors read from git configuration.
 # Set to "no" to disable.


### PR DESCRIPTION
A third attempt after #1223 to commit flexible pager view output highlighter.

Any line matching the regex given by option `color_pager_regex` will be drawn in a new color ↔ `color-match`. The option is empty by default, as requested. The color is magenta by default.

Example:
![2022-12-27-150236_1888x926_scrot](https://user-images.githubusercontent.com/6049288/209677685-d0a08e0d-74be-4e85-b7f4-5f2b5fe4a710.png)

Typically useful to make compiler warnings easy visible.
