### PR TITLE
Initialise struct timezone in main_add_changes_commit

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,7 @@ main_add_changes_commit(struct view *view, enum line_type type, const char *pare
 	struct graph *graph = state->graph;
 	struct commit commit = {{0}};
 	struct timeval now;
-	struct timezone tz;
+	struct timezone tz = {0};
 
 	if (!parent)
 		return true;


### PR DESCRIPTION
On musl libc `gettimeofday` (which is used by [time_now](https://github.com/jonas/tig/blob/06a1b89d98f32e9ac2d81b94515b200b0acb7dbb/src/util.c#L101)) [does not populate the timezone struct](https://git.musl-libc.org/cgit/musl/tree/src/time/gettimeofday.c?id=400c5e5c8307a2ebe44ef1f203f5a15669f20347) passed to it as [POSIX says](https://pubs.opengroup.org/onlinepubs/009604599/functions/gettimeofday.html):

> If tzp is not a null pointer, the behavior is unspecified.

[tz_minuteswest is later multiplied by 60](https://github.com/jonas/tig/blob/06a1b89d98f32e9ac2d81b94515b200b0acb7dbb/src/main.c#L136) which can overflow (if the value that happens to be in `tz_minuteswest` is large). When tig is compiled with integer overflow hardening (as is done on [Chimera Linux](https://chimera-linux.org/)) via the clang option `-fsanitize=signed-integer-overflow` this can result in tig crashing due to the overflow.

This PR initialises `tz` to prevent this.