### PR TITLE
Fix blob view edit not writing changes to working directory

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -152,6 +152,8 @@ blob_request(struct view *view, enum request request, struct line *line)
 	case REQ_EDIT:
 		if (state->file)
 			open_editor(state->file, (line - view->line) + 1);
+		else if (is_head_commit(state->commit))
+			open_editor(view->env->file, (line - view->line) + 1);
 		else
 			open_blob_editor(view->vid, basename(view->ref), (line - view->line) + 1);
 		return REQ_NONE;


### PR DESCRIPTION
## Summary

When using the file finder (`f`) to open a file in blob view, pressing `e` to edit opens a **temporary file** instead of the working directory file. Changes are silently lost when the editor closes.

## Root Cause

In `blob_request()` (`src/blob.c:152-157`), when `state->file` is NULL (which is the case when entering blob view from the file finder), the code unconditionally calls `open_blob_editor()`:

```c
case REQ_EDIT:
    if (state->file)
        open_editor(state->file, ...);       // working dir file
    else
        open_blob_editor(view->vid, ...);    // temp file (deleted after edit!)
```

`open_blob_editor()` (`src/tree.c:336-360`) works by:
1. Running `git cat-file blob <id>` to write blob content to a temp file (`/tmp/tigblob.XXXXXX.xxx`)
2. Opening the editor on the temp file
3. Calling `unlink()` to **delete the temp file** immediately after the editor closes

Since the edit targets a temporary file that gets deleted, all changes are lost.

## Contrast with Tree View

The tree view (`src/tree.c:378-386`) handles this correctly by checking whether the current commit is HEAD:

```c
case REQ_EDIT:
    if (!is_head_commit(view->vid))
        open_blob_editor(entry->id, entry->name, 0);  // historical commit → temp file
    else
        open_editor(view->env->file, 0);               // HEAD → working dir file
```

## Fix

Add the same `is_head_commit()` check to blob view. When viewing a file at HEAD (which is always the case from the file finder), edit the working directory file directly:

```c
case REQ_EDIT:
    if (state->file)
        open_editor(state->file, ...);
    else if (is_head_commit(state->commit))
        open_editor(view->env->file, ...);              // ← new: HEAD → working dir
    else
        open_blob_editor(view->vid, ...);               // historical → temp file
```

## Steps to Reproduce

1. Open tig
2. Press `f` to open file finder
3. Select a file and press Enter to enter blob view
4. Press `e` to edit
5. Make changes and save (`:wq`)
6. Return to tig, press `s` for status view
7. **Expected**: file appears under "Changes not staged for commit"
8. **Actual**: no changes detected

Fixes #1415