### PR TITLE
Add PACKAGE_TARNAME to config.make so it's resolveable

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -5,6 +5,7 @@ exec_prefix = @exec_prefix@
 bindir = @bindir@
 mandir = @mandir@
 docdir = @docdir@
+PACKAGE_TARNAME = @PACKAGE_TARNAME@
 datarootdir = @datarootdir@
 sysconfdir = @sysconfdir@
 


### PR DESCRIPTION
Without it, docdir='${datarootdir}/doc/${PACKAGE_TARNAME}' will resolve to /usr/share/doc/ and the docfiles will end up in the wrong place.

I noticed this during packaging it for Debian, where it expects the docs being in /usr/share/doc/tig/.