### PR TITLE
One more fix display non-ascii character.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -319,7 +319,7 @@ get_author_initials(const char *author)
 	size_t pos = 0;
 	const char *end = strchr(author, '\0');
 
-#define is_initial_sep(c) (isspace(c) || ispunct(c) || (c) == '@' || (c) == '-')
+#define is_initial_sep(c) (isspace((unsigned char)(c)) || ispunct((unsigned char)(c)) || (c) == '@' || (c) == '-')
 
 	memset(initials, 0, sizeof(initials));
 	while (author < end) {


### PR DESCRIPTION
In addition to the fixes merged in #1299, one more fix was needed.

Before the fix, one test was failing, but after the fix, all tests passed.
```
      TEST  test/tigrc/view-column-test
            | Failed 1 out of 2 test(s)
            | [FAIL] main-view.screen != expected/main-view.screen
            | diff --git a/expected/main-view.screen b/main-view.screen
            | index 53a71c6..4a307fd 100644
            | --- a/expected/main-view.screen
            | +++ b/main-view.screen
            | @@ -1,15 +1,15 @@
            |    1| 2010-04-07 MPower       Commit 10 E
            |     | 2010-03-29 JTBrahe      Commit 10 D
            | -  3| 2010-03-21 作者         Commit 10 C
            | +  3| 2010-03-21 作           Commit 10 C
            |     | 2010-03-12 RLévesque    Commit 10 B
            |     | 2010-03-04 AUThor       Commit 10 A
            |    6| 2010-02-23 MPower       Commit 9 E
            |     | 2010-02-15 JTBrahe      Commit 9 D
            | -   | 2010-02-06 作者         Commit 9 C
            | +   | 2010-02-06 作           Commit 9 C
            |    9| 2010-01-29 RLévesque    Commit 9 B
            |     | 2010-01-20 AUThor       Commit 9 A
            |     | 2010-01-12 MPower       Commit 8 E
            |   12| 2010-01-03 JTBrahe      Commit 8 D
            | -   | 2009-12-26 作者         Commit 8 C
            | +   | 2009-12-26 作           Commit 8 C
            |     | 2009-12-17 RLévesque    Commit 8 B
            |  [main] 5cb3412a5e06e506840495b91acc885037a48b72 - commit 1 of 50             28%
            |   [OK] stderr assertion
```