### PR TITLE
fix date so rpmbuild completes

### DIFF
--- a/contrib/tig.spec.in
+++ b/contrib/tig.spec.in
@@ -56,7 +56,7 @@ CFLAGS="$RPM_OPT_FLAGS -DVERSION=tig-%{version}-%{release}"
 %{?_without_docs:  %doc doc/*.txt}
 
 %changelog
-* Sun 23 Feb 2014 Jonas Fonseca <jonas.fonseca@gmail.com>
+* Sun Feb 23 2014 Jonas Fonseca <jonas.fonseca@gmail.com>
 - Add tigrc installed in /etc
 
 * Tue Jan  8 2013 Joakim Sernbrant <serbaut@gmail.com>


### PR DESCRIPTION
```
conor@dev:~$ rpmbuild -ta tig-2.5.8.tar.gz
error: bad date in %changelog: Sun 23 Feb 2014 Jonas Fonseca
```


Just needs the month and day switched around. Saw this behavior on Debian 11, SLES12, SLES15