### PR TITLE
fix diff blame navigation

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -27,7 +27,7 @@ diff_open(struct view *view, enum open_flags flags)
 {
 	const char *diff_argv[] = {
 		"git", "show", encoding_arg, "--pretty=fuller", "--root",
-			"--patch-with-stat", use_mailmap_arg(),
+			"--default-prefix", "--patch-with-stat", use_mailmap_arg(),
 			show_notes_arg(), diff_context_arg(), ignore_space_arg(),
 			DIFF_ARGS, "%(cmdlineargs)", "--no-color", word_diff_arg(),
 			"%(commit)", "--", "%(fileargs)", NULL


### PR DESCRIPTION
this does **not** "support" git options such as `noprefix`, `mnemonicPrefix`, etc. As in, they will not have the desired effect on diff view, like #1337 was trying to implement.

It just overrides them with the `--default-prefix` command line when getting the diffs, so blame navigation (e.g. pressing "b" in a diff) works.

fix #1336 