### PR TITLE
fix some implicit declarations

### DIFF
--- a/include/tig/tig.h
+++ b/include/tig/tig.h
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>

--- a/include/tig/tig.h
+++ b/include/tig/tig.h
@@ -18,6 +18,10 @@
 #include "config.h"
 #endif
 
+/* required for struct timezone */
+#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
+
 #include "compat/compat.h"
 
 #ifndef TIG_VERSION


### PR DESCRIPTION
fixes implicit-function-declaration of strcasecmp (strings.h) and implicit define of struct timezone (bsd/gnu source)