### PR TITLE
Committer toggle per view

### DIFF
--- a/include/tig/line.h
+++ b/include/tig/line.h
@@ -43,6 +43,11 @@ struct ref;
 	_(PP_REFS,		"Refs: "), \
 	_(PP_REFLOG,		"Reflog: "), \
 	_(PP_REFLOGMSG,		"Reflog message: "), \
+	_(PP_AUTHOR,		"Author: "	), \
+	_(PP_DATE,		"Date: "), \
+	_(PP_AUTHORDATE,		"AuthorDate: "), \
+	_(PP_COMMITTER,		"Commit: "	), \
+	_(PP_COMMITDATE,		"CommitDate: "), \
 	_(COMMIT,		"commit "), \
 	_(PARENT,		"parent "), \
 	_(TREE,			"tree "), \

--- a/include/tig/main.h
+++ b/include/tig/main.h
@@ -29,6 +29,7 @@ struct commit {
 struct main_state {
 	struct graph *graph;
 	struct commit current;
+	struct option_common optcom;
 	char **reflog;
 	size_t reflogs;
 	int reflog_width;

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -90,6 +90,8 @@ typedef struct view_column *view_settings;
 	_(vertical_split,		enum vertical_split,	VIEW_RESET_DISPLAY | VIEW_DIFF_LIKE) \
 	_(wrap_lines,			bool,			VIEW_DIFF_LIKE) \
 	_(wrap_search,			bool,			VIEW_NO_FLAGS) \
+	_(date_use_author,			bool,			VIEW_LOG_LIKE) \
+	_(author_as_committer,			bool,			VIEW_LOG_LIKE) \
 
 #define DEFINE_OPTION_EXTERNS(name, type, flags) extern type opt_##name;
 OPTION_INFO(DEFINE_OPTION_EXTERNS)
@@ -102,6 +104,7 @@ OPTION_INFO(DEFINE_OPTION_EXTERNS)
 	_(display,			enum author,		VIEW_NO_FLAGS) \
 	_(width,			int,			VIEW_NO_FLAGS) \
 	_(maxwidth,			int,			VIEW_NO_FLAGS) \
+	_(as_committer,			bool,			VIEW_BLAME_LIKE | VIEW_LOG_LIKE) \
 
 #define COMMIT_TITLE_COLUMN_OPTIONS(_) \
 	_(display,			bool,			VIEW_NO_FLAGS) \
@@ -198,7 +201,7 @@ void update_options_from_argv(const char *argv[]);
 const char *ignore_space_arg();
 const char *commit_order_arg();
 const char *commit_order_arg_with_graph(enum graph_display graph_display);
-const char *log_custom_pretty_arg(bool use_author_date);
+const char *log_custom_pretty_arg(struct option_common *optcom);
 const char *use_mailmap_arg();
 const char *diff_context_arg();
 const char *diff_prefix_arg();
@@ -222,6 +225,7 @@ struct option_info *find_option_info(struct option_info *option, size_t options,
 enum status_code parse_option(struct option_info *option, const char *prefix, const char *arg);
 struct option_info *find_column_option_info(enum view_column_type type, union view_column_options *opts,
 					const char *option, struct option_info *column_info, const char **column_name);
+void read_option_common(void *view, struct option_common *optcom);
 enum status_code parse_int(int *opt, const char *arg, int min, int max);
 enum status_code parse_step(double *opt, const char *arg);
 enum status_code set_option(const char *opt, int argc, const char *argv[]);

--- a/include/tig/parse.h
+++ b/include/tig/parse.h
@@ -48,7 +48,7 @@ struct blame_header {
 };
 
 bool parse_blame_header(struct blame_header *header, const char *text);
-bool parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *line, bool use_author_date);
+bool parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *line, struct option_common *optcom);
 
 /* Parse author lines where the name may be empty:
  *	author  <email@address.tld> 1138474660 +0100

--- a/include/tig/util.h
+++ b/include/tig/util.h
@@ -118,5 +118,14 @@ name(type **mem, size_t size, size_t increase)					\
 
 void sigsegv_handler(int sig);
 
+/*
+ * Common structures
+ */
+
+struct option_common {
+    bool author_as_committer;
+    bool use_author_date;
+};
+
 #endif
 /* vim: set ts=8 sw=8 noexpandtab: */

--- a/src/blame.c
+++ b/src/blame.c
@@ -43,6 +43,7 @@ struct blame {
 struct blame_state {
 	struct blame_commit *commit;
 	struct blame_header header;
+	struct option_common optcom;
 	char author[SIZEOF_STR];
 	bool auto_filename_display;
 	const char *filename;
@@ -76,6 +77,8 @@ blame_open(struct view *view, enum open_flags flags)
 	};
 	enum status_code code;
 	size_t i;
+
+	read_option_common(view, &state->optcom);
 
 	if (is_initial_view(view)) {
 		/* Finish validating and setting up blame options */
@@ -216,8 +219,6 @@ static bool
 blame_read(struct view *view, struct buffer *buf, bool force_stop)
 {
 	struct blame_state *state = view->private;
-	struct view_column *column = get_view_column(view, VIEW_COLUMN_DATE);
-	bool use_author_date = column && column->opt.date.use_author;
 
 	if (!buf) {
 		if (failed_to_load_initial_view(view))
@@ -255,7 +256,7 @@ blame_read(struct view *view, struct buffer *buf, bool force_stop)
 
 		state->commit = NULL;
 
-	} else if (parse_blame_info(state->commit, state->author, buf->data, use_author_date)) {
+	} else if (parse_blame_info(state->commit, state->author, buf->data, &state->optcom)) {
 		if (!state->commit->filename)
 			return false;
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -591,6 +591,10 @@ diff_blame_line(const char *ref, const char *file, unsigned long lineno,
 	struct io io;
 	bool ok = false;
 	struct buffer buf;
+	struct option_common optcom = {
+		.author_as_committer = false,
+		.use_author_date = false,
+	};
 
 	if (!string_format(line_arg, "-L%lu,+1", lineno))
 		return false;
@@ -604,7 +608,7 @@ diff_blame_line(const char *ref, const char *file, unsigned long lineno,
 				break;
 			header = NULL;
 
-		} else if (parse_blame_info(commit, author, buf.data, false)) {
+		} else if (parse_blame_info(commit, author, buf.data, &optcom)) {
 			ok = commit->filename != NULL;
 			break;
 		}

--- a/src/parse.c
+++ b/src/parse.c
@@ -14,6 +14,7 @@
 #include "tig/tig.h"
 #include "tig/parse.h"
 #include "tig/map.h"
+#include "tig/options.h"
 
 size_t
 parse_size(const char *text)
@@ -139,12 +140,12 @@ match_blame_header(const char *name, char **line)
 }
 
 bool
-parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *line, bool use_author_date)
+parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *line, struct option_common *optcom)
 {
-	if (match_blame_header("author ", &line)) {
+	if (match_blame_header(optcom->author_as_committer ? "committer " : "author ", &line)) {
 		string_ncopy_do(author, SIZEOF_STR, line, strlen(line));
 
-	} else if (match_blame_header("author-mail ", &line)) {
+	} else if (match_blame_header(optcom->author_as_committer ? "committer-mail " : "author-mail ", &line)) {
 		char *end = strchr(line, '>');
 
 		if (end)
@@ -154,10 +155,10 @@ parse_blame_info(struct blame_commit *commit, char author[SIZEOF_STR], char *lin
 		commit->author = get_author(author, line);
 		author[0] = 0;
 
-	} else if (match_blame_header(use_author_date ? "author-time " : "committer-time ", &line)) {
+	} else if (match_blame_header(optcom->use_author_date ? "author-time " : "committer-time ", &line)) {
 		parse_timesec(&commit->time, line);
 
-	} else if (match_blame_header(use_author_date ? "author-tz " : "committer-tz ", &line)) {
+	} else if (match_blame_header(optcom->use_author_date ? "author-tz " : "committer-tz ", &line)) {
 		parse_timezone(&commit->time, line);
 
 	} else if (match_blame_header("summary ", &line)) {

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -41,10 +41,12 @@ reflog_request(struct view *view, enum request request, struct line *line)
 	switch (request) {
 	case REQ_ENTER:
 	{
-		const char *main_argv[] = {
+		struct option_common optcom;
+		read_option_common(view, &optcom);
+ 		const char *main_argv[] = {
 			GIT_MAIN_LOG(encoding_arg, commit_order_arg(),
 				"%(mainargs)", "", commit->id, "",
-				show_notes_arg(), log_custom_pretty_arg(false))
+				show_notes_arg(), log_custom_pretty_arg(&optcom))
 		};
 		enum open_flags flags = view_is_displayed(view) ? OPEN_SPLIT : OPEN_DEFAULT;
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -74,13 +74,13 @@ refs_request(struct view *view, enum request request, struct line *line)
 	case REQ_ENTER:
 	{
 		const struct ref *ref = reference->ref;
-		struct view_column *column = get_view_column(view, VIEW_COLUMN_DATE);
-		bool use_author_date = column && column->opt.date.use_author;
+		struct option_common optcom;
+		read_option_common(view, &optcom);
 		const char *all_references_argv[] = {
 			GIT_MAIN_LOG(encoding_arg, commit_order_arg(),
 				"%(mainargs)", "",
 				refs_is_all(reference) ? "--all" : ref->id, "",
-				show_notes_arg(), log_custom_pretty_arg(use_author_date))
+				show_notes_arg(), log_custom_pretty_arg(&optcom))
 		};
 		enum open_flags flags = view_is_displayed(view) ? OPEN_SPLIT : OPEN_DEFAULT;
 
@@ -179,23 +179,42 @@ refs_open_visitor(void *data, const struct ref *ref)
 	return true;
 }
 
+static const char *
+refs_custom_pretty_arg(struct option_common *optcom)
+{
+	switch ((optcom->author_as_committer*2) + opt_mailmap)
+	{
+	case 0x3:
+		return optcom->use_author_date ?
+				"--pretty=format:%H%x00%cN <%cE> %ad%x00%s" :
+				"--pretty=format:%H%x00%cN <%cE> %cd%x00%s";
+	case 0x2:
+		return optcom->use_author_date ?
+				"--pretty=format:%H%x00%cn <%ce> %ad%x00%s" :
+				"--pretty=format:%H%x00%cn <%ce> %cd%x00%s";
+	case 0x1:
+		return optcom->use_author_date ?
+				"--pretty=format:%H%x00%aN <%aE> %ad%x00%s" :
+				"--pretty=format:%H%x00%aN <%aE> %cd%x00%s";
+	case 0x0:
+	default:
+		return optcom->use_author_date ?
+				"--pretty=format:%H%x00%an <%ae> %ad%x00%s" :
+				"--pretty=format:%H%x00%an <%ae> %cd%x00%s";
+	}
+}
+
 static const char **refs_argv;
 
 static enum status_code
 refs_open(struct view *view, enum open_flags flags)
 {
-	struct view_column *column = get_view_column(view, VIEW_COLUMN_DATE);
-	bool use_author_date = column && column->opt.date.use_author;
+	struct option_common optcom;
+	read_option_common(view, &optcom);
 	const char *refs_log[] = {
-		"git", "log", encoding_arg, "--no-color", "--date=raw", use_author_date
-			? opt_mailmap
-				? "--pretty=format:%H%x00%aN <%aE> %ad%x00%s"
-				: "--pretty=format:%H%x00%an <%ae> %ad%x00%s"
-			: opt_mailmap
-				? "--pretty=format:%H%x00%aN <%aE> %cd%x00%s"
-				: "--pretty=format:%H%x00%an <%ae> %cd%x00%s",
-			"--all", "--decorate-refs=", "--simplify-by-decoration",
-			NULL
+		"git", "log", encoding_arg, "--no-color", "--date=raw",
+		refs_custom_pretty_arg(&optcom), "--all", "--simplify-by-decoration",
+		NULL
 	};
 	enum status_code code;
 	const char *name = REFS_ALL_NAME;

--- a/src/tig.c
+++ b/src/tig.c
@@ -82,6 +82,10 @@
 	_('$', "commit title overflow display",	"commit-title-overflow"), \
 	_('d', "untracked directory info",	"status-show-untracked-dirs"), \
 	_('|', "view split",			"vertical-split"), \
+	_('E', "mail map",          "mailmap"), \
+	_('L', "local date",            "date-local"), \
+	_('M', "use author date",         "date-use-author"), \
+	_('m', "author as committer",         "author-as-committer"), \
 
 
 const struct menu_item toggle_menu_items[] = {

--- a/test/diff/diff-stat-test
+++ b/test/diff/diff-stat-test
@@ -46,9 +46,9 @@ Dimensions: height=28 width=181
 Position: offset=0 column=0 lineno=0
 line[  0] type=commit selected=1
 line[  0] cells=1 text=[commit 1b4c64b595aeb4de1d317d669faacd3c1d82f0b0]
-line[  1] type= selected=0
+line[  1] type=pp-author selected=0
 line[  1] cells=1 text=[Author: A. U. Thor <author@example.com>]
-line[  2] type= selected=0
+line[  2] type=pp-date selected=0
 line[  2] cells=1 text=[Date:   Sun Jul 2 15:01:24 2017 +0200]
 line[  3] type=default selected=0
 line[  3] cells=1 text=[]

--- a/test/help/all-keybindings-test.expected
+++ b/test/help/all-keybindings-test.expected
@@ -1,6 +1,6 @@
 Quick reference for tig keybindings:
 [-] Collapse all sections
-
+ 
 [-] generic bindings
 View switching
                            m view-main           Show main view
@@ -126,4 +126,4 @@ External commands:
                            ! ?git stash drop %(stash)
 [-] pager bindings
 Internal commands:
-[help] - line 2 of 148                                                                 86%
+[help] - line 2 of 152                                                                           84%

--- a/test/help/default-test
+++ b/test/help/default-test
@@ -30,30 +30,30 @@ Quick reference for tig keybindings:
 
 [-] generic bindings
 View switching
-                           m view-main           Show main view
-                           d view-diff           Show diff view
-                           l view-log            Show log view
-                           L view-reflog         Show reflog view
-                           t view-tree           Show tree view
-                           f view-blob           Show blob view
-                           b view-blame          Show blame view
-                           r view-refs           Show refs view
-                        s, S view-status         Show status view
-                           c view-stage          Show stage view
-                           y view-stash          Show stash view
-                           g view-grep           Show grep view
-                           p view-pager          Show pager view
-                           h view-help           Show help view
+                           m view-main                  Show main view
+                           d view-diff                  Show diff view
+                           l view-log                   Show log view
+                           L view-reflog                Show reflog view
+                           t view-tree                  Show tree view
+                           f view-blob                  Show blob view
+                           b view-blame                 Show blame view
+                           r view-refs                  Show refs view
+                        s, S view-status                Show status view
+                           c view-stage                 Show stage view
+                           y view-stash                 Show stash view
+                           g view-grep                  Show grep view
+                           p view-pager                 Show pager view
+                           h view-help                  Show help view
 View manipulation
-                     <Enter> enter               Enter and open selected line
-                           < back                Go back to the previous view state
-         <Down>, <Ctrl-N>, J next                Move to next
-           <Up>, <Ctrl-P>, K previous            Move to previous
-                         ',' parent              Move to parent
-                       <Tab> view-next           Move focus to the next view
-                     R, <F5> refresh             Reload and refresh view
-                           O maximize            Maximize the current view
-[help] - line 1 of 107                                                       26%
+                     <Enter> enter                      Enter and open selected line
+                           < back                       Go back to the previous view state
+         <Down>, <Ctrl-N>, J next                       Move to next
+           <Up>, <Ctrl-P>, K previous                   Move to previous
+                         ',' parent                     Move to parent
+                       <Tab> view-next                  Move focus to the next view
+                     R, <F5> refresh                    Reload and refresh view
+                           O maximize                   Maximize the current view
+[help] - line 1 of 111                                                       25%
 EOF
 
 assert_equals 'help-search.screen' <<EOF
@@ -62,30 +62,30 @@ Quick reference for tig keybindings:
 
 [-] generic bindings
 View switching
-                           m view-main           Show main view
-                           d view-diff           Show diff view
-                           l view-log            Show log view
-                           L view-reflog         Show reflog view
-                           t view-tree           Show tree view
-                           f view-blob           Show blob view
-                           b view-blame          Show blame view
-                           r view-refs           Show refs view
-                        s, S view-status         Show status view
-                           c view-stage          Show stage view
-                           y view-stash          Show stash view
-                           g view-grep           Show grep view
-                           p view-pager          Show pager view
-                           h view-help           Show help view
+                           m view-main                  Show main view
+                           d view-diff                  Show diff view
+                           l view-log                   Show log view
+                           L view-reflog                Show reflog view
+                           t view-tree                  Show tree view
+                           f view-blob                  Show blob view
+                           b view-blame                 Show blame view
+                           r view-refs                  Show refs view
+                        s, S view-status                Show status view
+                           c view-stage                 Show stage view
+                           y view-stash                 Show stash view
+                           g view-grep                  Show grep view
+                           p view-pager                 Show pager view
+                           h view-help                  Show help view
 View manipulation
-                     <Enter> enter               Enter and open selected line
-                           < back                Go back to the previous view state
-         <Down>, <Ctrl-N>, J next                Move to next
-           <Up>, <Ctrl-P>, K previous            Move to previous
-                         ',' parent              Move to parent
-                       <Tab> view-next           Move focus to the next view
-                     R, <F5> refresh             Reload and refresh view
-                           O maximize            Maximize the current view
-[help] - line 20 of 107                                                      26%
+                     <Enter> enter                      Enter and open selected line
+                           < back                       Go back to the previous view state
+         <Down>, <Ctrl-N>, J next                       Move to next
+           <Up>, <Ctrl-P>, K previous                   Move to previous
+                         ',' parent                     Move to parent
+                       <Tab> view-next                  Move focus to the next view
+                     R, <F5> refresh                    Reload and refresh view
+                           O maximize                   Maximize the current view
+[help] - line 20 of 111                                                      25%
 EOF
 
 assert_equals 'help-collapsed.screen' <<EOF
@@ -106,16 +106,16 @@ Internal commands:
   @ :/^@@
 [-] toggle bindings
 Toggle keys (enter: o <key>):
-                           . line-number                  Toggle line numbers
-                           D date                         Toggle dates
-                           A author                       Toggle author
-                           ~ line-graphics                Toggle graphics
-                           g commit-title-graph           Toggle revision graph
-                           # file-name                    Toggle file names
-                           * file-size                    Toggle file sizes
-                           W ignore-space                 Toggle space changes
-                           l commit-order                 Toggle commit order
-                           F commit-title-refs            Toggle reference display
-                           C show-changes                 Toggle local change display
-[help] - line 5 of 34                                                        82%
+                           . line-number                Toggle line numbers
+                           D date                       Toggle dates
+                           A author                     Toggle author
+                           ~ line-graphics              Toggle graphics
+                           g commit-title-graph         Toggle revision graph
+                           # file-name                  Toggle file names
+                           * file-size                  Toggle file sizes
+                           W ignore-space               Toggle space changes
+                           l commit-order               Toggle commit order
+                           F commit-title-refs          Toggle reference display
+                           C show-changes               Toggle local change display
+[help] - line 5 of 38                                                        73%
 EOF

--- a/test/help/user-command-test
+++ b/test/help/user-command-test
@@ -55,5 +55,5 @@ Searching
 [+] main bindings
 [+] diff bindings
 [+] reflog bindings
-[help] - line 82 of 132                                                                          82%
+[help] - line 82 of 136                                                                          80%
 EOF

--- a/test/log/log-graph-test
+++ b/test/log/log-graph-test
@@ -35,7 +35,7 @@ assert_equals 'log-graph.screen' <<EOF
 |
 * commit 110e090f815f40d649f5432172584057b550a160
 | Author: Jonas Fonseca <jonas.fonseca@gmail.com>
-| Date:   Tue Dec 17 00:02:15 2013 +0100
+| Date:   Tue Dec 17 00:10:36 2013 +0100
 |
 |     Update links to reflect project name change
 |

--- a/test/tigrc/env-vars-test
+++ b/test/tigrc/env-vars-test
@@ -36,5 +36,5 @@ Quick reference for tig keybindings:
 [-] generic bindings
 Misc
   : prompt Open the prompt
-[help] - line 1 of 25                                                        24%
+[help] - line 1 of 29                                                        20%
 EOF

--- a/test/tigrc/parse-test
+++ b/test/tigrc/parse-test
@@ -128,5 +128,5 @@ External commands:
    4 <quitting command
    5 +echoed command
    0 @?<+all modifiers
-[help] - line 9 of 37                                                        48%
+[help] - line 9 of 41                                                        43%
 EOF

--- a/test/tigrc/source-test
+++ b/test/tigrc/source-test
@@ -29,7 +29,7 @@ View manipulation
   q quit   Close all views and quit
 Misc
   : prompt Open the prompt
-[help] - line 1 of 27                                                        29%
+[help] - line 1 of 31                                                        25%
 EOF
 
 test_case source-file-quietly \
@@ -50,7 +50,7 @@ View manipulation
   q quit   Close all views and quit
 Misc
   : prompt Open the prompt
-[help] - line 1 of 27                                                        29%
+[help] - line 1 of 31                                                        25%
 EOF
 
 test_case source-nonexistent-file \
@@ -73,7 +73,7 @@ Misc
   : prompt Open the prompt
 [-] toggle bindings
 Toggle keys (enter: o <key>):
-[help] - line 1 of 25                                                        32%
+[help] - line 1 of 29                                                        27%
 EOF
 
 test_case source-nonexistent-file-quietly \
@@ -94,7 +94,7 @@ Misc
   : prompt Open the prompt
 [-] toggle bindings
 Toggle keys (enter: o <key>):
-[help] - line 1 of 25                                                        32%
+[help] - line 1 of 29                                                        27%
 EOF
 
 test_case source-tilde-path \
@@ -115,7 +115,7 @@ View manipulation
   q quit   Close all views and quit
 Misc
   : prompt Open the prompt
-[help] - line 1 of 27                                                        29%
+[help] - line 1 of 31                                                        25%
 EOF
 
 run_test_cases

--- a/tigrc
+++ b/tigrc
@@ -16,6 +16,7 @@
 #					: Show author information?
 #    - width (int)			: Fixed width when nonzero
 #    - maxwidth (int)			: Autosize limit
+#    - as_committer (bool)			: Show committer instead of author?
 #
 #   commit-title
 #    - display (bool)			: Show the commit title?
@@ -129,6 +130,8 @@ set diff-indicator		= yes		# Show diff +/- signs?
 set log-options			= --cc --stat	# User-defined options for `tig log` (git-log)
 #set main-options		= -n 1000	# User-defined options for `tig` (git-log)
 set mailmap			= yes		# Use .mailmap to show canonical name and email address?
+set author-as-committer = no		# Show committer instead of author?
+set date-use-author = no		# Show author date instead of committer date?
 
 # Misc
 set start-on-head		= no		# Start with cursor on HEAD commit?


### PR DESCRIPTION
Toggle name between committer and author

1. View specific option author-as-committer, similar to date-use-author
2. Work dynamically in views: main, log, refs, blame and tree.
   tig command: `:toggle author-as-committer`
   toggle key seq. : o, m
   * for log view, it is using `author-as-committer` instead of
     column option `log-view-author-as-committer` because log
     view does not have author column.
3. Give precedence to external formatter arguments if any, e.g.
   `tig log --prettry=fuller`

This reworked #810 and #1383 and can replace the latter one.