### PR TITLE
prompt: make a better effort to configure terminal for Readline

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -499,8 +499,10 @@ read_prompt(const char *prompt)
 	curs_set(1);
 	if (signal(SIGINT, sigint_absorb_handler) == SIG_ERR)
 		die("Failed to setup sigint handler");
+	noraw();
 	cbreak();
 	line = readline(prompt);
+	nocbreak();
 	raw();
 	if (signal(SIGINT, SIG_DFL) == SIG_ERR)
 		die("Failed to remove sigint handler");


### PR DESCRIPTION
This fixes `^C` behavior within the Readline prompt. This does _not_ implement any sane ESC handling, nor does it seem to handle `^C` after an outstanding `ESC`.

Still better than nothing.