### PR TITLE
Allow to go to stage view without Enter

### DIFF
--- a/include/tig/stage.h
+++ b/include/tig/stage.h
@@ -20,7 +20,7 @@ struct status;
 
 extern struct view stage_view;
 
-void open_stage_view(struct view *prev, struct status *status, enum line_type type, enum open_flags flags);
+void open_stage_view(struct view *prev, struct status *status, enum open_flags flags);
 
 #endif
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -49,6 +49,7 @@ struct line {
 	unsigned int no_commit_refs:1;
 	unsigned int graph_indent:1;
 	unsigned int search_result:1;
+	unsigned int stat_header:1;
 
 	void *data;		/* User data */
 };

--- a/src/main.c
+++ b/src/main.c
@@ -92,6 +92,8 @@ main_add_commit(struct view *view, enum line_type type, struct commit *template,
 	line = add_line_alloc(view, &commit, type, titlelen, custom);
 	if (!line)
 		return NULL;
+	if (custom)
+		line->stat_header = 1;
 
 	*commit = *template;
 	strcpy(commit->title, title);
@@ -561,7 +563,7 @@ main_request(struct view *view, enum request request, struct line *line)
 
 		if (line->type == LINE_STAT_UNSTAGED
 		    || line->type == LINE_STAT_STAGED)
-			open_stage_view(view, NULL, line->type, flags);
+			open_stage_view(view, NULL, flags);
 		else if (line->type == LINE_STAT_UNTRACKED)
 			open_status_view(view, true, flags);
 		else

--- a/src/status.c
+++ b/src/status.c
@@ -94,13 +94,14 @@ status_run(struct view *view, const char *argv[], char status, enum line_type ty
 	const char **status_argv = NULL;
 	bool ok = argv_format(view->env, &status_argv, argv, 0) &&
 		  io_run(&io, IO_RD, repo.exec_dir, NULL, status_argv);
+	size_t header_offset;
 
 	argv_free(status_argv);
 	free(status_argv);
 	if (!ok)
 		return false;
 
-	add_line_nodata(view, type);
+	header_offset = add_line_nodata(view, type) - view->line;
 
 	while (io_get(&io, &buf, 0, true)) {
 		struct line *line;
@@ -171,6 +172,7 @@ error_out:
 			watch_apply(&view->watch, WATCH_INDEX_UNTRACKED_NO);
 		}
 	} else {
+		view->line[header_offset].stat_header = 1;
 		if (type == LINE_STAT_STAGED) {
 			watch_apply(&view->watch, WATCH_INDEX_STAGED_YES);
 			no_files_staged = false;
@@ -498,7 +500,7 @@ status_enter(struct view *view, struct line *line)
 		return REQ_NONE;
 	}
 
-	open_stage_view(view, status, line->type, flags);
+	open_stage_view(view, status, flags);
 	return REQ_NONE;
 }
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -180,7 +180,7 @@ view_driver(struct view *view, enum request request)
 		break;
 	case REQ_VIEW_DIFF:
 		if (view && string_rev_is_null(view->env->commit))
-			open_stage_view(view, NULL, 0, OPEN_DEFAULT);
+			open_stage_view(view, NULL, OPEN_DEFAULT);
 		else
 			open_diff_view(view, OPEN_DEFAULT);
 		break;
@@ -209,7 +209,7 @@ view_driver(struct view *view, enum request request)
 		open_status_view(view, false, OPEN_DEFAULT);
 		break;
 	case REQ_VIEW_STAGE:
-		open_stage_view(view, NULL, 0, OPEN_DEFAULT);
+		open_stage_view(view, NULL, OPEN_DEFAULT);
 		break;
 	case REQ_VIEW_PAGER:
 		open_pager_view(view, OPEN_DEFAULT);

--- a/test/stage/default-test
+++ b/test/stage/default-test
@@ -9,6 +9,35 @@ steps '
 	:save-display status.screen
 
 	:2
+	:view-stage
+	:save-display staged-changes-shortcut.screen
+	:view-close
+
+	:5
+	:view-stage
+	:save-display unstaged-changes-shortcut.screen
+	:view-close
+
+	:view-main
+
+	:1
+	:view-stage
+	:save-display unstaged-changes-shortcut-from-main.screen
+	:view-close
+
+	:2
+	:view-stage
+	:save-display staged-changes-shortcut-from-main.screen
+	:view-close
+
+	:view-close
+
+	:4
+	:view-stage
+	:save-display staged-changes-for-a-shortcut.screen
+	:view-close
+
+	:2
 	:enter
 	:maximize
 	:save-display staged-changes.screen
@@ -39,6 +68,7 @@ steps '
 	:4
 	:status-update
 	:save-display unstaged-changes-staged-all.screen
+
 '
 
 in_work_dir create_dirty_workdir
@@ -66,6 +96,33 @@ Untracked files:
 
 
 [status] Nothing to update                                                  100%
+EOF
+
+assert_equals 'staged-changes.screen' < 'staged-changes-shortcut.screen'
+assert_equals 'unstaged-changes.screen' < 'unstaged-changes-shortcut.screen'
+assert_equals 'staged-changes.screen' < 'staged-changes-shortcut-from-main.screen'
+assert_equals 'unstaged-changes.screen' < 'unstaged-changes-shortcut-from-main.screen'
+
+assert_equals 'staged-changes-for-a-shortcut.screen' <<EOF
+ a | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+ 
+diff --git a/a b/a
+index 12d1d9e..0a4a332 100644
+--- a/a
++++ b/a
+@@ -1,4 +1,4 @@
+-a
++a CHANGED
+ 1
+ 2
+ 3
+@@ -6,6 +6,4 @@ a
+ 5
+ 6
+ 7
+-8
+[stage] Press '<Enter>' to jump to file diff - line 1 of 23                  78%
 EOF
 
 assert_equals 'staged-changes.screen' <<EOF


### PR DESCRIPTION
After selecting unstaged or staged changes in main or status view
and pressing "c" to go to stage view, we fail with this error

	No stage content, press s to open the status view and choose file

We can work around this by pressing Enter before "c".  This extra key
press is really not necessary because the intent is clear.  Let's make
view-stage (and view-diff) go to the stage view straight away.

Note: "d" already worked this way but only in the main view, I'm not
sure why.

The implementation needs to differentiate between "stat headers"
like "Changes to be committed" and status lines that actually contain
a file. For stat headers we show all files so we must be careful not
to include a file filter.
For untracked files, we show a blob so there is no natural way of
showing all untracked files. Keep the above behavior for the untracked
stat header.
