### PR TITLE
Update git information after running ':!'

### DIFF
--- a/include/tig/view.h
+++ b/include/tig/view.h
@@ -157,6 +157,7 @@ struct view {
 	time_t update_secs;
 	struct encoding *encoding;
 	bool unrefreshable;
+	bool watch_after_command;
 	struct watch watch;
 
 	/* Private data */

--- a/src/pager.c
+++ b/src/pager.c
@@ -21,6 +21,7 @@
 #include "tig/view.h"
 #include "tig/draw.h"
 #include "tig/diff.h"
+#include "tig/watch.h"
 
 /*
  * Pager backend
@@ -145,6 +146,13 @@ pager_read(struct view *view, struct buffer *buf, bool force_stop)
 			if (!force_stop)
 				report("Failed to run the diff-highlight program: %s", opt_diff_highlight);
 			return false;
+		}
+
+		/* Commands entered as :! are run in this view instead of through
+		 * open_external_viewer(), so notify repository watchers here. */
+		if (view->watch_after_command) {
+			view->watch_after_command = false;
+			watch_update(WATCH_EVENT_AFTER_COMMAND);
 		}
 
 		return true;

--- a/src/prompt.c
+++ b/src/prompt.c
@@ -997,6 +997,7 @@ run_prompt_command(struct view *view, const char *argv[])
 			argv_to_string(next->argv, next->ref, sizeof(next->ref), " ");
 
 			next->dir = NULL;
+			next->watch_after_command = true;
 			open_pager_view(view, OPEN_PREPARED | OPEN_WITH_STDERR);
 		}
 

--- a/src/view.c
+++ b/src/view.c
@@ -807,11 +807,18 @@ load_view(struct view *view, struct view *prev, enum open_flags flags)
 		view->prev = prev;
 	}
 
-	if (!refresh && view_can_refresh(view) &&
-	    watch_update_single(&view->watch, WATCH_EVENT_SWITCH_VIEW)) {
-		refresh = watch_dirty(&view->watch);
-		if (refresh)
-			flags |= OPEN_REFRESH;
+	if (!refresh && view_can_refresh(view)) {
+		enum watch_trigger changed =
+			watch_update_single(&view->watch, WATCH_EVENT_SWITCH_VIEW);
+
+		if (changed) {
+			if (changed & WATCH_REFS)
+				load_refs(true);
+
+			refresh = watch_dirty(&view->watch);
+			if (refresh)
+				flags |= OPEN_REFRESH;
+		}
 	}
 
 	if (refresh) {

--- a/test/main/refresh-test
+++ b/test/main/refresh-test
@@ -26,6 +26,10 @@ steps '
 
 	:exec @git reset --hard
 	:save-display main-after-reset-hard.screen
+
+	:!git tag test
+	q
+	:save-display main-after-tag.screen
 '
 
 tigrc <<EOF
@@ -83,6 +87,13 @@ EOF
 
 assert_equals 'main-after-reset-hard.screen' <<EOF
 2009-02-13 23:31 +0000 A. U. Thor I [master] Initial commit
+
+
+[main] ca34b8bb5a0034fc5b5ab9840f74cae1fab2c3a9 - commit 1 of 1             100%
+EOF
+
+assert_equals 'main-after-tag.screen' <<EOF
+2009-02-13 23:31 +0000 A. U. Thor I [master] <test> Initial commit
 
 
 [main] ca34b8bb5a0034fc5b5ab9840f74cae1fab2c3a9 - commit 1 of 1             100%


### PR DESCRIPTION
The current program won't update git information after running command with ':!'.

For example, a simple command running under the main view.
```:!git tag test```
The main view wasn't update until manual refresh.

Actually, any commands issued by ':!' would have the same problem, so this commit is to fix the problem.
