### PR TITLE
Feature: add an option to enable/disable counter and view-cleaning

### DIFF
--- a/doc/manual.adoc
+++ b/doc/manual.adoc
@@ -498,6 +498,8 @@ Prompt
 |:<sha>			|Jump to a specific commit, e.g. `:2f12bcc`.
 |:<x>			|Execute the corresponding key binding, e.g. `:q`.
 |:!<command>		|Execute a system command in a pager, e.g. `:!git log -p`.
+			 Set `show-loading` to `no` to keep the previous contents visible
+			 while waiting for output and hide the elapsed-time counter.
 |:<action>		|Execute a Tig command, e.g. `:edit`.
 |:goto <rev>		|Jump to a specific revision, e.g. `:goto %(commit)^2`
 			 to go to the current commit's 2nd parent or

--- a/doc/tigrc.5.adoc
+++ b/doc/tigrc.5.adoc
@@ -389,6 +389,12 @@ The following variables can be set:
 	Whether to automatically scroll the pager view while loading. Move the
 	cursor out of the last line to stop scrolling and back in to resume.
 
+'show-loading' (bool)::
+
+	Whether to clear a view while waiting for its first line of output and
+	show the elapsed loading time in its title. Enabled by default. When
+	disabled, the previous contents remain visible until new output arrives.
+
 'recurse-tree' (bool)::
 
 	Whether to show all files recursively in the tree view.
@@ -735,6 +741,14 @@ Unless otherwise specified, commands are run in the foreground with their
 console output shown (as if '!' was specified). When multiple command options
 are specified their behavior is combined, e.g. "?<git commit" will prompt the
 user whether to execute the command and will exit Tig after completion.
+
+When entered at the prompt, `:!<command>` opens a pager view. By default, the
+pager is cleared before command output is read, and its title shows the elapsed
+loading time after three seconds. Set `show-loading` to `no` to retain the
+previous contents until output arrives and hide the timer. Use
+`:exec @<command>` to avoid opening the pager by running the command silently in
+the background, or `:exec +<command>` to run it synchronously and show only its
+first output line in the status bar.
 
 Note that if you want to use pipes or redirection in your commands then you
 must run them in a subshell, i.e. embed your commands in `sh -c '<commands>'`.

--- a/include/tig/options.h
+++ b/include/tig/options.h
@@ -75,6 +75,7 @@ typedef struct view_column *view_settings;
 	_(rev_filter,			bool,			VIEW_REV_FILTER) \
 	_(send_child_enter,		bool,			VIEW_NO_FLAGS) \
 	_(show_changes,			bool,			VIEW_LOG_LIKE) \
+	_(show_loading,			bool,			VIEW_NO_FLAGS) \
 	_(show_notes,			bool,			VIEW_DIFF_LIKE | VIEW_LOG_LIKE) \
 	_(show_untracked,		bool,			VIEW_LOG_LIKE) \
 	_(split_view_height,		double,			VIEW_RESET_DISPLAY) \

--- a/src/view.c
+++ b/src/view.c
@@ -632,7 +632,7 @@ update_view(struct view *view)
 		return true;
 
 	if (!io_can_read(view->pipe, false)) {
-		if (view->lines == 0 && view_is_displayed(view)) {
+		if (opt_show_loading && view->lines == 0 && view_is_displayed(view)) {
 			time_t secs = time(NULL) - view->start_time;
 
 			if (secs > 1 && secs > view->update_secs) {
@@ -670,6 +670,8 @@ update_view(struct view *view)
 	if (!view_is_displayed(view))
 		return true;
 
+	if (redraw && !opt_show_loading)
+		werase(view->win);
 	if (redraw || view->force_redraw)
 		redraw_view_from(view, 0);
 	else
@@ -851,7 +853,8 @@ load_view(struct view *view, struct view *prev, enum open_flags flags)
 	if (view->pipe && view->lines == 0) {
 		/* Clear the old view and let the incremental updating refill
 		 * the screen. */
-		werase(view->win);
+		if (opt_show_loading)
+			werase(view->win);
 		/* Do not clear the position if it is the first view. */
 		if (view->prev && !(flags & (OPEN_RELOAD | OPEN_REFRESH))) {
 			clear_position(&view->prev_pos);

--- a/test/tigrc/save-option-test
+++ b/test/tigrc/save-option-test
@@ -3,6 +3,7 @@
 . libtest.sh
 
 steps "
+	:set show-loading = no
 	:save-options saved-tigrc
 "
 

--- a/tigrc
+++ b/tigrc
@@ -152,6 +152,7 @@ set mouse-scroll		= 3		# Number of lines to scroll via the mouse
 set mouse-wheel-cursor		= no		# Prefer moving the cursor to scrolling the view?
 set pgrp			= no		# Make tig process-group leader?
 set pager-autoscroll		= no		# Scroll the pager view automatically while loading?
+set show-loading		= yes		# Clear empty loading views and show the loading timer?
 set recurse-tree		= no		# Show all files recursively in the tree view?
 
 # User-defined commands


### PR DESCRIPTION
## Problem
It's not necessary to show the timer and clean the view every time running the commands via `:!`.
In my use case, I integrate fzf with tig. When I was selecting the menu items over certain seconds, `tig` would clean the view, causing screen tearing.

## Solution
As originally there is no way to change the behavior, I added an option to enable/disable the feature.