### PR TITLE
Use correct line from parent on recursive blame on blob

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -373,9 +373,12 @@ blame_go_forward(struct view *view, struct blame *blame, bool parent)
 
 	string_ncopy(view->env->ref, id, sizeof(commit->id));
 	string_ncopy(view->env->file, filename, strlen(filename));
-	if (parent)
+	if (parent) {
 		setup_blame_parent_line(view, blame);
-	view->env->goto_lineno = view->pos.lineno;
+		view->env->goto_lineno = view->pos.lineno;
+	} else {
+		view->env->goto_lineno = blame->lineno - 1;
+	}
 	reload_view(view);
 }
 

--- a/test/blame/blob-blame-test
+++ b/test/blame/blob-blame-test
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export COLUMNS=200
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+tigrc <<EOF
+set line-graphics = ascii
+EOF
+
+steps '
+	# Go to the "clean in deltablue" line.
+	:36
+	# Find the commit that added that line.
+	:view-blame
+	# Assert that we still select that line.
+	:save-display recursive-blame.screen
+'
+
+test_tig blame project/Build.scala
+
+assert_equals 'recursive-blame.screen' <<EOF
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  22|           "-feature",
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  23|           "-encoding", "utf8"
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  24|       )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  25|   )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  26|
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  27|   lazy val benchmarkSettings = defaultSettings ++ Seq(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  28|       unmanagedSources in (Compile, packageJS) +=
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  29|           baseDirectory.value / "exports.js"
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  30|   )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  31|
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  32|   lazy val parent: Project = Project(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  33|       id = "parent",
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  34|       base = file("."),
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  35|       settings = projectSettings ++ Seq(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  36|           name := "Scala.js Benchmarks",
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  37|           publishArtifact in Compile := false,
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  38|
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  39|           clean := clean.dependsOn(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  40|              clean in common,
+b103989 Jonas Fonseca 2013-10-20 00:23 -0700  41|              clean in deltablue,
+4edd069 Jonas Fonseca 2013-10-17 20:34 -0400  42|              clean in richards,
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  43|              clean in tracer
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  44|           ).value
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  45|       )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  46|   ).aggregate(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  47|       common,
+b103989 Jonas Fonseca 2013-10-20 00:23 -0700  48|       deltablue,
+4edd069 Jonas Fonseca 2013-10-17 20:34 -0400  49|       richards,
+[blame] b103989d59edab3adc312ff5408fa3d344ea0201 changed project/Build.scala - line 41 of 66                                                                                                         74%
+EOF


### PR DESCRIPTION
Running

	tig blame +28 tig-2.5.12 -- src/diff.c

and pressing "b" should keep the line containing "const char *diff_argv[]
= }" selected. It actually moves the selection somewhere else.

This regressed in ca0809db (Fix cursor position after "Move to parent"
in blame view, 2019-11-29).

Commit ca0809db was only about "," (":back" or ":parent").  When we press
"b" (":view-blame"), we want to use the old behavior (originally added in
ba7c7d30 (Use file and line number information when loading blame for commit,
2009-02-07)). Do that.

(Note that the behavior fixed by ca0809db regressed in 22807341 (Enable
textconv in the blame view and fix blame -L (#1190), 2022-06-03).  I have
not yet figured out what's going on, but this patch shouldn't make that worse.)

Fixes #1369
