### PR TITLE
chocolate-theme: Fix cursor color on selecting commit in main view.

### DIFF
--- a/contrib/chocolate.theme.tigrc
+++ b/contrib/chocolate.theme.tigrc
@@ -5,7 +5,9 @@ color graph-commit		red	default
 color id			167	default
 color "author "			95	default
 color "Commit: "		90	default
+
 color cursor			white	101	bold
+color cursor-blur		white	101
 
 color palette-0			93	default
 color palette-1			95	default


### PR DESCRIPTION
Otherwise we have a bright yellow cursor on pressing enter in main view. White text on bright yellow cursor is very hard to read.

Without:

<img width="257" height="71" alt="image" src="https://github.com/user-attachments/assets/b691b0b9-518e-4402-87fc-70d3946cfa97" />

<br>

With:

<img width="306" height="60" alt="image" src="https://github.com/user-attachments/assets/2f0c325b-47ac-4ced-b604-868f4e344d34" />
