### PR TITLE
Run tests against system's tig when SYSTEM_TIG=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,8 +274,13 @@ else
 export MAKE_TEST_OPTS =
 endif
 
+ifeq ($(SYSTEM_TIG),1)
+$(TESTS): PATH := $(CURDIR)/test/tools:$(PATH)
+$(TESTS): test/tools/test-graph
+else
 $(TESTS): PATH := $(CURDIR)/test/tools:$(CURDIR)/src:$(PATH)
 $(TESTS): $(EXE) test/tools/test-graph
+endif
 	$(QUIET_TEST)$(TEST_SHELL) $@
 
 test-todo: MAKE_TEST_OPTS += todo


### PR DESCRIPTION
This PR allows running the tests against tig installed on the system. This is useful for downstream projects that want to test the packaged version for typical errors. In Debian this is used via autopkgtest to ensure that any libraries tig depends on don't cause any regressions.