### PR TITLE
Fix incorrect filename coloring in `tig status`

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,6 +1,14 @@
 Release notes
 =============
 
+tig-2.5.10
+----------
+
+Bug fixes:
+
+ - Fix `stat-*` coloring file names in `tig status` instead of just
+   markers (regression in 2.5.9).
+
 tig-2.5.9
 ---------
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -276,10 +276,11 @@ draw_id(struct view *view, struct view_column *column, const char *id)
 }
 
 static bool
-draw_filename(struct view *view, struct view_column *column, enum line_type type, const char *filename)
+draw_filename(struct view *view, struct view_column *column, const char *filename, mode_t mode)
 {
 	size_t width = filename ? utf8_width(filename) : 0;
 	bool trim = width >= column->width;
+	enum line_type type = S_ISDIR(mode) ? LINE_DIRECTORY : LINE_FILE;
 	int column_width = column->width ? column->width : width;
 
 	if (column->opt.file_name.display == FILENAME_NO)
@@ -528,7 +529,7 @@ view_column_draw(struct view *view, struct line *line, unsigned int lineno)
 			continue;
 
 		case VIEW_COLUMN_FILE_NAME:
-			if (draw_filename(view, column, line->type, column_data.file_name))
+			if (draw_filename(view, column, column_data.file_name, mode))
 				return true;
 			continue;
 


### PR DESCRIPTION
Due to the way commit a37ce5cfe1f256b81092dda365b1d66450e0929e updated src/draw.c:draw_filename() the whole line in `tig status` got colored according to `stat-*` which supposed to color only status markers.

***

I don't see other such adhoc conditionals in the file, so there is probably a better way of doing it, but I thought this demonstrates the issue and the approximate way of addressing it.