### PR TITLE
Fix slow tig status in large repo when given a subdirectory path

### DIFF
--- a/include/tig/git.h
+++ b/include/tig/git.h
@@ -38,10 +38,10 @@
 /* Don't show staged unmerged entries. */
 #define GIT_DIFF_STAGED_FILES(output_arg) \
 	"git", "diff-index", (output_arg), "%(cmdlineargs)", "--diff-filter=ACDMRTXB", \
-		"-C", "--cached", "HEAD", "--", NULL
+		"-C", "--cached", "HEAD", "--", "%(fileargs)", NULL
 
 #define GIT_DIFF_UNSTAGED_FILES(output_arg) \
-	"git", "diff-files", (output_arg), "%(cmdlineargs)", NULL
+	"git", "diff-files", (output_arg), "%(cmdlineargs)", "--", "%(fileargs)", NULL
 
 #define GIT_DIFF_BLAME(encoding_arg, context_arg, prefix_arg, space_arg, word_diff_arg, new_name) \
 	"git", "diff-files", (encoding_arg), "--textconv", "--patch-with-stat", "-C", \

--- a/src/status.c
+++ b/src/status.c
@@ -11,6 +11,7 @@
  * GNU General Public License for more details.
  */
 
+#include "tig/argv.h"
 #include "tig/io.h"
 #include "tig/refdb.h"
 #include "tig/repo.h"
