### PR TITLE
refdb: ignore prefetch refs

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -12,8 +12,8 @@ Improvements:
  - Use HTTPS for GitHub clone URLs. (#1310)
  - Move default log view options to tigrc.
  - Allow to go to stage view without Enter. (#1284)
- - Add new "prefetch" reference type for refs created by `git maintenance`.
-   (#1318)
+ - Add new "prefetch" reference type for refs created by `git maintenance`
+   (hidden in default config). (#1318)
 
 Bug fixes:
 

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -12,6 +12,8 @@ Improvements:
  - Use HTTPS for GitHub clone URLs. (#1310)
  - Move default log view options to tigrc.
  - Allow to go to stage view without Enter. (#1284)
+ - Add new "prefetch" reference type for refs created by `git maintenance`.
+   (#1318)
 
 Bug fixes:
 

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -181,7 +181,9 @@ The following variables can be set:
 	names. Wrap the name of the reference type with the characters you would
 	like to use for formatting, e.g. `[tag]` and `<remote>`. If no format is
 	specified for `local-tag`, the format for `tag` is used. Similarly, if no
-	format is specified for `tracked-remote` the `remote` format is used.
+	format is specified for `tracked-remote`, the format for `remote` is used,
+	and if no format is specified for any other reference type, the format for
+	`branch` is used.
 	Prefix with `hide:` to not show that reference type, e.g. `hide:remote`.
 	Supported reference types are:
 	 - head			: The current HEAD.

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -192,6 +192,7 @@ The following variables can be set:
 	 - replace		: A replaced reference.
 	 - branch		: A branch.
 	 - stash		: The stash.
+	 - prefetch		: Refs prefetched by `git maintenance`.
 	 - other		: Any other reference.
 
 'line-graphics' (mixed) [ascii|default|utf-8|auto|<bool>]::

--- a/include/tig/types.h
+++ b/include/tig/types.h
@@ -150,7 +150,8 @@ bool map_enum_do(const struct enum_map_entry *map, size_t map_size, int *value, 
 	_(REFERENCE, REMOTE), \
 	_(REFERENCE, TAG), \
 	_(REFERENCE, LOCAL_TAG), \
-	_(REFERENCE, REPLACE)
+	_(REFERENCE, REPLACE), \
+	_(REFERENCE, PREFETCH)
 
 #define STATUS_LABEL_ENUM(_) \
 	_(STATUS_LABEL, NO), \

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -224,6 +224,9 @@ add_to_refs(const char *id, size_t idlen, char *name, size_t namelen, struct ref
 		    !strncmp(opt->head, name, namelen))
 			type = REFERENCE_HEAD;
 
+	} else if (!prefixcmp(name, "refs/prefetch/")) {
+		type = REFERENCE_PREFETCH;
+
 	} else if (!strcmp(name, "HEAD")) {
 		/* Handle the case of HEAD not being a symbolic ref,
 		 * i.e. during a rebase. */

--- a/tigrc
+++ b/tigrc
@@ -108,7 +108,7 @@ set truncation-delimiter	= ~		# Character drawn for truncations, or "utf-8"
 #  - If no format is specified for `tracked-remote`, the format for `remote` is used.
 #  - If no format is specified for any other reference type, the format for `branch` is used.
 # Prefix with `hide:` to not show that reference type, e.g. `hide:remote`.
-set reference-format		= [branch] <tag> {remote} ~replace~
+set reference-format		= [branch] <tag> {remote} ~replace~ hide:prefetch
 
 # Settings controlling how content is read from Git
 set commit-order		= auto		# Enum: auto, default, topo, date, reverse (main)

--- a/tigrc
+++ b/tigrc
@@ -102,10 +102,12 @@ set truncation-delimiter	= ~		# Character drawn for truncations, or "utf-8"
 #  - stash		: The stash.
 #  - prefetch		: Refs prefetched by `git maintenance`.
 #  - other		: Any other reference.
-# If no format is defined for `local-tag` then the one for `tag` is used.
-# Similarly, `remote` is used if no `tracked-remote` format exists.
-# Prefix with `hide:` to not show that reference type, e.g. `hide:remote`.
+#
 # Expects a space-separated list of format strings.
+#  - If no format is specified for `local-tag`, the format for `tag` is used.
+#  - If no format is specified for `tracked-remote`, the format for `remote` is used.
+#  - If no format is specified for any other reference type, the format for `branch` is used.
+# Prefix with `hide:` to not show that reference type, e.g. `hide:remote`.
 set reference-format		= [branch] <tag> {remote} ~replace~
 
 # Settings controlling how content is read from Git

--- a/tigrc
+++ b/tigrc
@@ -100,6 +100,7 @@ set truncation-delimiter	= ~		# Character drawn for truncations, or "utf-8"
 #  - replace		: A replaced reference.
 #  - branch		: A branch.
 #  - stash		: The stash.
+#  - prefetch		: Refs prefetched by `git maintenance`.
 #  - other		: Any other reference.
 # If no format is defined for `local-tag` then the one for `tag` is used.
 # Similarly, `remote` is used if no `tracked-remote` format exists.


### PR DESCRIPTION
These are created by `git maintentance` and are special-cased in git tools to not be shown, since they are mostly noise.