### PR TITLE
diff parsing, regardless of diff-prefix choices

### DIFF
--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -37,6 +37,8 @@ typedef struct view_column *view_settings;
 	_(commit_order,			enum commit_order,	VIEW_LOG_LIKE) \
 	_(diff_context,			int,			VIEW_DIFF_LIKE) \
 	_(diff_noprefix,		bool,			VIEW_NO_FLAGS) \
+	// TODO: _(diff_dstprefix,
+	// TODO: _(diff_srcprefix,
 	_(diff_options,			const char **,		VIEW_DIFF_LIKE) \
 	_(diff_highlight,		const char *,		VIEW_DIFF_LIKE) \
 	_(word_diff,			bool,			VIEW_DIFF_LIKE) \

--- a/src/diff.c
+++ b/src/diff.c
@@ -657,7 +657,7 @@ diff_trace_origin(struct view *view, struct line *line)
 		if (!prefixcmp(data, "--- ")) {
 			const char *data_n1 = box_text(diff+1);
 			const char *data_n2 = box_text(diff+2);
-			if(!prefixcmp(data_n1, "+++ ") && prefixcmp(data_n2, "@@ ")){
+			if(!prefixcmp(data_n1, "+++ ") && !prefixcmp(data_n2, "@@ ")){
 				file = data + STRING_SIZE("--- ");
 				break;
 			}

--- a/src/diff.c
+++ b/src/diff.c
@@ -654,13 +654,10 @@ diff_trace_origin(struct view *view, struct line *line)
 
 	for (; diff < line && !file; diff++) {
 		const char *data = box_text(diff);
+
 		if (!prefixcmp(data, "--- ")) {
-			const char *data_n1 = box_text(diff+1);
-			const char *data_n2 = box_text(diff+2);
-			if(!prefixcmp(data_n1, "+++ ") && !prefixcmp(data_n2, "@@ ")){
-				file = data + STRING_SIZE("--- ");
-				break;
-			}
+			file = data + (opt_diff_noprefix ? STRING_SIZE("--- ") : STRING_SIZE("--- a/"));
+			break;
 		}
 	}
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -654,10 +654,13 @@ diff_trace_origin(struct view *view, struct line *line)
 
 	for (; diff < line && !file; diff++) {
 		const char *data = box_text(diff);
-
-		if (!prefixcmp(data, "--- a/")) {
-			file = data + STRING_SIZE("--- a/");
-			break;
+		if (!prefixcmp(data, "--- ")) {
+			const char *data_n1 = box_text(diff+1);
+			const char *data_n2 = box_text(diff+2);
+			if(!prefixcmp(data_n1, "+++ ") && prefixcmp(data_n2, "@@ ")){
+				file = data + STRING_SIZE("--- ");
+				break;
+			}
 		}
 	}
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -655,6 +655,7 @@ diff_trace_origin(struct view *view, struct line *line)
 	for (; diff < line && !file; diff++) {
 		const char *data = box_text(diff);
 
+		// TODO: make a diff file name parser generic
 		if (!prefixcmp(data, "--- ")) {
 			file = data + (opt_diff_noprefix ? STRING_SIZE("--- ") : STRING_SIZE("--- a/"));
 			break;
@@ -735,6 +736,7 @@ diff_get_pathname(struct view *view, struct line *line, bool old)
 	if (!header)
 		return NULL;
 
+	// TODO: make a diff file name parser generic
 	name = box_text(header);
 	if (old ? !prefixcmp(name, "--- ") : !prefixcmp(name, "+++ "))
 		name += STRING_SIZE("+++ ");

--- a/src/options.c
+++ b/src/options.c
@@ -1534,6 +1534,10 @@ read_repo_config_option(char *name, size_t namelen, char *value, size_t valuelen
 	else if (!strcmp(name, "diff.noprefix"))
 		parse_bool(&opt_diff_noprefix, value);
 
+	// TODO: else if (!strcmp(name, "diff.dstprefix")) and store it somewhere
+
+	// TODO: else if (!strcmp(name, "diff.srcprefix")) and store it somewhere
+
 	else if (!strcmp(name, "status.showuntrackedfiles"))
 		opt_status_show_untracked_files = !!strcmp(value, "no"),
 		opt_status_show_untracked_dirs = !strcmp(value, "all");


### PR DESCRIPTION
handle all diff view options (noprefix, mnemonicPrefix, srcPrefix, dstPrefix, line-prefix)

(moved quick fix of #1336 to #1338)