### PR TITLE
Keep splitted view when coming back from a maximized view

### DIFF
--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -53,6 +53,7 @@ struct display_lineage {
 };
 extern struct display_lineage *display_lineage;
 
+void rewind_lineage();
 void free_display_lineage();
 
 void init_tty(void);

--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -43,6 +43,18 @@ extern unsigned int current_view;
 #define view_is_displayed(view) \
 	(view == display[0] || view == display[1])
 
+// Save the succession of the array of active views
+struct display_lineage;
+struct display_lineage {
+	struct view *display[2];
+	unsigned int current_view;
+
+	struct display_lineage *prev;
+};
+extern struct display_lineage *display_lineage;
+
+void free_display_lineage();
+
 void init_tty(void);
 void init_display(void);
 void resize_display(void);

--- a/src/display.c
+++ b/src/display.c
@@ -32,6 +32,8 @@ static void set_terminal_modes(void);
 struct view *display[2];
 unsigned int current_view;
 
+struct display_lineage *display_lineage = NULL;
+
 static WINDOW *display_win[2];
 static WINDOW *display_title[2];
 static WINDOW *display_sep;
@@ -898,6 +900,17 @@ enable_mouse(bool enable)
 		enabled = enable;
 	}
 #endif
+}
+
+void
+free_display_lineage()
+{
+	struct display_lineage *lineage = display_lineage;
+	while(lineage != NULL) {
+		struct display_lineage *prev = lineage->prev;
+		free(lineage);
+		lineage = prev;
+	}
 }
 
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/display.c
+++ b/src/display.c
@@ -902,6 +902,11 @@ enable_mouse(bool enable)
 #endif
 }
 
+void rewind_lineage() {
+	struct display_lineage *exited = display_lineage;
+	display_lineage = display_lineage->prev;
+	free(exited);
+}
 void
 free_display_lineage()
 {

--- a/src/stage.c
+++ b/src/stage.c
@@ -670,7 +670,6 @@ stage_request(struct view *view, enum request request, struct line *line)
 
 	case REQ_VIEW_CLOSE:
 	case REQ_VIEW_CLOSE_NO_QUIT:
-		stage_line_type = 0;
 		return request;
 
 	case REQ_ENTER:

--- a/src/stage.c
+++ b/src/stage.c
@@ -802,10 +802,13 @@ stage_read(struct view *view, struct buffer *buf, bool force_stop)
 		}
 
 		/* After git apply, git diff-files can sometimes return an empty line. */
-		if (view->lines <= 1 && !force_stop && view->prev) {
+		if (view->lines <= 1 && !force_stop && display_lineage) {
 			watch_apply(&view->watch, WATCH_INDEX);
 			stage_line_type = 0;
-			maximize_view(view->prev, false);
+			maximize_view(display_lineage->display[0], false);
+			struct display_lineage * exiting_dl = display_lineage;
+			display_lineage = display_lineage->prev;
+			free(exiting_dl);
 			return false;
 		}
 

--- a/src/stage.c
+++ b/src/stage.c
@@ -806,9 +806,7 @@ stage_read(struct view *view, struct buffer *buf, bool force_stop)
 			watch_apply(&view->watch, WATCH_INDEX);
 			stage_line_type = 0;
 			maximize_view(display_lineage->display[0], false);
-			struct display_lineage * exiting_dl = display_lineage;
-			display_lineage = display_lineage->prev;
-			free(exiting_dl);
+			rewind_lineage();
 			return false;
 		}
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -341,8 +341,8 @@ view_driver(struct view *view, enum request request)
 				if (dl->current_view == 1) {
 					load_view(dl->display[1], dl->display[0], OPEN_SPLIT);
 				}
-				free(display_lineage);
 				display_lineage = display_lineage->prev;
+				free(dl);
 			break;
 			}
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -341,8 +341,7 @@ view_driver(struct view *view, enum request request)
 				if (dl->current_view == 1) {
 					load_view(dl->display[1], dl->display[0], OPEN_SPLIT);
 				}
-				display_lineage = display_lineage->prev;
-				free(dl);
+				rewind_lineage();
 			break;
 			}
 

--- a/src/tig.c
+++ b/src/tig.c
@@ -329,6 +329,24 @@ view_driver(struct view *view, enum request request)
 			view->prev = view;
 			break;
 		}
