### PR TITLE
Blame: improve error messages for the `,` operation

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -355,12 +355,12 @@ blame_go_forward(struct view *view, struct blame *blame, bool parent)
 	const char *filename = parent ? commit->parent_filename : commit->filename;
 
 	if (!*id && parent) {
-		report("The selected commit has no parents");
+		report("Commit %.8s has no ancestors modifying the selected line", commit->id);
 		return;
 	}
 
 	if (!strcmp(history_state->id, id) && !strcmp(history_state->filename, filename)) {
-		report("The selected commit is already displayed");
+		report("Commit %.8s is already being displayed", commit->id);
 		return;
 	}
 


### PR DESCRIPTION
This addresses a portion of https://github.com/jonas/tig/issues/1315.

The message is now:

   Commit f4657f00 has no ancestors modifying the selected line

instead of  

   The selected commit has no parents

Apart from being a bit clearer, the user will be able to learn what `,`
is meant to do from it. In particular, they should notice that commit
`f4657f00` is the commit on the selected *line*, not the commit that is
currently displayed in general.

Trying to press `,` a few times is a natural thing to try to do after
reading the help while trying to figure out how blame works in tig.

----------

I would still appreciate pointers on how to create a help section. I'm also
curious whether you think that the additional command I describe in the "update" in https://github.com/jonas/tig/issues/1315#issuecomment-1942506665 is a good idea.

I'd also need a pointer if you'd like me to add the test. Changing the message didn't seem to break any tests.