@@ -92,8 +93,14 @@ status_run(struct view *view, const char *argv[], char status, enum line_type ty
 	struct buffer buf;
 	struct io io;
 	const char **status_argv = NULL;
-	bool ok = argv_format(view->env, &status_argv, argv, 0) &&
-		  io_run(&io, IO_RD, repo.exec_dir, NULL, status_argv);
+	int format_flags = 0;
+	bool ok;
+
+	if (!view_has_flags(view, VIEW_FILE_FILTER) || opt_file_filter)
+		format_flags |= argv_flag_file_filter;
+
+	ok = argv_format(view->env, &status_argv, argv, format_flags) &&
+	    io_run(&io, IO_RD, repo.exec_dir, NULL, status_argv);
 
 	argv_free(status_argv);
 	free(status_argv);
@@ -188,12 +195,8 @@ error_out:
 static const char *status_diff_index_argv[] = { GIT_DIFF_STAGED_FILES("-z") };
 static const char *status_diff_files_argv[] = { GIT_DIFF_UNSTAGED_FILES("-z") };
 
-static const char *status_list_other_argv[] = {
-	"git", "ls-files", "-z", "--others", "--exclude-standard", NULL, NULL, NULL
-};
-
 static const char *status_list_no_head_argv[] = {
-	"git", "ls-files", "-z", "--cached", "--exclude-standard", NULL
+	"git", "ls-files", "-z", "--cached", "--exclude-standard", "%(fileargs)", NULL
 };
 
 /* Restore the previous line number to stay in the context or select a
@@ -361,16 +364,26 @@ status_update_onbranch(void)
 static bool
 status_read_untracked(struct view *view)
 {
+	const char *argv[16];
+	int argc = 0;
+
 	if (!opt_status_show_untracked_files)
 		return add_line_nodata(view, LINE_STAT_UNTRACKED)
 		    && add_line_nodata(view, LINE_STAT_NONE);
 
-	status_list_other_argv[ARRAY_SIZE(status_list_other_argv) - 3] =
-		opt_status_show_untracked_dirs ? NULL : "--directory";
-	status_list_other_argv[ARRAY_SIZE(status_list_other_argv) - 2] =
-		opt_status_show_untracked_dirs ? NULL : "--no-empty-directory";
+	argv[argc++] = "git";
+	argv[argc++] = "ls-files";
+	argv[argc++] = "-z";
+	argv[argc++] = "--others";
+	argv[argc++] = "--exclude-standard";
+	if (!opt_status_show_untracked_dirs) {
+		argv[argc++] = "--directory";
+		argv[argc++] = "--no-empty-directory";
+	}
+	argv[argc++] = "%(fileargs)";
+	argv[argc] = NULL;
 
-	return status_run(view, status_list_other_argv, '?', LINE_STAT_UNTRACKED);
+	return status_run(view, argv, '?', LINE_STAT_UNTRACKED);
 }
 
 /* First parse staged info using git-diff-index(1), then parse unstaged
@@ -394,7 +407,8 @@ status_open(struct view *view, enum open_flags flags)
 	add_line_nodata(view, LINE_HEADER);
 	status_update_onbranch();
 
-	update_index();
+	if (!opt_file_args || !opt_file_filter)
+		update_index();
 
 	if ((!show_untracked_only && !status_run(view, staged_argv, staged_status, LINE_STAT_STAGED)) ||
 	    (!show_untracked_only && !status_run(view, status_diff_files_argv, 0, LINE_STAT_UNSTAGED)) ||
@@ -865,7 +879,7 @@ status_select(struct view *view, struct line *line)
 static struct view_ops status_ops = {
 	"file",
 	"",
-	VIEW_CUSTOM_STATUS | VIEW_SEND_CHILD_ENTER | VIEW_STATUS_LIKE | VIEW_REFRESH,
+	VIEW_CUSTOM_STATUS | VIEW_SEND_CHILD_ENTER | VIEW_STATUS_LIKE | VIEW_FILE_FILTER | VIEW_REFRESH,
 	0,
 	status_open,
 	NULL,

--- a/test/status/file-filter-test
+++ b/test/status/file-filter-test
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+. libtest.sh
+. libgit.sh
+
+export LINES=15
+export COLUMNS=120
+
+# This test uses the trace output so do not show trace for this test.
+trace=
+export TIG_TRACE="$HOME/trace"
+
+test_setup_work_dir()
+{
+	git_init .
+
+	git_add subdir/staged <<EOF
+staged in subdir
+EOF
+
+	git_add other/staged <<EOF
+staged in other
+EOF
+
+	git_commit -m "Initial commit"
+	git branch -M master
+
+	printf 'unstaged in subdir\n' >> subdir/staged
+	printf 'unstaged in other\n' >> other/staged
+	touch -- subdir/untracked other/untracked
+}
+
+test_case 'status-path-filter' \
+	--args='status subdir' \
+<<EXPECTED_SCREEN
+On branch master
+Changes to be committed:
+  (no files)
+Changes not staged for commit:
+M subdir/staged
+Untracked files:
+? subdir/untracked
+
+
+
+
+
+
+[status] Nothing to update                                                                                          100%
+EXPECTED_SCREEN
+
+run_test_cases
+
+grep 'git rev-parse' < "$TIG_TRACE" > rev-parse.trace
+grep 'git diff-index' < "$TIG_TRACE" > diff-index.trace
+grep 'git diff-files' < "$TIG_TRACE" > diff-files.trace
+grep 'git ls-files' < "$TIG_TRACE" > ls-files.trace
+
+if grep -q 'update-index' < "$TIG_TRACE"; then
+	die "update-index should not run when status is path-filtered"
+fi
+
+assert_equals 'rev-parse.trace' <<EOF
+git rev-parse --no-revs --no-flags subdir
+git rev-parse --flags --no-revs subdir
+git rev-parse --symbolic --revs-only subdir
+git rev-parse --git-dir --is-inside-work-tree --show-cdup --show-prefix HEAD --symbolic-full-name HEAD
+EOF
+
+assert_equals 'diff-index.trace' <<EOF
+git diff-index -z --diff-filter=ACDMRTXB -C --cached HEAD -- subdir
+EOF
+
+assert_equals 'diff-files.trace' <<EOF
+git diff-files -z -- subdir
+EOF
+
+assert_equals 'ls-files.trace' <<EOF
+git ls-files -z --others --exclude-standard subdir
+EOF


### PR DESCRIPTION
## Summary

`git status `is quite slow in large repositories like chromium, but  `git status <path>` is much faster because it limits the scan to the given pathspec. while `tig status <path>` was as slow as `tig status`.

This change makes the status view pass path arguments to the underlying Git commands and skip the full index refresh when path filtering is active.

## Changes

- Pass `%(fileargs)` to `git diff-index`, `git diff-files`, and `git ls-files` when loading the status view
- Enable file argument expansion in `status_run()` (same mechanism as log/diff views)
- Skip `git update-index --refresh` when a path filter is active (this was the main bottleneck in large repos)
- Add `VIEW_FILE_FILTER` to the status view
- Add `test/status/file-filter-test`

## Result
- Before: 
   It used to take ages—around 37 seconds—looking like the app completely froze.
<img width="1336" height="516" alt="20260522161217_rec_" src="https://github.com/user-attachments/assets/92e15cb6-515f-4797-a4d0-41aab0099527" />


- After:  Reduced to ~1 second, drastically improving the user experience for this widely used feature.
<img width="1612" height="468" alt="20260522161148_rec_" src="https://github.com/user-attachments/assets/10c4fcd3-d9b2-4823-8592-171d389fd690" />




## Test plan

- [x] `make test/status/file-filter-test`
- [x] In a large repo, verify `tig status subdir` is much faster than `tig status`
- [x] Verify `tig status subdir` shows the same changes as `git status subdir`
- [x] Verify `tig status` (without path) still works as before