### PR TITLE
support option append

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -630,10 +630,17 @@ parse_encoding(struct encoding **encoding_ref, const char *arg, bool priority)
 }
 
 static enum status_code
-parse_args(const char ***args, const char *argv[])
+parse_args(const char ***args, const char *argv[], bool append)
 {
+	if (append) {
+		if (!argv_append_array(args, argv))
+			return ERROR_OUT_OF_MEMORY;
+		return SUCCESS;
+	}
+
 	if (!argv_copy(args, argv))
 		return ERROR_OUT_OF_MEMORY;
+
 	return SUCCESS;
 }
 
@@ -801,7 +808,7 @@ parse_view_settings(struct view_column **view_column, const char *name_, const c
 }
 
 static enum status_code
-option_update(struct option_info *option, int argc, const char *argv[])
+option_update(struct option_info *option, int argc, const char *argv[], bool append)
 {
 	enum status_code code;
 
@@ -809,7 +816,10 @@ option_update(struct option_info *option, int argc, const char *argv[])
 		return SUCCESS;
 
 	if (!strcmp(option->type, "const char **"))
-		return parse_args(option->value, argv + 2);
+		return parse_args(option->value, argv + 2, append);
+
+	if (append)
+		return error("Option %s does not support +=", argv[0]);
 
 	if (argc < 3)
 		return error("Invalid set command: set option = value");
@@ -821,6 +831,7 @@ option_update(struct option_info *option, int argc, const char *argv[])
 		return parse_ref_formats(option->value, argv + 2);
 
 	code = parse_option(option, "", argv[2]);
+
 	if (code == SUCCESS && argc != 3)
 		return error("Option %s only takes one value", argv[0]);
 
@@ -832,16 +843,22 @@ static enum status_code
 option_set_command(int argc, const char *argv[])
 {
 	struct option_info *option;
+	bool append = false;
 
 	if (argc < 2)
 		return error("Invalid set command: set option = value");
 
-	if (strcmp(argv[1], "="))
+	if (!strcmp(argv[1], "=")) {
+		append = false;
+	} else if (!strcmp(argv[1], "+=")) {
+		append = true;
+	} else {
 		return error("No value assigned to %s", argv[0]);
+	}
 
 	option = find_option_info(option_info, ARRAY_SIZE(option_info), "", argv[0]);
 	if (option)
-		return option_update(option, argc, argv);
+		return option_update(option, argc, argv, append);
 
 	{
 		const char *obsolete[][2] = {
@@ -852,7 +869,7 @@ option_set_command(int argc, const char *argv[])
 		if (index != -1) {
 			option = find_option_info(option_info, ARRAY_SIZE(option_info), "", obsolete[index][1]);
 			if (option) {
-				enum status_code code = option_update(option, argc, argv);
+				enum status_code code = option_update(option, argc, argv, append);
 
 				if (code != SUCCESS)
 					return code;


### PR DESCRIPTION
Adding append support for string-based options makes tigrc configuration more composable and less error-prone. Today, options such as main-options must be rewritten in full whenever a user wants to add one more argument, which leads to duplication and makes small customizations harder to maintain. With append support, users can keep a shared base configuration and extend it incrementally in later config blocks or local overrides. This improves readability, reduces accidental loss of existing arguments, and makes configuration layering much easier.