+		// If we try to quit the first view of the display lineage
+		// and there is a previous views configuration,
+		// restore this last
+		else if(view->prev && view->prev == view) {
+			if(display_lineage) {
+				foreach_view(view, i)
+					end_update(view, true);
+				struct display_lineage * dl = display_lineage;
+					load_view(dl->display[0], dl->display[0], OPEN_DEFAULT | OPEN_RELOAD);
+				if (dl->current_view == 1) {
+					load_view(dl->display[1], dl->display[0], OPEN_SPLIT);
+				}
+				free(display_lineage);
+				display_lineage = display_lineage->prev;
+			break;
+			}
+
+		}
 		if (request == REQ_VIEW_CLOSE_NO_QUIT) {
 			report("Can't close last remaining view");
 			break;
@@ -337,6 +355,7 @@ view_driver(struct view *view, enum request request)
 	case REQ_QUIT:
 		foreach_view(view, i)
 			end_update(view, true);
+		free_display_lineage();
 		return false;
 
 	default:

--- a/src/view.c
+++ b/src/view.c
@@ -800,9 +800,24 @@ load_view(struct view *view, struct view *prev, enum open_flags flags)
 {
 	bool refresh = !view_no_refresh(view, flags);
 
-	/* When prev == view it means this is the first loaded view. */
 	if (prev && view != prev) {
-		view->prev = prev;
+		bool split = !!(flags & OPEN_SPLIT);
+		if (split) {
+			view->prev = prev;
+		} else {
+			// A new maximized view is up to be opened,
+			// so let's create a new lineage element
+			struct display_lineage *prev_dl = display_lineage;
+
+			display_lineage = malloc(sizeof(struct display_lineage));
+			display_lineage->prev = prev_dl;
+			display_lineage->display[0] = display[0];
+			display_lineage->display[1] = display[1];
+			display_lineage->current_view = current_view;
+			//Mimic that we are on the first view of the lineage element
+			view->prev = view;
+
+		}
 	}
 
 	if (!refresh && view_can_refresh(view) &&

--- a/test/main/keep-split-view-test
+++ b/test/main/keep-split-view-test
@@ -1,0 +1,27 @@
+
+#!/bin/sh
+#
+# Test display and options specific to the main view.
+
+. libtest.sh
+. libgit.sh
+
+export LINES=16
+
+tigrc <<EOF
+set vertical-split = no
+EOF
+
+steps '
+	<Enter>
+	:save-display main-and-diff.screen
+	:view-help
+	:view-close
+	:save-display main-and-diff-back.screen
+'
+
+git_clone 'repo-one'
+
+test_tig
+
+assert_equals 'main-and-diff.screen' < main-and-diff-back.screen

--- a/test/stage/maximized-unstaged-changes-test
+++ b/test/stage/maximized-unstaged-changes-test
@@ -18,6 +18,8 @@ steps '
 	:save-display split.screen
 	:view-diff
 	:save-display maximized.screen
+	:status-update
+	:save-display closed.screen
 '
 
 tigrc <<EOF
@@ -55,4 +57,18 @@ diff --git a/.j b/.j
 index e697dfd..9d8ef3d 100644
 --- a/.j
 [stage] Press '<Enter>' to jump to file diff - line 1 of 107                  9%
+EOF
+
+assert_equals 'closed.screen' <<EOF
+2014-05-25 19:42 +0000 Not Committed Yet o Staged changes
+2009-02-13 23:31 +0000 A. U. Thor        I [master] Initial commit
+
+
+
+
+
+
+
+
+[main] Staged changes                                                       100%
 EOF


### PR DESCRIPTION
## Old behavior
- Open a splitted view like ("Main + Diff" or "Status + diff" for example)
- Then open a new maximized window like help
- Quitting the maximized view does **not** bring back the splitted view but only the top view ("Main or "Status" for example)
## New behavior
- Open a splitted view like ("Main + Diff" or "Status + diff" for example)
- Then open a new maximized window like help
- Quitting the maximized view **does bring back** the splitted view ("Main + Diff" or "Status + diff" for example)

## Example:
```
From Main view
 :enter      -> Main view | Status view
 :view-help  -> Help view
 :view-close -> Main view               (old behavior) 
 :view-close -> Main view | Status view (new behavior) 
```

Enable requested behaviors in https://github.com/jonas/tig/issues/336