### PR TITLE
Set terminal window title using OSC escape sequences

### DIFF
--- a/include/tig/display.h
+++ b/include/tig/display.h
@@ -26,6 +26,7 @@ void update_status(const char *msg, ...) PRINTF_LIKE(1, 2);
 void update_status_with_context(const char *context, const char *msg, ...) PRINTF_LIKE(2, 3);
 void report(const char *msg, ...) PRINTF_LIKE(1, 2);
 void report_clear(void);
+void set_terminal_title(const char *title);
 
 /*
  * Display management.

--- a/src/display.c
+++ b/src/display.c
@@ -699,7 +699,6 @@ init_display(void)
 
 	set_terminal_modes();
 	save_terminal_title();
-	set_terminal_title("tig");
 	init_colors();
 
 	getmaxyx(stdscr, y, x);

--- a/src/display.c
+++ b/src/display.c
@@ -572,6 +572,15 @@ report_clear(void)
 }
 
 static void
+restore_terminal_title(void)
+{
+	static const char restore_seq[] = "\033[23;2t";
+
+	if (opt_tty.fd >= 0)
+		write(opt_tty.fd, restore_seq, sizeof(restore_seq) - 1);
+}
+
+static void
 done_display(void)
 {
 	if (cursed) {
@@ -581,6 +590,7 @@ done_display(void)
 		}
 		curs_set(1);
 		endwin();
+		restore_terminal_title();
 	}
 	cursed = false;
 
@@ -604,6 +614,29 @@ set_terminal_modes(void)
 	noecho();	/* Don't echo input */
 	curs_set(0);
 	leaveok(stdscr, false);
+}
+
+void
+set_terminal_title(const char *title)
+{
+	char buf[SIZEOF_STR];
+	int len;
+
+	if (opt_tty.fd < 0)
+		return;
+
+	len = snprintf(buf, sizeof(buf), "\033]0;%s\007", title);
+	if (len > 0 && (size_t) len < sizeof(buf))
+		write(opt_tty.fd, buf, len);
+}
+
+static void
+save_terminal_title(void)
+{
+	static const char save_seq[] = "\033[22;2t";
+
+	if (opt_tty.fd >= 0)
+		write(opt_tty.fd, save_seq, sizeof(save_seq) - 1);
 }
 
 void
@@ -665,6 +698,8 @@ init_display(void)
 		die("Failed to initialize curses");
 
 	set_terminal_modes();
+	save_terminal_title();
+	set_terminal_title("tig");
 	init_colors();
 
 	getmaxyx(stdscr, y, x);

--- a/src/view.c
+++ b/src/view.c
@@ -664,6 +664,37 @@ update_view(struct view *view)
 	return true;
 }
 
+static const char *
+get_repo_name(void)
+{
+	static char name[SIZEOF_REF];
+	char *resolved, *base, *dir;
+
+	if (*name)
+		return name;
+
+	if (!*repo.git_dir) {
+		string_ncopy(name, "unknown", 7);
+		return name;
+	}
+
+	resolved = realpath(repo.git_dir, NULL);
+	if (!resolved) {
+		string_ncopy(name, "unknown", 7);
+		return name;
+	}
+
+	base = basename(resolved);
+	if (!strcmp(base, ".git")) {
+		dir = dirname(resolved);
+		base = basename(dir);
+	}
+
+	string_ncopy(name, base, strlen(base));
+	free(resolved);
+	return name;
+}
+
 void
 update_view_title(struct view *view)
 {
@@ -711,6 +742,14 @@ update_view_title(struct view *view)
 	view_lines = view->pos.offset + view->height;
 	lines = view->lines ? MIN(view_lines, view->lines) * 100 / view->lines : 0;
 	mvwprintw(window, 0, view->width - count_digits(lines) - 1, "%u%%", lines);
+
+	if (view == display[current_view]) {
+		char title[SIZEOF_STR];
+
+		snprintf(title, sizeof(title), "tig (%s): %s",
+			 get_repo_name(), view->name);
+		set_terminal_title(title);
+	}
 
 	wnoutrefresh(window);
 }


### PR DESCRIPTION
Closes #1430

## Summary

tig does not set the terminal window title, making it hard to distinguish between multiple tig instances in a taskbar or window switcher. This is especially important for tiling window managers and window switchers that rely on the title to let users find windows.

This adds terminal title support using the OSC 0 escape sequence. The title follows the format `tig (<repo>): <view>` (e.g. `tig (linux): main`) and updates dynamically as the user switches views.

## Details

- The title is written directly to the tty fd to avoid interfering with ncurses buffering
- The previous terminal title is saved on startup and restored on exit using the xterm title stack (CSI 22;2 t / CSI 23;2 t)
- The repo name is derived from the git directory path using `realpath()`
- Terminals that do not support these sequences silently ignore them
