### PR TITLE
feature: add --describe support for git-describe options

### DIFF
--- a/include/tig/argv.h
+++ b/include/tig/argv.h
@@ -67,6 +67,7 @@ struct argv_env {
 	char goto_id[SIZEOF_REV];
 	char search[SIZEOF_STR];
 	char none[1];
+	char *describe;
 };
 
 extern struct argv_env argv_env;

--- a/src/diff.c
+++ b/src/diff.c
@@ -520,6 +520,16 @@ diff_read_describe(struct view *view, struct buffer *buffer, struct diff_state *
 	return true;
 }
 
+static char *trim_quotes(char *start, char *end)
+{
+	if ( (*start == '\'' && *(end - 1) == '\'') ||
+	     (*start == '"'  && *(end - 1) == '"' ) ) {
+		start += 1;
+		*(end - 1) = '\0';
+	}
+	return start;
+}
+
 static bool
 diff_read(struct view *view, struct buffer *buf, bool force_stop)
 {
@@ -565,8 +575,28 @@ diff_read(struct view *view, struct buffer *buf, bool force_stop)
 		diff_restore_line(view, state);
 
 		if (!state->adding_describe_ref && !ref_list_contains_tag(view->vid)) {
-			const char *describe_argv[] = { "git", "describe", "--tags", view->vid, NULL };
+			const char *describe_args[] = { "git", "describe", "--tags", NULL };
+			const char **describe_argv = NULL;
+			argv_append_array(&describe_argv, describe_args);
+			if (argv_env.describe && strlen(argv_env.describe) > 0) {
+				char *p, *start;
+				for (p = argv_env.describe, start = p; *p; ++p) {
+					if (*p == ' ') {
+						*p = '\0';
+						start = trim_quotes(start, p);
+						argv_append(&describe_argv, start);
+						start = p + 1;
+					}
+				}
+				if (start < p) {
+					start = trim_quotes(start, p);
+					argv_append(&describe_argv, start);
+				}
+			}
+			argv_append(&describe_argv, view->vid);
 			enum status_code code = begin_update(view, NULL, describe_argv, OPEN_EXTRA);
+			argv_free(describe_argv);
+			free(describe_argv);
 
 			if (code != SUCCESS) {
 				report("Failed to load describe data: %s", get_status_message(code));

--- a/src/tig.c
+++ b/src/tig.c
@@ -378,6 +378,7 @@ static const char usage_string[] =
 "\n"
 "Options:\n"
 "  +<number>       Select line <number> in the first view\n"
+"  --describe      git-describe arguments e.g: --describe=\"--exclude 'next-*' --contains\"\n"
 "  -v, --version   Show version and exit\n"
 "  -h, --help      Show help message and exit\n"
 "  -C <path>       Start in <path>";
@@ -525,13 +526,19 @@ parse_options(int argc, const char *argv[], bool pager_mode)
 		i--; /* revisit option in loop below */
 	}
 
+	argv_env.describe = NULL;
+
 	for (; i < argc; i++) {
 		const char *opt = argv[i];
 
 		// stop parsing our options after -- and let rev-parse handle the rest
 		if (!seen_dashdash) {
-			if (!strcmp(opt, "--")) {
+			if (strlen(opt) == 2 && !strcmp(opt, "--")) {
 				seen_dashdash = true;
+
+			} else if (!strncmp(opt, "--describe=", 11)) {
+				argv_env.describe = (char *)opt + 11;
+				continue;
 
 			} else if (!strcmp(opt, "-v") || !strcmp(opt, "--version")) {
 #if defined HAVE_PCRE2


### PR DESCRIPTION
In my case - working with multiple Linux kernel remote trees - the default Ref: reported for a commit isn't helpful since it shows a prior tag rather than the containing tag.

In almost all cases I need to see the equivalent of:

  git describe --contains

and additionally need to filter the returned tags with e.g:

  --exclude 'next-*'

or

  --match ...

This feature adds the command-line option --describe= that accepts additional git-describe options and appends them to the args passed to git-describe.

An example usage:

tig --describe="--exclude 'next-*' --contains" v6.18..v6.19 drivers/iommu/intel

Closes: #1435