### PR TITLE
Remove the exclusion between '?' and internal command

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -1124,24 +1124,23 @@ exec_run_request(struct view *view, struct run_request *req)
 		return REQ_NONE;
 	}
 
-	if (req->flags.internal) {
-		request = run_prompt_command(view, argv);
+	confirmed = !req->flags.confirm;
 
-	} else {
-		confirmed = !req->flags.confirm;
+	if (req->flags.confirm) {
+		char cmd[SIZEOF_STR], prompt[SIZEOF_STR];
+		const char *and_exit = req->flags.exit ? " and exit" : "";
 
-		if (req->flags.confirm) {
-			char cmd[SIZEOF_STR], prompt[SIZEOF_STR];
-			const char *and_exit = req->flags.exit ? " and exit" : "";
-
-			if (argv_to_string_quoted(argv, cmd, sizeof(cmd), " ") &&
-			    string_format(prompt, "Run `%s`%s?", cmd, and_exit) &&
-			    prompt_yesno(prompt)) {
-				confirmed = true;
-			}
+		if (argv_to_string_quoted(argv, cmd, sizeof(cmd), " ") &&
+		    string_format(prompt, "Run `%s`%s?", cmd, and_exit) &&
+		    prompt_yesno(prompt)) {
+			confirmed = true;
 		}
+	}
 
-		if (confirmed)
+	if (confirmed) {
+		if (req->flags.internal)
+			request = run_prompt_command(view, argv);
+		else
 			open_external_viewer(argv, repo.cdup, req->flags.silent,
 					     !req->flags.exit, req->flags.echo, req->flags.quick, false, "");
 	}


### PR DESCRIPTION
According to the document, '?' have the top priority while running external command, but it will fail if the keybind is like this `bind main pc :?!git log` which is a legal combination.

In this commit, I simply move the `confirm` check to the first place.

```
External user-defined command
    These actions start with one or more of the following option flags followed by the command that should be executed.
    !   Run the command in the foreground with output shown.
    @   Run the command in the background with no output.
    +   Run the command synchronously, and echo the first line of
        output to the status bar.
    ?   Prompt the user before executing the command.
    <   Exit Tig after executing the command.
    >   Re-open Tig instantly in the last displayed view after
        executing the command.
```