### PR TITLE
Fix readline ignores Ctrl-C on macOS (#1347)

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -475,8 +475,13 @@ readline_init(void)
 	/* Let ncurses deal with the LINES and COLUMNS environment variables */
 	rl_change_environment = 0;
 	rl_catch_sigwinch = 0;
+	/* Fix “Piping to tig segfaults on exit” (#893),
+	 * except on macOS inhibits `readline()` Ctrl-C.
+	 */
+#ifndef __APPLE__
 	rl_deprep_term_function = NULL;
 	rl_prep_term_function = NULL;
+#endif
 }
 
 static void sigint_absorb_handler(int sig) {


### PR DESCRIPTION
Proposed PR for #1347

- On macOS, you cannot cancel out of search ('/') using Ctrl-C (SIGINT), but rather must press <Enter> (and perform the search) to return to the main view.

- This commit partially reverts ea43f8be, “Fix segfaults with readline 8.0” (and associated Issue, “Piping to tig segfaults on exit” #893), but just for macOS builds.