### PR TITLE
Use correct line when using `:parent` in blame view 

### DIFF
--- a/src/blame.c
+++ b/src/blame.c
@@ -335,7 +335,7 @@ setup_blame_parent_line(struct view *view, struct blame *blame)
 				blamed_lineno = atoi(pos + 1);
 
 		} else if (*line == '+' && parent_lineno != -1) {
-			if (blame->lineno == blamed_lineno - 1 &&
+			if (blame->lineno == blamed_lineno &&
 			    !strcmp(blame->text, line + 1)) {
 				view->pos.lineno = parent_lineno ? parent_lineno - 1 : 0;
 				break;

--- a/test/blame/navigation-parent-test
+++ b/test/blame/navigation-parent-test
@@ -22,8 +22,9 @@ steps '
 
 test_tig blame +36 project/Build.scala
 
-# This demonstrates a BUG: after pressing ',' we stay at line 36, as shown in the status
-# bar. Line 36 has nothing to do with line 36 of the original commit.
+# This shows that after pressing ',' we should be positioned on line 40
+# (starting with "clean in common"), as shown in the status bar. We should *not*
+# stay on line 36.
 assert_equals 'recursive-blame.screen' <<EOF
 90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  22|           "-feature",
 90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  23|           "-encoding", "utf8"
@@ -53,5 +54,5 @@ assert_equals 'recursive-blame.screen' <<EOF
 4edd069 Jonas Fonseca 2013-10-17 20:34 -0400  47|       richards,
 90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  48|       tracer
 90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  49|   )
-[blame] 90286e0752016a6bca30dfa7ca236d1f99345eb8 changed project/Build.scala - line 36 of 63                                                                                                         77%
+[blame] 90286e0752016a6bca30dfa7ca236d1f99345eb8 changed project/Build.scala - line 40 of 63                                                                                                         77%
 EOF

--- a/test/blame/navigation-parent-test
+++ b/test/blame/navigation-parent-test
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export COLUMNS=200
+
+# The test checks that pressing ',' in blame view correctly navigates
+# to the corresponding line in the target commit.
+
+in_work_dir create_repo_from_tgz "$base_dir/files/scala-js-benchmarks.tgz"
+
+tigrc <<EOF
+set line-graphics = ascii
+EOF
+
+steps '
+	# Press , to go to the parent of the blamed commit for that line
+	:parent
+	:save-display recursive-blame.screen
+'
+
+test_tig blame +36 project/Build.scala
+
+# This demonstrates a BUG: after pressing ',' we stay at line 36, as shown in the status
+# bar. Line 36 has nothing to do with line 36 of the original commit.
+assert_equals 'recursive-blame.screen' <<EOF
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  22|           "-feature",
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  23|           "-encoding", "utf8"
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  24|       )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  25|   )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  26|
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  27|   lazy val benchmarkSettings = defaultSettings ++ Seq(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  28|       unmanagedSources in (Compile, packageJS) +=
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  29|           baseDirectory.value / "exports.js"
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  30|   )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  31|
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  32|   lazy val parent: Project = Project(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  33|       id = "parent",
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  34|       base = file("."),
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  35|       settings = projectSettings ++ Seq(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  36|           name := "Scala.js Benchmarks",
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  37|           publishArtifact in Compile := false,
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  38|
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  39|           clean := clean.dependsOn(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  40|              clean in common,
+4edd069 Jonas Fonseca 2013-10-17 20:34 -0400  41|              clean in richards,
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  42|              clean in tracer
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  43|           ).value
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  44|       )
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  45|   ).aggregate(
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  46|       common,
+4edd069 Jonas Fonseca 2013-10-17 20:34 -0400  47|       richards,
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  48|       tracer
+90286e0 Jonas Fonseca 2013-10-14 14:56 -0400  49|   )
+[blame] 90286e0752016a6bca30dfa7ca236d1f99345eb8 changed project/Build.scala - line 36 of 63                                                                                                         77%
+EOF


### PR DESCRIPTION
@krobelus observed in https://github.com/jonas/tig/pull/1370 that this behavior, fixed in https://github.com/jonas/tig/commit/ca0809dbd20a31f6fa9b84c7eed5ecaa1368cd9d, regressed again in https://github.com/jonas/tig/commit/2280734104fd362a1188b0678109e01cdb9322cf.

This bug is similar to, but not identical with, https://github.com/jonas/tig/issues/1369.

The easiest way to observe the bug is to run `tig blame +28 tig-2.5.12 -- src/diff.c` and press `,` AKA `:parent`. The problem is that the view stays on line 28 instead of jumping to the corresponding line.

-----

This PR is complementary with #1370, they fix different bugs and can be merged independently. We could also decide on a different solution of changing the meaning of `blame->line`. That would also require a change to #1370.

See https://github.com/jonas/tig/pull/1370#issuecomment-2744658685 and the following comment for more details

A lot of this work is based heavily on that of @krobelus; the test is almost an exact copy of the test from #1370 for example.