### PR TITLE
Added GitHub CI/CD workflow to generate and release man pages

### DIFF
--- a/.github/workflows/generate-man-pages.yml
+++ b/.github/workflows/generate-man-pages.yml
@@ -1,0 +1,41 @@
+name: Generate Man Pages
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-man-pages:
+    runs-on: ubuntu-latest
+    container:
+      image: asciidoctor/docker-asciidoctor
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Generate Man Pages
+        run: |
+          mkdir -p man_pages
+          asciidoctor -b manpage -o man_pages/tig.1 doc/tig.1.adoc
+          asciidoctor -b manpage -o man_pages/tigmanual.7 doc/tigmanual.7.adoc
+          asciidoctor -b manpage -o man_pages/tigrc.5 doc/tigrc.5.adoc
+          ls -l man_pages/
+
+      # - name: Upload Man Pages as Artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: man-pages
+      #     path: man_pages/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: latest-man-pages
+          release_name: "Latest Man Pages"
+          files: man_pages/*
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thank you for the amazing utility.

I wanted to be able to install `tig` directly from your GitHub repo, but I wanted to install on all my linux machines asciidoc to generate the man pages. Thus, I added a GitHub CI/CD workflow that generates the man pages from the asciidoc and then release them automatically. This way, I can install `tig` directly using `zinit`. 

You do not need to understand the code below if you never worked with zinit. It is just to give you an idea how you can install `tig` directly. The instruction `dl` downloads the man pages from the GitHub release page.

```zsh
zinit ice \
  binary \
  depth=1 \
  wait \
  lucid \
  dl"https://github.com/alberti42/fork-tig/releases/download/latest-man-pages/tig.1 -> $ZINIT[MAN_DIR]/man1/tig.1;
  https://github.com/alberti42/fork-tig/releases/download/latest-man-pages/tigmanual.7 -> $ZINIT[MAN_DIR]/man7/tigmanual.7;
  https://github.com/alberti42/fork-tig/releases/download/latest-man-pages/tigrc.5 -> $ZINIT[MAN_DIR]/man5/tigrc.5;" \
  make \
  id-as'jonas/tig' \
  lbin'src/tig -> tig' \
  nocompile
zinit light @alberti42/fork-tig
```

I believe other people can find other useful applications of the automatically released man pages.