### PR TITLE
Use HTTPS for GitHub clone URLs

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -3,7 +3,7 @@ Installation instructions
 :docext: adoc
 
 Download a tarball from https://github.com/jonas/tig/releases[] or clone the Tig
-repository https://github.com/jonas/tig[git://github.com/jonas/tig.git].
+repository https://github.com/jonas/tig[https://github.com/jonas/tig.git].
 
 The latest version is:
 https://github.com/jonas/tig/releases/download/tig-2.5.8/tig-2.5.8.tar.gz[tig-2.5.8]

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ Resources
  - Homepage:	https://jonas.github.io/tig/[]
  - Manual:	https://jonas.github.io/tig/doc/manual.html[]
  - Tarballs:	https://github.com/jonas/tig/releases[]
- - Git URL:	git://github.com/jonas/tig.git
+ - Git URL:	https://github.com/jonas/tig.git
  - Gitter:	https://gitter.im/jonas/tig[]
  - Q&A:		https://stackoverflow.com/questions/tagged/tig[]
 


### PR DESCRIPTION
GitHub has dropped support for the git:// protocol:
https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/